### PR TITLE
Adapt optimizer interface to new history recording mechanism

### DIFF
--- a/src/python/zquantum/core/interfaces/optimizer.py
+++ b/src/python/zquantum/core/interfaces/optimizer.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod
 
 import scipy
 from scipy.optimize import OptimizeResult
+from zquantum.core.interfaces.functions import CallableWithGradient
+
 from .cost_function import CostFunction
 from typing import Callable, Optional, Dict
 import numpy as np
@@ -25,14 +27,13 @@ class Optimizer(ABC):
 
     @abstractmethod
     def minimize(
-        self, cost_function: CostFunction, initial_params: np.ndarray, **kwargs
+        self, cost_function: CallableWithGradient, initial_params: np.ndarray, **kwargs
     ) -> OptimizeResult:
-        """
-        Finds the parameters which minimize given cost function.
+        """Finds the parameters which minimize given cost function.
 
         Args:
-            cost_function (zquantu.core.interfaces.CostFunction): an object representing the cost function.
-            inital_params (np.ndarray): initial parameters for the cost function
+            cost_function: an object representing the cost function.
+            initial_params: initial parameters for the cost function.
 
         Returns:
             OptimizeResults

--- a/src/python/zquantum/core/interfaces/optimizer_test.py
+++ b/src/python/zquantum/core/interfaces/optimizer_test.py
@@ -1,9 +1,11 @@
 import unittest
 import numpy as np
 import pytest
+from zquantum.core.interfaces.functions import FunctionWithGradient
 
 from .optimizer import optimization_result
 from ..cost_function import BasicCostFunction
+from ..gradients import finite_differences_gradient
 
 
 def rosenbrock_function(x):
@@ -19,11 +21,10 @@ class OptimizerTests(object):
     # To run tests with this base class, the following variables need to be properly initialized in the child class:
     # self.optimizers
 
-    def test_optimization(self):
+    def test_optimizer_succeeds_with_optimizing_rosenbrock_function(self):
         for optimizer in self.optimizers:
-            cost_function = BasicCostFunction(
-                rosenbrock_function, gradient_type="finite_difference"
-            )
+            cost_function = FunctionWithGradient(rosenbrock_function, finite_differences_gradient(rosenbrock_function))
+
             results = optimizer.minimize(cost_function, initial_params=np.array([0, 0]))
             self.assertAlmostEqual(results.opt_value, 0, places=4)
             self.assertAlmostEqual(results.opt_params[0], 1, places=3)
@@ -35,11 +36,10 @@ class OptimizerTests(object):
             self.assertIn("opt_params", results.keys())
             self.assertIn("history", results.keys())
 
-    def test_optimization_simple_function(self):
+    def test_optimizer_succeeds_with_optimizing_simple_function(self):
         for optimizer in self.optimizers:
-            cost_function = BasicCostFunction(
-                sum_x_squared, gradient_type="finite_difference"
-            )
+            cost_function = FunctionWithGradient(sum_x_squared, finite_differences_gradient(sum_x_squared))
+
             results = optimizer.minimize(
                 cost_function, initial_params=np.array([1, -1])
             )

--- a/src/python/zquantum/core/interfaces/optimizer_test.py
+++ b/src/python/zquantum/core/interfaces/optimizer_test.py
@@ -36,7 +36,7 @@ class OptimizerTests(object):
             self.assertIn("opt_params", results.keys())
             self.assertIn("history", results.keys())
 
-    def test_optimizer_succeeds_with_optimizing_simple_function(self):
+    def test_optimizer_succeeds_with_optimizing_sum_of_squares_function(self):
         for optimizer in self.optimizers:
             cost_function = FunctionWithGradient(sum_x_squared, finite_differences_gradient(sum_x_squared))
 


### PR DESCRIPTION
This adapts optimizer interface to new history recording mechanism (which does not need a `CostFunction` objects). The base class for optimizer tests is also updated so the function being optimized are also callables with gradients as opposed to Cost functions.