### PR TITLE
Add missing tests

### DIFF
--- a/src/python/zquantum/core/interfaces/ansatz_utils_test.py
+++ b/src/python/zquantum/core/interfaces/ansatz_utils_test.py
@@ -1,6 +1,29 @@
 """Test cases for ansatz-related utilities."""
 import unittest
-from .ansatz_utils import DynamicProperty, ansatz_property
+from unittest import mock
+from .ansatz_utils import DynamicProperty, ansatz_property, invalidates_parametrized_circuit
+
+
+class PseudoAnsatz:
+    n_layers = ansatz_property(name="n_layers")
+
+    def __init__(self, n_layers):
+        self.n_layers = n_layers
+        self._parametrized_circuit = None
+
+    @property
+    def parametrized_circuit(self):
+        if self._parametrized_circuit is None:
+            self._parametrized_circuit = f"Circuit with {self.n_layers} layers"
+        return self._parametrized_circuit
+
+    @invalidates_parametrized_circuit
+    def rotate(self):
+        """Mock method that "alters" some characteristics of ansatz.
+
+        Using this method should invalidate parametrized circuit.
+        """
+        pass
 
 
 class DynamicPropertyTests(unittest.TestCase):
@@ -42,25 +65,13 @@ class DynamicPropertyTests(unittest.TestCase):
 class TestAnsatzProperty(unittest.TestCase):
     """Test cases for ansatz_property.
 
-    Note that we don't relaly need an ansatz intance, we only need to check that _parametrized_circuit is
+    Note that we don't really need an ansatz intance, we only need to check that _parametrized_circuit is
     set to None.
     """
 
-    class PseudoAnsatz:
-        n_layers = ansatz_property(name="n_layers")
-
-        def __init__(self, n_layers):
-            self.n_layers = n_layers
-            self._parametrized_circuit = None
-
-        @property
-        def parametrized_circuit(self):
-            if self._parametrized_circuit is None:
-                self._parametrized_circuit = f"Circuit with {self.n_layers} layers"
-            return self._parametrized_circuit
-
     def test_setter_resets_parametrized_circuit(self):
-        ansatz = self.PseudoAnsatz(n_layers=10)
+        """Setter of this property should set _parametrized_circuit to None."""
+        ansatz = PseudoAnsatz(n_layers=10)
 
         # Trigger initial computation of parametrized circuit
         self.assertEqual(ansatz.parametrized_circuit, "Circuit with 10 layers")
@@ -69,3 +80,31 @@ class TestAnsatzProperty(unittest.TestCase):
         ansatz.n_layers = 20
         self.assertIsNone(ansatz._parametrized_circuit)
         self.assertEqual(ansatz.parametrized_circuit, "Circuit with 20 layers")
+
+
+class InvalidatesParametrizedCircuitTest(unittest.TestCase):
+    """Test cases for invalidate_parametrized_circuit."""
+
+    def test_resets_parametrized_circuit(self):
+        """Calling decorated method should reset _parametrized_circuit."""
+        ansatz = PseudoAnsatz(n_layers=10)
+
+        # Trigger initial computation of parametrized circuit
+        self.assertEqual(ansatz.parametrized_circuit, "Circuit with 10 layers")
+
+        # Trigger circuit invalidation
+        ansatz.rotate()
+
+        self.assertIsNone(ansatz._parametrized_circuit)
+
+    def test_forwards_arguments_to_underlying_methods(self):
+        """Calling decorated methods should pass arguments to underlying method."""
+        method_mock = mock.Mock()
+        decorated_method = invalidates_parametrized_circuit(method_mock)
+        ansatz = PseudoAnsatz(n_layers=10)
+
+        # Mock calling a regular method. Notice that we need to pass self explicitly
+        decorated_method(ansatz, 2.0, 1.0, x=100, label="test")
+
+        # Check that arguments were passed to underlying method
+        method_mock.assert_called_once_with(ansatz, 2.0, 1.0, x=100, label="test")


### PR DESCRIPTION
This adds missing tests for `invalidates_parametrized_circuit`.

Additionally, this fixes some minor issues (typos, lack of docstrings) in previous tests that I wrote.