### PR TITLE
Build circuitset

### DIFF
--- a/templates/circuit.yaml
+++ b/templates/circuit.yaml
@@ -260,7 +260,7 @@ spec:
           - name: circuit-set
             path: /app/circuit_set.json
 
-    # Add a circuit to a circuit-set 
+    # Add a circuit to a circuit-set
     - name: add-circuit-artifact-to-circuit-set
       parent: generic-task
       inputs:
@@ -269,7 +269,7 @@ spec:
             value: python3 main_script.py
         artifacts:
           - name: circuit-set
-            path: /app/circuit_set.json
+            path: /app/circuit_set_input.json
             optional: true
           - name: circuit
             path: /app/circuit.json
@@ -280,8 +280,8 @@ spec:
                 import os
                 from zquantum.core.circuit import load_circuit_set, load_circuit, save_circuit_set
 
-                if os.path.exists('circuit_set.json'):
-                  circuit_set = load_circuit_set('circuit_set.json')
+                if os.path.exists('circuit_set_input.json'):
+                  circuit_set = load_circuit_set('circuit_set_input.json')
                 else:
                   circuit_set = []
 

--- a/templates/circuit.yaml
+++ b/templates/circuit.yaml
@@ -261,28 +261,3 @@ spec:
         artifacts:
           - name: circuit-set
             path: /app/circuit_set.json
-
-    # Add circuits in a circuit set
-    - name: add-circuits-in-circuit-set
-      parent: generic-task
-      inputs:
-        parameters:
-          - name: command
-            value: python3 main_script.py
-        artifacts:
-          - name: circuit-set
-            path: /app/circuit_set.json
-          - name: main-script
-            path: /app/main_script.py
-            raw:
-              data: |
-                from zquantum.core.circuit import load_circuit_set, save_circuit, Circuit
-                circuit_set = load_circuit_set("circuit_set.json")
-                circuit = Circuit()
-                for circ in circuit_set:
-                  circuit += circ
-                save_circuit(circuit,"circuit.json")
-      outputs:
-        artifacts:
-          - name: circuit
-            path: /app/circuit.json

--- a/templates/circuit.yaml
+++ b/templates/circuit.yaml
@@ -291,3 +291,32 @@ spec:
         artifacts:
           - name: circuit-set
             path: /app/circuit_set.json
+
+
+    # Initialize
+    - name: initalize-circuit-set
+      parent: generic-task
+      inputs:
+        parameters:
+          - name: command
+            value: python3 main_script.py
+        artifacts:
+          - name: circuit-set
+            path: /app/circuit_set_input.json
+            optional: true
+          - name: main-script
+            path: /app/main_script.py
+            raw:
+              data: |
+                import os
+                from zquantum.core.circuit import load_circuit_set, save_circuit_set
+
+                if os.path.exists('circuit_set_input.json'):
+                  circuit_set = load_circuit_set('circuit_set_input.json')
+                else:
+                  circuit_set = []
+                save_circuit_set(circuit_set,"circuit_set.json")
+      outputs:
+        artifacts:
+          - name: circuit-set
+            path: /app/circuit_set.json

--- a/templates/circuit.yaml
+++ b/templates/circuit.yaml
@@ -293,7 +293,7 @@ spec:
                   if os.path.exists(file):
                     circuit_set.append(load_circuit(file))
 
-                 save_circuit_set(circuit_set,"circuit_set.json")
+                save_circuit_set(circuit_set,"circuit_set.json")
       outputs:
         artifacts:
           - name: circuit-set

--- a/templates/circuit.yaml
+++ b/templates/circuit.yaml
@@ -235,3 +235,28 @@ spec:
         artifacts:
           - name: circuit-set
             path: /app/circuit_set.json
+
+    # Add circuits in a circuit set
+    - name: add-circuits-in-circuit-set
+      parent: generic-task
+      inputs:
+        parameters:
+          - name: command
+            value: python3 main_script.py
+        artifacts:
+          - name: circuit-set
+            path: /app/circuit_set.json
+          - name: main-script
+            path: /app/main_script.py
+            raw:
+              data: |
+                from zquantum.core.circuit import load_circuit_set, save_circuit, Circuit
+                circuit_set = load_circuit_set("circuit.json")
+                circuit = Circuit()
+                for circ in circuit_set:
+                  circuit += circ
+                save_circuit(circuit,"circuit.json")
+      outputs:
+        artifacts:
+          - name: circuit
+            path: /app/circuit.json

--- a/templates/circuit.yaml
+++ b/templates/circuit.yaml
@@ -229,7 +229,7 @@ spec:
             path: /app/extended_circuit.json
 
 
-    # Create circuit set from 4 circuit artifacts #TODO for an arbitrary number of artifacts
+    # Create circuit set from 4 circuit artifacts
     - name: create-circuit-set-from-circuit-artifacts
       parent: generic-task
       inputs:
@@ -260,7 +260,7 @@ spec:
           - name: circuit-set
             path: /app/circuit_set.json
 
-    # Add a circuit to a circuit-set
+    # Add a circuit to a circuit-set (if we want to add more than 4 circuit artifacts)
     - name: add-circuit-artifact-to-circuit-set
       parent: generic-task
       inputs:
@@ -286,35 +286,6 @@ spec:
                   circuit_set = []
 
                 circuit_set.append(load_circuit("circuit.json"))
-                save_circuit_set(circuit_set,"circuit_set.json")
-      outputs:
-        artifacts:
-          - name: circuit-set
-            path: /app/circuit_set.json
-
-
-    # Initialize
-    - name: initalize-circuit-set
-      parent: generic-task
-      inputs:
-        parameters:
-          - name: command
-            value: python3 main_script.py
-        artifacts:
-          - name: circuit-set
-            path: /app/circuit_set_input.json
-            optional: true
-          - name: main-script
-            path: /app/main_script.py
-            raw:
-              data: |
-                import os
-                from zquantum.core.circuit import load_circuit_set, save_circuit_set
-
-                if os.path.exists('circuit_set_input.json'):
-                  circuit_set = load_circuit_set('circuit_set_input.json')
-                else:
-                  circuit_set = []
                 save_circuit_set(circuit_set,"circuit_set.json")
       outputs:
         artifacts:

--- a/templates/circuit.yaml
+++ b/templates/circuit.yaml
@@ -252,9 +252,9 @@ spec:
         artifacts:
           - name: circuit
             path: /app/circuit.json
-            
-            
-    # Create circuit set from 4 circuit artifacts
+
+
+    # Create circuit set from circuit artifacts
     - name: create-circuit-set-from-circuit-artifacts
       parent: generic-task
       inputs:
@@ -266,52 +266,34 @@ spec:
             path: /app/circuit1.json
           - name: circuit-2
             path: /app/circuit2.json
+            optional: true
           - name: circuit-3
             path: /app/circuit3.json
+            optional: true
           - name: circuit-4
             path: /app/circuit4.json
-          - name: main-script
-            path: /app/main_script.py
-            raw:
-              data: |
-                from zquantum.core.circuit import load_circuit, save_circuit_set
-                filenames = ["circuit1.json", "circuit2.json", "circuit3.json", "circuit4.json"]
-                circuit_set = []
-                for file in filenames:
-                  circuit_set.append(load_circuit(file))
-                save_circuit_set(circuit_set,"circuit_set.json")
-      outputs:
-        artifacts:
-          - name: circuit-set
-            path: /app/circuit_set.json
-
-    # Add a circuit to a circuit-set (if we want to add more than 4 circuit artifacts)
-    - name: add-circuit-artifact-to-circuit-set
-      parent: generic-task
-      inputs:
-        parameters:
-          - name: command
-            value: python3 main_script.py
-        artifacts:
-          - name: circuit-set
-            path: /app/circuit_set_input.json
             optional: true
-          - name: circuit
-            path: /app/circuit.json
+          - name: circuit-set
+            path: /app/circuit_set_in.json
+            optional: true
           - name: main-script
             path: /app/main_script.py
             raw:
               data: |
-              import os
+                import os
                 from zquantum.core.circuit import load_circuit_set, load_circuit, save_circuit_set
-                
-                if os.path.exists('circuit_set_input.json'):
-                  circuit_set = load_circuit_set('circuit_set_input.json')
+
+                if os.path.exists('circuit_set_in.json'):
+                  circuit_set = load_circuit_set('circuit_set_in.json')
                 else:
                   circuit_set = []
 
-                circuit_set.append(load_circuit("circuit.json"))
-                save_circuit_set(circuit_set,"circuit_set.json")
+                filenames = ["circuit1.json", "circuit2.json", "circuit3.json", "circuit4.json"]
+                for file in filenames:
+                  if os.path.exists(file):
+                    circuit_set.append(load_circuit(file))
+
+                 save_circuit_set(circuit_set,"circuit_set.json")
       outputs:
         artifacts:
           - name: circuit-set

--- a/templates/circuit.yaml
+++ b/templates/circuit.yaml
@@ -91,7 +91,7 @@ spec:
                 params = load_circuit_template_params('params.json')
               else:
                 params = None
-              
+
               if params is not None:
                 circuit = ansatz.get_executable_circuit(params)
               elif ansatz.supports_parametrized_circuits:
@@ -202,3 +202,36 @@ spec:
         artifacts:
           - name: circuit
             path: /app/circuit.json
+
+
+
+    # Create circuit set from 4 circuit artifacts #TODO for an arbitrary number of artifacts
+    - name: create-circuit-set-from-circuit-artifacts
+      parent: generic-task
+      inputs:
+        parameters:
+          - name: command
+            value: python3 main_script.py
+        artifacts:
+          - name: circuit-1
+            path: /app/circuit1.json
+          - name: circuit-2
+            path: /app/circuit2.json
+          - name: circuit-3
+            path: /app/circuit3.json
+          - name: circuit-4
+            path: /app/circuit4.json
+          - name: main-script
+            path: /app/main_script.py
+            raw:
+              data: |
+                from zquantum.core.circuit import load_circuit, save_circuit_set
+                filenames = ["circuit1.json", "circuit2.json", "circuit3.json", "circuit4.json"]
+                circuit_set = []
+                for file in filenames:
+                  circuit_set.append(load_circuit(file))
+                save_circuit_set(circuit_set,"circuit_set.json")
+      outputs:
+        artifacts:
+          - name: circuit-set
+            path: /app/circuit_set.json

--- a/templates/circuit.yaml
+++ b/templates/circuit.yaml
@@ -229,8 +229,6 @@ spec:
             path: /app/extended_circuit.json
 
 
-
-
     # Create circuit set from 4 circuit artifacts #TODO for an arbitrary number of artifacts
     - name: create-circuit-set-from-circuit-artifacts
       parent: generic-task
@@ -256,6 +254,38 @@ spec:
                 circuit_set = []
                 for file in filenames:
                   circuit_set.append(load_circuit(file))
+                save_circuit_set(circuit_set,"circuit_set.json")
+      outputs:
+        artifacts:
+          - name: circuit-set
+            path: /app/circuit_set.json
+
+    # Add a circuit to a circuit-set 
+    - name: add-circuit-artifact-to-circuit-set
+      parent: generic-task
+      inputs:
+        parameters:
+          - name: command
+            value: python3 main_script.py
+        artifacts:
+          - name: circuit-set
+            path: /app/circuit_set.json
+            optional: true
+          - name: circuit
+            path: /app/circuit.json
+          - name: main-script
+            path: /app/main_script.py
+            raw:
+              data: |
+                import os
+                from zquantum.core.circuit import load_circuit_set, load_circuit, save_circuit_set
+
+                if os.path.exists('circuit_set.json'):
+                  circuit_set = load_circuit_set('circuit_set.json')
+                else:
+                  circuit_set = []
+
+                circuit_set.append(load_circuit("circuit.json"))
                 save_circuit_set(circuit_set,"circuit_set.json")
       outputs:
         artifacts:

--- a/templates/circuit.yaml
+++ b/templates/circuit.yaml
@@ -251,7 +251,7 @@ spec:
             raw:
               data: |
                 from zquantum.core.circuit import load_circuit_set, save_circuit, Circuit
-                circuit_set = load_circuit_set("circuit.json")
+                circuit_set = load_circuit_set("circuit_set.json")
                 circuit = Circuit()
                 for circ in circuit_set:
                   circuit += circ


### PR DESCRIPTION
This PR adds 2 templates: 
1. combine 4 circuit artifacts in a circuitset  
2. add a circuit artifact to an existing circuitset 

Template 2 allows to create bigger circuitsets (more than 4 circuits). 
To me, the ideal way to go here would be to keep in the resource only template 2, and run it in a loop (in the workflow) so to update the circuitset with one circuit at a time, namely: 
```
name: loop-over-circuits
steps:
- - name: add-circuit-artifact-to-circuit-set
     arguments:
     - circuit-set: *the one from the previous loop step*
     - circuit: item 
withItems: [circuit1, circuit2]

```
This seems not to be possible because the input of step n is the output of step n-1, and as far as I know this is not possible to do in the workflow. I looked into argo docs and some examples + thought about some other possible strategies to make this more general but could not find a solution, so I decided to leave the two templates available. Any comments/ideas? 

Context: once you have a circuitset, you can easily combine its elements adding them up to build a more complicated circuit (see [this PR](https://github.com/zapatacomputing/z-quantum-core/pull/82))

