### PR TITLE
Context selection

### DIFF
--- a/src/python/zquantum/core/estimator.py
+++ b/src/python/zquantum/core/estimator.py
@@ -1,7 +1,11 @@
 from .interfaces.estimator import Estimator
 from .interfaces.backend import QuantumBackend, QuantumSimulator
 from .circuit import Circuit
-from .measurement import ExpectationValues
+from .measurement import (
+    ExpectationValues,
+    expectation_values_to_real,
+    concatenate_expectation_values,
+)
 from openfermion import SymbolicOperator, QubitOperator, IsingOperator
 from overrides import overrides
 import numpy as np
@@ -68,6 +72,13 @@ class BasicEstimator(Estimator):
         self._log_ignore_parameter(estimator_name, "epsilon", epsilon)
         self._log_ignore_parameter(estimator_name, "delta", delta)
 
+        frame_operators = []
+        frame_circuits = []
+        for term in target_operator.terms:
+            frame_circuit, frame_operator = get_context_selection_circuit(term)
+            frame_circuits.append(circuit + frame_circuit)
+            frame_operators.append(target_operator.terms[term] * frame_operator)
+
         if n_samples is not None:
             self.logger.warning(
                 "Using n_samples={} (argument passed to get_estimated_expectation_values). Ignoring backend.n_samples={}.".format(
@@ -76,12 +87,22 @@ class BasicEstimator(Estimator):
             )
             saved_n_samples = backend.n_samples
             backend.n_samples = n_samples
-            expectation_values = backend.get_expectation_values(
-                circuit, target_operator
-            )
+            measurements_set = backend.run_circuitset_and_measure(frame_circuits)
             backend.n_samples = saved_n_samples
-            return expectation_values
-        return backend.get_expectation_values(circuit, target_operator)
+        else:
+            measurements_set = backend.run_circuitset_and_measure(frame_circuits)
+
+        expectation_values_set = []
+        for frame_operator, measurements in zip(frame_operators, measurements_set):
+            expectation_values_set.append(
+                expectation_values_to_real(
+                    measurements.get_expectation_values(frame_operator)
+                )
+            )
+
+        return expectation_values_to_real(
+            concatenate_expectation_values(expectation_values_set)
+        )
 
 
 class ExactEstimator(Estimator):

--- a/src/python/zquantum/core/estimator_test.py
+++ b/src/python/zquantum/core/estimator_test.py
@@ -42,7 +42,7 @@ class TestBasicEstimator(unittest.TestCase, EstimatorTests):
         # Setting up inherited tests
         self.operator = QubitOperator("Z0")
         self.circuit = Circuit(Program(X(0)))
-        self.backend = MockQuantumBackend()
+        self.backend = MockQuantumBackend(n_samples=20)
         self.n_samples = 10
         self.epsilon = None
         self.delta = None
@@ -57,6 +57,23 @@ class TestBasicEstimator(unittest.TestCase, EstimatorTests):
                 self.circuit,
                 self.operator,
                 n_samples=self.n_samples,
+                epsilon=self.epsilon,
+                delta=self.delta,
+            ).values
+            value = values[0]
+            # Then
+            self.assertTrue(len(values) == 1)
+            self.assertGreaterEqual(value, -1)
+            self.assertLessEqual(value, 1)
+
+    def test_get_estimated_expectation_values_samples_from_backend(self):
+        for estimator in self.estimators:
+            # Given
+            # When
+            values = estimator.get_estimated_expectation_values(
+                self.backend,
+                self.circuit,
+                self.operator,
                 epsilon=self.epsilon,
                 delta=self.delta,
             ).values

--- a/src/python/zquantum/core/estimator_test.py
+++ b/src/python/zquantum/core/estimator_test.py
@@ -43,7 +43,7 @@ class TestBasicEstimator(unittest.TestCase, EstimatorTests):
         self.operator = QubitOperator("Z0")
         self.circuit = Circuit(Program(X(0)))
         self.backend = MockQuantumBackend()
-        self.n_samples = None
+        self.n_samples = 10
         self.epsilon = None
         self.delta = None
         self.estimators = [BasicEstimator()]
@@ -53,12 +53,17 @@ class TestBasicEstimator(unittest.TestCase, EstimatorTests):
             # Given
             # When
             values = estimator.get_estimated_expectation_values(
-                self.backend, self.circuit, self.operator,
+                self.backend,
+                self.circuit,
+                self.operator,
+                n_samples=self.n_samples,
+                epsilon=self.epsilon,
+                delta=self.delta,
             ).values
             value = values[0]
             # Then
             self.assertTrue(len(values) == 1)
-            self.assertGreaterEqual(value, 0)
+            self.assertGreaterEqual(value, -1)
             self.assertLessEqual(value, 1)
 
     def test_n_samples_is_restored(self):

--- a/src/python/zquantum/core/estimator_test.py
+++ b/src/python/zquantum/core/estimator_test.py
@@ -117,6 +117,24 @@ class TestExactEstimator(unittest.TestCase, EstimatorTests):
                     self.backend, self.circuit, self.operator,
                 ).values
 
+    def test_get_estimated_expectation_values(self):
+        for estimator in self.estimators:
+            # Given
+            # When
+            values = estimator.get_estimated_expectation_values(
+                self.backend,
+                self.circuit,
+                self.operator,
+                n_samples=self.n_samples,
+                epsilon=self.epsilon,
+                delta=self.delta,
+            ).values
+            value = values[0]
+            # Then
+            self.assertTrue(len(values) == 1)
+            self.assertGreaterEqual(value, -1)
+            self.assertLessEqual(value, 1)
+
     def test_n_samples_is_ignored(self):
         for estimator in self.estimators:
             # Given

--- a/src/python/zquantum/core/interfaces/backend.py
+++ b/src/python/zquantum/core/interfaces/backend.py
@@ -4,8 +4,8 @@ from ..bitstring_distribution import (
     create_bitstring_distribution_from_probability_distribution,
 )
 from ..circuit import Circuit, CircuitConnectivity
-from ..measurement import ExpectationValues
-from typing import Optional, List, Tuple
+from ..measurement import ExpectationValues, Measurements
+from typing import Optional, List, Tuple, Iterable
 from openfermion import QubitOperator
 from pyquil.wavefunction import Wavefunction
 
@@ -32,6 +32,25 @@ class QuantumBackend(ABC):
             core.measurement.Measurements: object representing the measurements resulting from the circuit
         """
         raise NotImplementedError
+
+    def run_circuitset_and_measure(
+        self, circuit_set: Iterable[Circuit], **kwargs
+    ) -> List[Measurements]:
+        """Run a set of circuits and measure a certain number of bitstrings.
+        
+        It may be useful to override this method for backends that support
+        batching. Note that self.n_samples shots are used for each circuit.
+
+        Args:
+            circuit_set: The circuits to execute.
+
+        Returns:
+            Measurements for each circuit.
+        """
+        measurement_set = []
+        for circuit in circuit_set:
+            measurement_set.append(self.run_circuit_and_measure(circuit), **kwargs)
+        return measurement_set
 
     def get_expectation_values(
         self, circuit: Circuit, qubit_operator: QubitOperator, **kwargs

--- a/src/python/zquantum/core/interfaces/estimator_test.py
+++ b/src/python/zquantum/core/interfaces/estimator_test.py
@@ -34,7 +34,7 @@ class EstimatorTests(object):
     # self.backend
     # self.circuit
     # self.operator
-    # self.n_sample
+    # self.n_samples
     # self.epsilon
     # self.delta
 
@@ -77,11 +77,9 @@ def parameter_is_ignored(
 ):
     with self.assertLogs("z-quantum-core", level="WARN") as context_manager:
         # Given
-        expected_logs = [
-            "WARNING:z-quantum-core:{} = {}. {} does not use {}. The value was ignored.".format(
-                parameter_name, parameter_value, estimator_name, parameter_name
-            )
-        ]
+        expected_log = "WARNING:z-quantum-core:{} = {}. {} does not use {}. The value was ignored.".format(
+            parameter_name, parameter_value, estimator_name, parameter_name
+        )
         # When
         if parameter_name == "n_samples":
             self.n_samples = parameter_value
@@ -99,4 +97,4 @@ def parameter_is_ignored(
             delta=self.delta,
         )
         # Then
-        self.assertEqual(context_manager.output, expected_logs)
+        self.assertIn(expected_log, context_manager.output)

--- a/src/python/zquantum/core/interfaces/estimator_test.py
+++ b/src/python/zquantum/core/interfaces/estimator_test.py
@@ -53,24 +53,6 @@ class EstimatorTests(object):
             # Then
             self.assertIsInstance(value, ExpectationValues)
 
-    def test_get_estimated_expectation_values(self):
-        for estimator in self.estimators:
-            # Given
-            # When
-            values = estimator.get_estimated_expectation_values(
-                self.backend,
-                self.circuit,
-                self.operator,
-                n_samples=self.n_samples,
-                epsilon=self.epsilon,
-                delta=self.delta,
-            ).values
-            value = values[0]
-            # Then
-            self.assertTrue(len(values) == 1)
-            self.assertGreaterEqual(value, 0)
-            self.assertLessEqual(value, 1)
-
 
 def parameter_is_ignored(
     self, estimator, estimator_name, parameter_name, parameter_value

--- a/src/python/zquantum/core/interfaces/mock_objects.py
+++ b/src/python/zquantum/core/interfaces/mock_objects.py
@@ -19,6 +19,7 @@ class MockQuantumBackend(QuantumBackend):
         self.n_samples = n_samples
 
     def run_circuit_and_measure(self, circuit, **kwargs):
+
         n_qubits = len(circuit.qubits)
         measurements = Measurements()
         for _ in range(self.n_samples):

--- a/src/python/zquantum/core/measurement.py
+++ b/src/python/zquantum/core/measurement.py
@@ -514,3 +514,32 @@ class Measurements:
                 expectation += np.real(coefficient) * value
             expectation_values.append(np.real(expectation))
         return ExpectationValues(np.array(expectation_values))
+
+def concatenate_expectation_values(
+    expectation_values_set: Iterable[ExpectationValues],
+) -> ExpectationValues:
+    """Concatenates a set of expectation values objects.
+
+    Args:
+        expectation_values_set: The expectation values objects to be concatenated.
+    
+    Returns:
+        The combined expectation values.
+    """
+
+    combined_expectation_values = ExpectationValues(np.zeros(0,))
+
+    for expectation_values in expectation_values_set:
+        combined_expectation_values.values = np.concatenate(
+            (combined_expectation_values.values, expectation_values.values)
+        )
+        if expectation_values.correlations:
+            if not combined_expectation_values.correlations:
+                combined_expectation_values.correlations = []
+            combined_expectation_values.correlations += expectation_values.correlations
+        if expectation_values.covariances:
+            if not combined_expectation_values.covariances:
+                combined_expectation_values.covariances = []
+            combined_expectation_values.covariances += expectation_values.covariances
+
+    return combined_expectation_values


### PR DESCRIPTION
Updates the `BasicEstimator` to handle non-diagonal operators by applying context selection gates. Each term is computed in a separate circuit; grouping will be implemented in future PRs.