### PR TITLE
Make logger in Estimator at the module level.

### DIFF
--- a/src/python/zquantum/core/estimator.py
+++ b/src/python/zquantum/core/estimator.py
@@ -8,9 +8,12 @@ from .measurement import (
 )
 from openfermion import SymbolicOperator, QubitOperator, IsingOperator
 from overrides import overrides
+import logging
 import numpy as np
 import pyquil
 from typing import Tuple, Optional
+
+logger = logging.getLogger(__name__)
 
 
 def get_context_selection_circuit(
@@ -80,7 +83,7 @@ class BasicEstimator(Estimator):
             frame_operators.append(target_operator.terms[term] * frame_operator)
 
         if n_samples is not None:
-            self.logger.warning(
+            logger.warning(
                 "Using n_samples={} (argument passed to get_estimated_expectation_values). Ignoring backend.n_samples={}.".format(
                     n_samples, backend.n_samples
                 )

--- a/src/python/zquantum/core/estimator.py
+++ b/src/python/zquantum/core/estimator.py
@@ -6,7 +6,7 @@ from .measurement import (
     expectation_values_to_real,
     concatenate_expectation_values,
 )
-from openfermion import SymbolicOperator, QubitOperator, IsingOperator
+from openfermion import SymbolicOperator, IsingOperator
 from overrides import overrides
 import logging
 import numpy as np
@@ -71,10 +71,6 @@ class BasicEstimator(Estimator):
         Returns:
             ExpectationValues: expectation values for each term in the target operator.
         """
-        estimator_name = type(self).__name__
-        self._log_ignore_parameter(estimator_name, "epsilon", epsilon)
-        self._log_ignore_parameter(estimator_name, "delta", delta)
-
         frame_operators = []
         frame_circuits = []
         for term in target_operator.terms:
@@ -84,9 +80,8 @@ class BasicEstimator(Estimator):
 
         if n_samples is not None:
             logger.warning(
-                "Using n_samples={} (argument passed to get_estimated_expectation_values). Ignoring backend.n_samples={}.".format(
-                    n_samples, backend.n_samples
-                )
+                f"""Using n_samples={n_samples} (argument passed to get_estimated_expectation_values). 
+                    Ignoring backend.n_samples={backend.n_samples}"""
             )
             saved_n_samples = backend.n_samples
             backend.n_samples = n_samples
@@ -139,11 +134,6 @@ class ExactEstimator(Estimator):
         Returns:
             ExpectationValues: expectation values for each term in the target operator.
         """
-        estimator_name = type(self).__name__
-        self._log_ignore_parameter(estimator_name, "n_samples", n_samples)
-        self._log_ignore_parameter(estimator_name, "epsilon", epsilon)
-        self._log_ignore_parameter(estimator_name, "delta", delta)
-
         if isinstance(backend, QuantumSimulator):
             return backend.get_exact_expectation_values(circuit, target_operator)
         else:

--- a/src/python/zquantum/core/estimator_test.py
+++ b/src/python/zquantum/core/estimator_test.py
@@ -1,5 +1,5 @@
 import unittest
-from .interfaces.estimator_test import EstimatorTests, parameter_is_ignored
+from .interfaces.estimator_test import EstimatorTests
 from .interfaces.mock_objects import MockQuantumBackend, MockQuantumSimulator
 from .estimator import (
     BasicEstimator,
@@ -98,26 +98,6 @@ class TestBasicEstimator(unittest.TestCase, EstimatorTests):
             # Then
             self.assertEqual(self.backend.n_samples, 5)
 
-    def test_epsilon_is_ignored(self):
-        for estimator in self.estimators:
-            # Given
-            estimator_name = type(estimator).__name__
-            parameter_name = "epsilon"
-            parameter_value = 0.1
-            parameter_is_ignored(
-                self, estimator, estimator_name, parameter_name, parameter_value
-            )
-
-    def test_delta_is_ignored(self):
-        for estimator in self.estimators:
-            # Given
-            estimator_name = type(estimator).__name__
-            parameter_name = "delta"
-            parameter_value = 0.9
-            parameter_is_ignored(
-                self, estimator, estimator_name, parameter_name, parameter_value
-            )
-
 
 class TestExactEstimator(unittest.TestCase, EstimatorTests):
     def setUp(self):
@@ -155,33 +135,3 @@ class TestExactEstimator(unittest.TestCase, EstimatorTests):
             self.assertTrue(len(values) == 1)
             self.assertGreaterEqual(value, -1)
             self.assertLessEqual(value, 1)
-
-    def test_n_samples_is_ignored(self):
-        for estimator in self.estimators:
-            # Given
-            estimator_name = type(estimator).__name__
-            parameter_name = "n_samples"
-            parameter_value = 1
-            parameter_is_ignored(
-                self, estimator, estimator_name, parameter_name, parameter_value
-            )
-
-    def test_epsilon_is_ignored(self):
-        for estimator in self.estimators:
-            # Given
-            estimator_name = type(estimator).__name__
-            parameter_name = "epsilon"
-            parameter_value = 0.1
-            parameter_is_ignored(
-                self, estimator, estimator_name, parameter_name, parameter_value
-            )
-
-    def test_delta_is_ignored(self):
-        for estimator in self.estimators:
-            # Given
-            estimator_name = type(estimator).__name__
-            parameter_name = "delta"
-            parameter_value = 0.9
-            parameter_is_ignored(
-                self, estimator, estimator_name, parameter_name, parameter_value
-            )

--- a/src/python/zquantum/core/estimator_test.py
+++ b/src/python/zquantum/core/estimator_test.py
@@ -12,6 +12,7 @@ from pyquil.gates import X
 from openfermion import QubitOperator, qubit_operator_sparse, IsingOperator
 import numpy as np
 
+
 class TestEstimatorUtils(unittest.TestCase):
     def test_get_context_selection_circuit_offdiagonal(self):
         term = ((0, "X"), (1, "Y"))

--- a/src/python/zquantum/core/interfaces/estimator.py
+++ b/src/python/zquantum/core/interfaces/estimator.py
@@ -4,15 +4,18 @@ from .backend import QuantumBackend
 from ..measurement import ExpectationValues
 from abc import ABC, abstractmethod
 from openfermion import SymbolicOperator
-from typing import List, Optional
+from typing import Optional
+from overrides import EnforceOverrides
+
+logger = logging.getLogger(__name__)
 
 
-class Estimator(ABC):
+class Estimator(ABC, EnforceOverrides):
     """Interface for implementing different estimators.
     """
 
     def __init__(self):
-        self.logger = logging.getLogger("z-quantum-core")
+        pass
 
     @abstractmethod
     def get_estimated_expectation_values(
@@ -40,8 +43,9 @@ class Estimator(ABC):
         """
         raise NotImplementedError
 
+    @staticmethod
     def _log_ignore_parameter(
-        self, estimator_name: str, parameter_name: str, parameter_value: float
+        estimator_name: str, parameter_name: str, parameter_value: float
     ):
         """In an estimator, users can specify the number of samples, an error term, and/or a confidence term. 
         Usually, selecting two terms fixes the third (e.g., chooseing a number of samples and an error term will fix the probability 
@@ -56,7 +60,7 @@ class Estimator(ABC):
             parameter_value (float): The parameter value.
         """
         if parameter_value is not None:
-            self.logger.warning(
+            logger.warning(
                 "{} = {}. {} does not use {}. The value was ignored.".format(
                     parameter_name, parameter_value, estimator_name, parameter_name,
                 )

--- a/src/python/zquantum/core/interfaces/estimator.py
+++ b/src/python/zquantum/core/interfaces/estimator.py
@@ -1,4 +1,3 @@
-import logging
 from ..circuit import Circuit
 from .backend import QuantumBackend
 from ..measurement import ExpectationValues
@@ -7,15 +6,10 @@ from openfermion import SymbolicOperator
 from typing import Optional
 from overrides import EnforceOverrides
 
-logger = logging.getLogger(__name__)
-
 
 class Estimator(ABC, EnforceOverrides):
     """Interface for implementing different estimators.
     """
-
-    def __init__(self):
-        pass
 
     @abstractmethod
     def get_estimated_expectation_values(
@@ -42,26 +36,3 @@ class Estimator(ABC, EnforceOverrides):
             ExpectationValues: The estimations of the terms in the target_operator. 
         """
         raise NotImplementedError
-
-    @staticmethod
-    def _log_ignore_parameter(
-        estimator_name: str, parameter_name: str, parameter_value: float
-    ):
-        """In an estimator, users can specify the number of samples, an error term, and/or a confidence term. 
-        Usually, selecting two terms fixes the third (e.g., chooseing a number of samples and an error term will fix the probability 
-        that your estimation falls within the error bounds.) 
-        
-        Depending on the estimator, some of these parameters are ignored. This method is used to log when a parameter is ignored.
-        See zquantum.core.estimators.BasicEstimator for an example.
-
-        Args:
-            estimator_name (str): The estimator that is ignoring the parameter.
-            parameter_name (str): The parameter name, either n_samples, epsilon, or delta.
-            parameter_value (float): The parameter value.
-        """
-        if parameter_value is not None:
-            logger.warning(
-                "{} = {}. {} does not use {}. The value was ignored.".format(
-                    parameter_name, parameter_value, estimator_name, parameter_name,
-                )
-            )

--- a/src/python/zquantum/core/interfaces/estimator_test.py
+++ b/src/python/zquantum/core/interfaces/estimator_test.py
@@ -1,31 +1,5 @@
 import unittest
-from unittest.mock import patch
-from .estimator import Estimator
 from ..measurement import ExpectationValues
-
-
-class TestEstimatorInterface(unittest.TestCase):
-    @patch.object(Estimator, "__abstractmethods__", set())
-    def test_ignore_parameter(self):
-        with self.assertLogs(
-            "core.interfaces.estimator", level="WARN"
-        ) as context_manager:
-            estimator = Estimator()
-            estimator_name = type(estimator).__name__
-            parameter_names = ["x", "y", "z"]
-            parameter_values = [1, 2, 3]
-            expected_logs = list(
-                [
-                    (
-                        yield f"WARNING:core.interfaces.estimator:{pn} = {pv}. {estimator_name} does not use {pn}. The value was ignored."
-                    )
-                    for (pn, pv) in zip(parameter_names, parameter_values)
-                ]
-            )
-
-            for pn, pv in zip(parameter_names, parameter_values):
-                estimator._log_ignore_parameter(estimator_name, pn, pv)
-            self.assertEqual(context_manager.output, expected_logs)
 
 
 class EstimatorTests(object):
@@ -52,34 +26,3 @@ class EstimatorTests(object):
             )
             # Then
             self.assertIsInstance(value, ExpectationValues)
-
-
-def parameter_is_ignored(
-    self,
-    estimator,
-    estimator_name,
-    parameter_name,
-    parameter_value,
-    logger_name="core.interfaces.estimator",
-):
-    with self.assertLogs(logger_name, level="WARN") as context_manager:
-        # Given
-        expected_log = f"WARNING:{logger_name}:{parameter_name} = {parameter_value}. {estimator_name} does not use {parameter_name}. The value was ignored."
-        # When
-        if parameter_name == "n_samples":
-            self.n_samples = parameter_value
-        if parameter_name == "epsilon":
-            self.epsilon = parameter_value
-        if parameter_name == "delta":
-            self.delta = parameter_value
-
-        estimator.get_estimated_expectation_values(
-            self.backend,
-            self.circuit,
-            self.operator,
-            n_samples=self.n_samples,
-            epsilon=self.epsilon,
-            delta=self.delta,
-        )
-        # Then
-        self.assertIn(expected_log, context_manager.output)

--- a/src/python/zquantum/core/interfaces/estimator_test.py
+++ b/src/python/zquantum/core/interfaces/estimator_test.py
@@ -7,7 +7,9 @@ from ..measurement import ExpectationValues
 class TestEstimatorInterface(unittest.TestCase):
     @patch.object(Estimator, "__abstractmethods__", set())
     def test_ignore_parameter(self):
-        with self.assertLogs("z-quantum-core", level="WARN") as context_manager:
+        with self.assertLogs(
+            "core.interfaces.estimator", level="WARN"
+        ) as context_manager:
             estimator = Estimator()
             estimator_name = type(estimator).__name__
             parameter_names = ["x", "y", "z"]
@@ -15,9 +17,7 @@ class TestEstimatorInterface(unittest.TestCase):
             expected_logs = list(
                 [
                     (
-                        yield "WARNING:z-quantum-core:{} = {}. {} does not use {}. The value was ignored.".format(
-                            pn, pv, estimator_name, pn
-                        )
+                        yield f"WARNING:core.interfaces.estimator:{pn} = {pv}. {estimator_name} does not use {pn}. The value was ignored."
                     )
                     for (pn, pv) in zip(parameter_names, parameter_values)
                 ]
@@ -55,13 +55,16 @@ class EstimatorTests(object):
 
 
 def parameter_is_ignored(
-    self, estimator, estimator_name, parameter_name, parameter_value
+    self,
+    estimator,
+    estimator_name,
+    parameter_name,
+    parameter_value,
+    logger_name="core.interfaces.estimator",
 ):
-    with self.assertLogs("z-quantum-core", level="WARN") as context_manager:
+    with self.assertLogs(logger_name, level="WARN") as context_manager:
         # Given
-        expected_log = "WARNING:z-quantum-core:{} = {}. {} does not use {}. The value was ignored.".format(
-            parameter_name, parameter_value, estimator_name, parameter_name
-        )
+        expected_log = f"WARNING:{logger_name}:{parameter_name} = {parameter_value}. {estimator_name} does not use {parameter_name}. The value was ignored."
         # When
         if parameter_name == "n_samples":
             self.n_samples = parameter_value
@@ -70,7 +73,7 @@ def parameter_is_ignored(
         if parameter_name == "delta":
             self.delta = parameter_value
 
-        values = estimator.get_estimated_expectation_values(
+        estimator.get_estimated_expectation_values(
             self.backend,
             self.circuit,
             self.operator,


### PR DESCRIPTION
These changes make the logger at the module level, which is the Pythonic way of doing logging.
We also make the logging helper function a static method since it does not depend on instance variables.
(There is a single unrelated change: we add `EnforceOverrides` to the `Estimator` abstract base class). 