### PR TITLE
Symmetrized loglikelihood

### DIFF
--- a/src/python/zquantum/core/bitstring_distribution/distance_measures/distance_measures_test.py
+++ b/src/python/zquantum/core/bitstring_distribution/distance_measures/distance_measures_test.py
@@ -155,7 +155,7 @@ def test_jensen_shannon_divergence_is_computed_correctly():
         target_distr, measured_dist, distance_measure_params
     )
 
-    assert jensen_shannon_divergence == 1.8971199848858813
+    assert jensen_shannon_divergence == 0.9485599924429406
 
 def test_uses_epsilon_instead_of_zero_in_target_distribution():
     """Computing jensen shannon divergence uses epsilon instead of zeros in log."""

--- a/src/python/zquantum/core/bitstring_distribution/distance_measures/jensen_shannon_divergence.py
+++ b/src/python/zquantum/core/bitstring_distribution/distance_measures/jensen_shannon_divergence.py
@@ -1,0 +1,31 @@
+import math
+from typing import Dict, TYPE_CHECKING
+from .clipped_negative_log_likelihood import compute_clipped_negative_log_likelihood
+if TYPE_CHECKING:
+    from zquantum.core.bitstring_distribution import BitstringDistribution
+
+
+def compute_jensen_shannon_divergence(
+    target_distribution: "BitstringDistribution",
+    measured_distribution: "BitstringDistribution",
+    distance_measure_parameters: Dict,
+) -> float:
+    """Computes the symmetrized version of the clipped negative log likelihood between a target bitstring distribution
+    and a measured bitstring distribution
+    See Equation (4) in https://advances.sciencemag.org/content/5/10/eaaw9918?rss=1
+
+    Args:
+        target_distribution (BitstringDistribution): The target bitstring probability distribution.
+        measured_distribution (BitstringDistribution): The measured bitstring probability distribution.
+
+        distance_measure_parameters (dict):
+            - epsilon (float): The small parameter needed to regularize log computation when argument is zero. The default value is 1e-9.
+
+    Returns:
+        float: The value of the symmetrized version
+    """
+
+    value = compute_clipped_negative_log_likelihood(target_distribution, measured_distribution, distance_measure_parameters)/2 + \
+            compute_clipped_negative_log_likelihood(measured_distribution, target_distribution, distance_measure_parameters)/2
+
+    return value

--- a/src/python/zquantum/core/bitstring_distribution/distance_measures/jensen_shannon_divergence.py
+++ b/src/python/zquantum/core/bitstring_distribution/distance_measures/jensen_shannon_divergence.py
@@ -1,4 +1,4 @@
-import math
+
 from typing import Dict, TYPE_CHECKING
 from .clipped_negative_log_likelihood import compute_clipped_negative_log_likelihood
 if TYPE_CHECKING:


### PR DESCRIPTION
Adding the jensen shannon divergence to the list of distance measures. It symmetrizes the clipped log likelihood