### PR TITLE
Feature/ansatz property

### DIFF
--- a/src/python/zquantum/core/interfaces/ansatz.py
+++ b/src/python/zquantum/core/interfaces/ansatz.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from ..circuit import Circuit
-from .ansatz_utils import invalidates_parametrized_circuit
+from .ansatz_utils import ansatz_property
 from ..utils import create_symbols_map
 import copy
 import sympy
@@ -12,6 +12,7 @@ import numpy as np
 class Ansatz(ABC, EnforceOverrides):
 
     supports_parametrized_circuits = None
+    n_layers = ansatz_property("n_layers")
 
     def __init__(self, n_layers: int):
         """
@@ -27,17 +28,8 @@ class Ansatz(ABC, EnforceOverrides):
             supports_parametrized_circuits(bool): flag indicating whether given ansatz supports parametrized circuits.
         
         """
-        self._n_layers = n_layers
+        self.n_layers = n_layers
         self._parametrized_circuit = None
-
-    @property
-    def n_layers(self):
-        return self._n_layers
-
-    @invalidates_parametrized_circuit
-    @n_layers.setter
-    def n_layers(self, new_n_layers):
-        self._n_layers = new_n_layers
 
     @property
     def parametrized_circuit(self) -> Circuit:

--- a/src/python/zquantum/core/interfaces/ansatz_utils.py
+++ b/src/python/zquantum/core/interfaces/ansatz_utils.py
@@ -39,3 +39,26 @@ def invalidates_parametrized_circuit(target):
             return return_value
 
         return _wrapper
+
+
+class DynamicProperty:
+    """A shortcut to create a getter-setter descriptor with one liners."""
+    def __init__(self, name: str, default_value=None):
+        self.default_value = default_value
+        self.name = name
+
+    @property
+    def attrname(self):
+        return f"_{self.name}"
+
+    def __get__(self, obj, obj_type):
+        if not hasattr(obj, self.attrname):
+            setattr(obj, self.attrname, self.default_value)
+        return getattr(obj, self.attrname)
+
+    def __set__(self, obj, new_obj):
+        setattr(obj, self.attrname, new_obj)
+
+
+def ansatz_property(name: str, default_value=None):
+    return _InvalidatingSetter(DynamicProperty(name, default_value))

--- a/src/python/zquantum/core/interfaces/ansatz_utils_test.py
+++ b/src/python/zquantum/core/interfaces/ansatz_utils_test.py
@@ -1,0 +1,71 @@
+"""Test cases for ansatz-related utilities."""
+import unittest
+from .ansatz_utils import DynamicProperty, ansatz_property
+
+
+class DynamicPropertyTests(unittest.TestCase):
+
+    def test_uses_default_value(self):
+        """DynamicProperty should use default value if it wasn't overwritten."""
+        class MyCls:
+            x = DynamicProperty(name="x", default_value=-15)
+
+        obj = MyCls()
+        self.assertEqual(obj.x, -15)
+
+    def test_can_be_set_in_init(self):
+        """It should be possible to initialize DynamicProperty's value in init method."""
+        class MyCls:
+            length = DynamicProperty(name="length")
+
+            def __init__(self, length):
+                self.length = length
+
+        obj = MyCls(0.5)
+        self.assertEqual(obj.length, 0.5)
+
+    def test_stores_values_in_instance(self):
+        """Values of DynamicProperty should be instance-dependent (i.e. should have its own copy)."""
+        class MyCls:
+            height = DynamicProperty(name="height")
+
+        obj1 = MyCls()
+        obj2 = MyCls()
+
+        obj1.height = 15
+        obj2.height = 30
+
+        self.assertEqual(obj1.height, 15)
+        self.assertEqual(obj2.height, 30)
+
+
+class TestAnsatzProperty(unittest.TestCase):
+    """Test cases for ansatz_property.
+
+    Note that we don't relaly need an ansatz intance, we only need to check that _parametrized_circuit is
+    set to None.
+    """
+
+    class PseudoAnsatz:
+        n_layers = ansatz_property(name="n_layers")
+
+        def __init__(self, n_layers):
+            self.n_layers = n_layers
+            self._parametrized_circuit = None
+
+        @property
+        def parametrized_circuit(self):
+            if self._parametrized_circuit is None:
+                self._parametrized_circuit = f"Circuit with {self.n_layers} layers"
+            return self._parametrized_circuit
+
+    def test_setter_resets_parametrized_circuit(self):
+        ansatz = self.PseudoAnsatz(n_layers=10)
+
+        # Trigger initial computation of parametrized circuit
+        self.assertEqual(ansatz.parametrized_circuit, "Circuit with 10 layers")
+
+        # Change n_layers -> check if it recalculated.
+        ansatz.n_layers = 20
+        self.assertIsNone(ansatz._parametrized_circuit)
+        self.assertEqual(ansatz.parametrized_circuit, "Circuit with 20 layers")


### PR DESCRIPTION
This implements a shortcut for defining properties of Ansatz that invalidate parametrized circuit.

Instead of writing getter and setter and decorating the setter with `invalidates_paramietrized_circuit`, one can just add one-liner in class definition. See `n_layers` attribute for example usage.

Unit tests for the feature are also supplied.
