### PR TITLE
Add the optimization_result function.

### DIFF
--- a/src/python/zquantum/core/interfaces/mock_objects.py
+++ b/src/python/zquantum/core/interfaces/mock_objects.py
@@ -1,7 +1,7 @@
 from .ansatz import Ansatz
 from .ansatz_utils import ansatz_property
 from .backend import QuantumBackend, QuantumSimulator
-from .optimizer import Optimizer
+from .optimizer import Optimizer, optimization_result
 from .cost_function import CostFunction
 from .estimator import Estimator
 from ..measurement import ExpectationValues, Measurements
@@ -98,10 +98,11 @@ class MockOptimizer(Optimizer):
         for i in range(len(initial_params)):
             new_parameters[i] += random.random()
         new_parameters = np.array(new_parameters)
-        result.opt_value = cost_function.evaluate(new_parameters)
-        result["history"] = cost_function.evaluations_history
-        result.opt_params = new_parameters
-        return result
+        return optimization_result(
+            opt_value=cost_function.evaluate(new_parameters),
+            opt_params= new_parameters,
+            history=cost_function.evaluations_history
+        )
 
 
 class MockCostFunction(CostFunction):

--- a/src/python/zquantum/core/interfaces/optimizer.py
+++ b/src/python/zquantum/core/interfaces/optimizer.py
@@ -1,4 +1,6 @@
 from abc import ABC, abstractmethod
+
+import scipy
 from scipy.optimize import OptimizeResult
 from .cost_function import CostFunction
 from typing import Callable, Optional, Dict
@@ -36,3 +38,24 @@ class Optimizer(ABC):
             OptimizeResults
         """
         raise NotImplementedError
+
+
+def optimization_result(*, opt_value, opt_params, **kwargs) -> scipy.optimize.OptimizeResult:
+    """Construct instance of OptimizeResult.
+
+    The purpose of this function is to add a safety layer by detecting if required
+    components of OptimizationResult are missing already during static analysis.
+
+    Args:
+        opt_value: the final value of the function being optimized.
+        opt_params: the parameters (arguments) for which opt_value has been achieved.
+        kwargs: other attributes (e.g. history) that should be stored in OptimizeResult.
+    Returns:
+        An instance of OptimizeResult containing opt_value, opt_params and all of the
+        other passed arguments.
+    """
+    return scipy.optimize.OptimizeResult(
+        opt_value=opt_value,
+        opt_params=opt_params,
+        **kwargs
+    )

--- a/src/python/zquantum/core/interfaces/optimizer_test.py
+++ b/src/python/zquantum/core/interfaces/optimizer_test.py
@@ -1,6 +1,8 @@
 import unittest
 import numpy as np
+import pytest
 
+from .optimizer import optimization_result
 from ..cost_function import BasicCostFunction
 
 
@@ -50,3 +52,23 @@ class OptimizerTests(object):
             self.assertIn("opt_value", results.keys())
             self.assertIn("opt_params", results.keys())
             self.assertIn("history", results.keys())
+
+
+def test_optimization_result_contains_opt_value_and_opt_params():
+    opt_value = 2.0
+    opt_params = [-1, 0, 3.2]
+
+    result = optimization_result(opt_value=opt_value, opt_params=opt_params)
+
+    assert result.opt_value == opt_value
+    assert result.opt_params == opt_params
+
+
+def test_optimization_result_contains_other_attributes_passed_as_kwargs():
+    opt_value = 0.0
+    opt_params = [1, 2, 3]
+    kwargs = {"bitstring": "01010", "foo": 3.0}
+
+    result = optimization_result(opt_value=opt_value, opt_params=opt_params, **kwargs)
+
+    assert all(getattr(result, key) == value for key, value in kwargs.items())


### PR DESCRIPTION
This adds the `optimization_result` convenience function that should serve as an additional, static safety layer for constructing instances of `scipy.optimize.OptimizeResult` while ensuring it has the required fields set. 

See accompanying tests for usage examples.

Several notes:
- I thought about calling this `create_optimization_result` but decided to go for a shorter name for the following reasons:
  - `create` is kind of an empty word (like get or set)
  - it is more in line with names used through scientific libraries (e.g. you have `numpy.array` not `numpy.create_array`)
  
  Please feel free to suggest a better name if you have one :)
- Tests don't check if you have to pass optimized value and params as keyword arguments, because it is already checked by the static type checker. Test in your IDE what happens if you skip those or pass them as positional arguments.

If this approach gets approved, I will follow up with PR to z-quantum-optimizers so that we actually use the function proposed here.