### PR TITLE
Reimplement ValueEstimate as a subclass of float

### DIFF
--- a/src/python/zquantum/core/utils.py
+++ b/src/python/zquantum/core/utils.py
@@ -1,4 +1,5 @@
 """General-purpose utilities."""
+import warnings
 
 import numpy as np
 from scipy.linalg import expm
@@ -15,7 +16,7 @@ from networkx.readwrite import json_graph
 import lea
 import collections
 import scipy
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 import importlib
 
 
@@ -245,12 +246,12 @@ def convert_tuples_to_bitstrings(tuples):
     return bitstrings
 
 
-class ValueEstimate:
+class ValueEstimate(float):
     """A class representing a numerical value and its precision corresponding
         to an observable or an objective function
 
     Args:
-        value (np.float): the numerical value
+        value (np.float): the numerical value or a value that can be converted to float
         precision (np.float): its precision
 
     Attributes:
@@ -258,18 +259,35 @@ class ValueEstimate:
         precision (np.float): its precision
     """
 
-    def __init__(self, value, precision=None):
-        self.value = value
+    def __init__(self, value, precision: Optional[float] = None):
+        super().__init__()
         self.precision = precision
 
+    def __new__(cls, value, precision=None):
+        return super().__new__(cls, value)
+
+    @property
+    def value(self):
+        warnings.warn(
+            "The value attribute is deprecated. Use ValueEstimate object directly instead.",
+            DeprecationWarning,
+        )
+        return float(self)
+
     def __eq__(self, other):
-        return self.value == other.value and self.precision == other.precision
+        return super().__eq__(other) and self.precision == getattr(
+            other, "precision", None
+        )
+
+    def __ne__(self, other):
+        return not self == other
 
     def __str__(self):
+        value_str = super().__str__()
         if self.precision is not None:
-            return f'{self.value} ± {self.precision}'
+            return f"{value_str} ± {self.precision}"
         else:
-            return f'{self.value}'
+            return f"{value_str}"
 
     def to_dict(self):
         """Convert to a dictionary"""
@@ -483,4 +501,3 @@ def save_timing(walltime: float, filename: str) -> None:
         f.write(
             json.dumps({"schema": SCHEMA_VERSION + "-timing", "walltime": walltime})
         )
-


### PR DESCRIPTION
This reimplements ValueEstimate as a subclass of float. This is backwards compatible, as new `ValueEstimate` still exposes `value` attribute (although marked as deprecated).
