### PR TITLE
175538989 add support for converting parametrized gates

### DIFF
--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
@@ -94,10 +94,7 @@ def test_converting_rotation_gate_to_pyquil_preserves_qubit_index_and_angle(
 
 
 @pytest.mark.parametrize("qubit", [0, 4, 10, 11])
-@pytest.mark.parametrize(
-    "zquantum_angle, pyquil_angle",
-    EXAMPLE_PARAMETRIZED_ANGLES
-)
+@pytest.mark.parametrize("zquantum_angle, pyquil_angle", EXAMPLE_PARAMETRIZED_ANGLES)
 @pytest.mark.parametrize("gate_cls", [RX, RY, RZ, PHASE])
 def test_converting_parametrized_rotation_gate_to_pyquil_translates_angle_expression(
     qubit, zquantum_angle, pyquil_angle, gate_cls
@@ -122,10 +119,7 @@ def test_pyquil_gate_created_from_zquantum_cphase_gate_has_the_same_qubits_and_a
 
 
 @pytest.mark.parametrize("qubits", [[0, 1], [2, 10], [4, 7]])
-@pytest.mark.parametrize(
-    "zquantum_angle, pyquil_angle",
-    EXAMPLE_PARAMETRIZED_ANGLES
-)
+@pytest.mark.parametrize("zquantum_angle, pyquil_angle", EXAMPLE_PARAMETRIZED_ANGLES)
 def test_angle_of_parametrized_cphase_gate_is_translated_when_converting_to_pyquil(
     qubits, zquantum_angle, pyquil_angle
 ):

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
@@ -67,6 +67,23 @@ def test_converting_rotation_gate_to_pyquil_preserves_qubit_index_and_angle(
     assert pyquil_gate.params[0] == angle
 
 
+@pytest.mark.parametrize("qubit", [0, 4, 10, 11])
+@pytest.mark.parametrize(
+    "native_angle, pyquil_angle",
+    [
+        (sympy.Symbol("theta"), pyquil.quil.Parameter("theta")),
+        (sympy.Symbol("x") + sympy.Symbol("y"), pyquil.quil.Parameter("x") + pyquil.quil.Parameter("y")),
+        (2 * sympy.Symbol("phi"), 2 * pyquil.quil.Parameter("phi"))
+    ]
+)
+@pytest.mark.parametrize("gate_cls", [RX, RY, RZ, PHASE])
+def test_converting_parametrized_rotation_gate_to_pyquil_translates_angle_expression(
+    qubit, native_angle, pyquil_angle, gate_cls
+):
+    pyquil_gate = convert_to_pyquil(gate_cls(qubit, native_angle))
+    assert pyquil_gate.params[0] == pyquil_angle
+
+
 @pytest.mark.parametrize("qubits", [[0, 1], [2, 10], [4, 7]])
 @pytest.mark.parametrize("angle", [0, np.pi / 4, np.pi / 2, np.pi, 2 * np.pi])
 def test_pyquil_gate_created_from_zquantum_cphase_gate_has_the_same_qubits_and_angle_as_the_original_one(

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
@@ -413,3 +413,11 @@ def test_converting_circuit_to_pyquil_gives_program_with_the_same_gates():
     )
 
     assert expected_program == converted_program
+
+
+def test_pyquil_circuit_obtained_from_empty_circuit_is_also_empty():
+    circuit = Circuit()
+
+    pyquil_circuit = convert_to_pyquil(circuit)
+
+    assert not pyquil_circuit.instructions

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
@@ -266,7 +266,7 @@ def test_converting_parametrized_custom_gate_to_pyquil_adds_its_definition_to_pr
         [sympy.cos(x + y), sympy.sin(theta), 0, 0],
         [-sympy.sin(theta), sympy.cos(x + y), 0, 0],
         [0, 0, sympy.sqrt(x), sympy.exp(y)],
-        [0, 0, 1, sympy.I]
+        [0, 0, 1.0, sympy.I]
     ]),
         (0, 2),
         "my_gate"
@@ -287,9 +287,13 @@ def test_converting_parametrized_custom_gate_to_pyquil_adds_its_definition_to_pr
     ]
     )
 
-    assert program.defined_gates == [
-        pyquil.quil.DefGate(custom_gate.name, expected_pyquil_matrix, [quil_x, quil_y, quil_theta])
-    ]
+    # Note: we cannot replace this with a single assertion. This is because
+    # the order of custom_gate.symbolic_params is not known.
+    gate_definition = program.defined_gates[0]
+    assert len(program.defined_gates) == 1
+    assert len(gate_definition.parameters) == 3
+    assert set(gate_definition.parameters) == {quil_x, quil_y, quil_theta}
+    assert np.array_equal(gate_definition.matrix, expected_pyquil_matrix)
 
 
 @pytest.mark.parametrize("times_to_convert", [2, 3, 5, 6])

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
@@ -119,6 +119,25 @@ def test_pyquil_gate_created_from_zquantum_cphase_gate_has_the_same_qubits_and_a
 
 
 @pytest.mark.parametrize("qubits", [[0, 1], [2, 10], [4, 7]])
+@pytest.mark.parametrize(
+    "zquantum_angle, pyquil_angle",
+    [
+        (sympy.Symbol("theta"), pyquil.quil.Parameter("theta")),
+        (
+            sympy.Symbol("x") + sympy.Symbol("y"),
+            pyquil.quil.Parameter("x") + pyquil.quil.Parameter("y"),
+        ),
+        (2 * sympy.Symbol("phi"), 2 * pyquil.quil.Parameter("phi")),
+    ],
+)
+def test_angle_of_parametrized_cphase_gate_is_translated_when_converting_to_pyquil(
+    qubits, zquantum_angle, pyquil_angle
+):
+    pyquil_gate = convert_to_pyquil(CPHASE(*qubits, zquantum_angle))
+    assert pyquil_gate.params[0] == pyquil_angle
+
+
+@pytest.mark.parametrize("qubits", [[0, 1], [2, 10], [4, 7]])
 def test_converting_swap_gate_to_pyquil_preserves_qubits(qubits):
     pyquil_gate = convert_to_pyquil(SWAP(qubits))
 

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
@@ -45,6 +45,15 @@ ORQUESTRA_GATE_TYPE_TO_PYQUIL_NAME = {
     CPHASE: "CPHASE",
 }
 
+EXAMPLE_PARAMETRIZED_ANGLES = [
+    (sympy.Symbol("theta"), pyquil.quil.Parameter("theta")),
+    (
+        sympy.Symbol("x") + sympy.Symbol("y"),
+        pyquil.quil.Parameter("x") + pyquil.quil.Parameter("y"),
+    ),
+    (2 * sympy.Symbol("phi"), 2 * pyquil.quil.Parameter("phi")),
+]
+
 
 def pyquil_gate_matrix(gate: pyquil.gates.Gate) -> np.ndarray:
     """Get numpy matrix corresponding to pyquil Gate.
@@ -85,21 +94,14 @@ def test_converting_rotation_gate_to_pyquil_preserves_qubit_index_and_angle(
 
 @pytest.mark.parametrize("qubit", [0, 4, 10, 11])
 @pytest.mark.parametrize(
-    "native_angle, pyquil_angle",
-    [
-        (sympy.Symbol("theta"), pyquil.quil.Parameter("theta")),
-        (
-            sympy.Symbol("x") + sympy.Symbol("y"),
-            pyquil.quil.Parameter("x") + pyquil.quil.Parameter("y"),
-        ),
-        (2 * sympy.Symbol("phi"), 2 * pyquil.quil.Parameter("phi")),
-    ],
+    "zquantum_angle, pyquil_angle",
+    EXAMPLE_PARAMETRIZED_ANGLES
 )
 @pytest.mark.parametrize("gate_cls", [RX, RY, RZ, PHASE])
 def test_converting_parametrized_rotation_gate_to_pyquil_translates_angle_expression(
-    qubit, native_angle, pyquil_angle, gate_cls
+    qubit, zquantum_angle, pyquil_angle, gate_cls
 ):
-    pyquil_gate = convert_to_pyquil(gate_cls(qubit, native_angle))
+    pyquil_gate = convert_to_pyquil(gate_cls(qubit, zquantum_angle))
     assert pyquil_gate.params[0] == pyquil_angle
 
 
@@ -121,14 +123,7 @@ def test_pyquil_gate_created_from_zquantum_cphase_gate_has_the_same_qubits_and_a
 @pytest.mark.parametrize("qubits", [[0, 1], [2, 10], [4, 7]])
 @pytest.mark.parametrize(
     "zquantum_angle, pyquil_angle",
-    [
-        (sympy.Symbol("theta"), pyquil.quil.Parameter("theta")),
-        (
-            sympy.Symbol("x") + sympy.Symbol("y"),
-            pyquil.quil.Parameter("x") + pyquil.quil.Parameter("y"),
-        ),
-        (2 * sympy.Symbol("phi"), 2 * pyquil.quil.Parameter("phi")),
-    ],
+    EXAMPLE_PARAMETRIZED_ANGLES
 )
 def test_angle_of_parametrized_cphase_gate_is_translated_when_converting_to_pyquil(
     qubits, zquantum_angle, pyquil_angle

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -111,7 +111,10 @@ def convert_two_qubit_nonparametric_gate_to_pyquil(
 def convert_CPHASE_to_pyquil(
     gate: CPHASE, _program: Optional[pyquil.Program]
 ) -> pyquil.gates.Gate:
-    return pyquil.gates.CPHASE(gate.angle, *gate.qubits)
+    return pyquil.gates.CPHASE(
+        translate_expression(expression_from_sympy(gate.angle), QUIL_DIALECT),
+        *gate.qubits,
+    )
 
 
 @_convert_gate_to_pyquil.register(SWAP)

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -1,6 +1,6 @@
 """Utilities for converting gates and circuits to and from Pyquil objects."""
 from functools import singledispatch
-from typing import Union, Optional
+from typing import Union, Optional, overload
 import numpy as np
 import pyquil
 import pyquil.gates
@@ -52,6 +52,18 @@ TWO_QUBIT_CONTROLLED_GATES = {
     CNOT: pyquil.gates.CNOT,
     SWAP: pyquil.gates.SWAP,
 }
+
+
+@overload
+def convert_to_pyquil(obj: Circuit) -> pyquil.Program:
+    pass
+
+
+@overload
+def convert_to_pyquil(
+    obj: Gate, program: Optional[pyquil.Program]
+) -> pyquil.quil.Gate:
+    pass
 
 
 @singledispatch

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -7,6 +7,10 @@ import pyquil.gates
 from ...circuit import Gate, ControlledGate
 from ..circuit import Circuit
 from ...circuit.gates import X, Y, Z, RX, RY, RZ, PHASE, T, I, H, Dagger, CZ, CNOT, CPHASE, SWAP, CustomGate
+from .symbolic.sympy_expressions import expression_from_sympy
+from .symbolic.translations import translate_expression
+from .symbolic.pyquil_expressions import QUIL_DIALECT
+
 
 SINGLE_QUBIT_NONPARAMETRIC_GATES = {
     X: pyquil.gates.X,
@@ -35,8 +39,6 @@ def convert_to_pyquil(obj, program: Optional[pyquil.Program] = None):
 
 @convert_to_pyquil.register
 def convert_gate_to_pyquil(gate: Gate, program: Optional[pyquil.Program] = None) -> pyquil.gates.Gate:
-    if gate.symbolic_params:
-        raise NotImplementedError(f"Cannot convert gate with symbolic params to PyQuil object.")
     return _convert_gate_to_pyquil(gate, program)
 
 
@@ -66,7 +68,10 @@ def convert_single_qubit_rotation_gate_to_pyquil(
     gate: Union[RX, RY, RZ, PHASE],
     _program: Optional[pyquil.Program] = None
 ) -> pyquil.gates.Gate:
-    return ROTATION_GATES[type(gate)](gate.angle, gate.qubit)
+    return ROTATION_GATES[type(gate)](
+        translate_expression(expression_from_sympy(gate.angle), QUIL_DIALECT),
+        gate.qubit
+    )
 
 
 @_convert_gate_to_pyquil.register(CNOT)

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -6,7 +6,24 @@ import pyquil
 import pyquil.gates
 from ...circuit import Gate, ControlledGate
 from ..circuit import Circuit
-from ...circuit.gates import X, Y, Z, RX, RY, RZ, PHASE, T, I, H, Dagger, CZ, CNOT, CPHASE, SWAP, CustomGate
+from ...circuit.gates import (
+    X,
+    Y,
+    Z,
+    RX,
+    RY,
+    RZ,
+    PHASE,
+    T,
+    I,
+    H,
+    Dagger,
+    CZ,
+    CNOT,
+    CPHASE,
+    SWAP,
+    CustomGate,
+)
 from .symbolic.sympy_expressions import expression_from_sympy
 from .symbolic.translations import translate_expression
 from .symbolic.pyquil_expressions import QUIL_DIALECT
@@ -18,17 +35,22 @@ SINGLE_QUBIT_NONPARAMETRIC_GATES = {
     Z: pyquil.gates.Z,
     I: pyquil.gates.I,
     T: pyquil.gates.T,
-    H: pyquil.gates.H
+    H: pyquil.gates.H,
 }
 
 
 ROTATION_GATES = {
-    RX: pyquil.gates.RX, RY: pyquil.gates.RY, RZ: pyquil.gates.RZ, PHASE: pyquil.gates.PHASE
+    RX: pyquil.gates.RX,
+    RY: pyquil.gates.RY,
+    RZ: pyquil.gates.RZ,
+    PHASE: pyquil.gates.PHASE,
 }
 
 
 TWO_QUBIT_CONTROLLED_GATES = {
-    CZ: pyquil.gates.CZ, CNOT: pyquil.gates.CNOT, SWAP: pyquil.gates.SWAP
+    CZ: pyquil.gates.CZ,
+    CNOT: pyquil.gates.CNOT,
+    SWAP: pyquil.gates.SWAP,
 }
 
 
@@ -38,12 +60,16 @@ def convert_to_pyquil(obj, program: Optional[pyquil.Program] = None):
 
 
 @convert_to_pyquil.register
-def convert_gate_to_pyquil(gate: Gate, program: Optional[pyquil.Program] = None) -> pyquil.gates.Gate:
+def convert_gate_to_pyquil(
+    gate: Gate, program: Optional[pyquil.Program] = None
+) -> pyquil.gates.Gate:
     return _convert_gate_to_pyquil(gate, program)
 
 
 @singledispatch
-def _convert_gate_to_pyquil(gate: Gate, _program: Optional[pyquil.Program] = None) -> pyquil.gates.Gate:
+def _convert_gate_to_pyquil(
+    gate: Gate, _program: Optional[pyquil.Program] = None
+) -> pyquil.gates.Gate:
     raise NotImplementedError(f"Cannot convert gate {gate} to PyQUil.")
 
 
@@ -54,8 +80,7 @@ def _convert_gate_to_pyquil(gate: Gate, _program: Optional[pyquil.Program] = Non
 @_convert_gate_to_pyquil.register(T)
 @_convert_gate_to_pyquil.register(H)
 def convert_single_qubit_nonparametric_gate_to_pyquil(
-    gate: Union[X, Y, Z],
-    _program: Optional[pyquil.Program] = None
+    gate: Union[X, Y, Z], _program: Optional[pyquil.Program] = None
 ) -> pyquil.gates.Gate:
     return SINGLE_QUBIT_NONPARAMETRIC_GATES[type(gate)](gate.qubit)
 
@@ -65,12 +90,11 @@ def convert_single_qubit_nonparametric_gate_to_pyquil(
 @_convert_gate_to_pyquil.register(RZ)
 @_convert_gate_to_pyquil.register(PHASE)
 def convert_single_qubit_rotation_gate_to_pyquil(
-    gate: Union[RX, RY, RZ, PHASE],
-    _program: Optional[pyquil.Program] = None
+    gate: Union[RX, RY, RZ, PHASE], _program: Optional[pyquil.Program] = None
 ) -> pyquil.gates.Gate:
     return ROTATION_GATES[type(gate)](
         translate_expression(expression_from_sympy(gate.angle), QUIL_DIALECT),
-        gate.qubit
+        gate.qubit,
     )
 
 
@@ -78,34 +102,43 @@ def convert_single_qubit_rotation_gate_to_pyquil(
 @_convert_gate_to_pyquil.register(CZ)
 @_convert_gate_to_pyquil.register(SWAP)
 def convert_two_qubit_nonparametric_gate_to_pyquil(
-    gate: Union[CZ],
-    _program: Optional[pyquil.Program] = None
+    gate: Union[CZ], _program: Optional[pyquil.Program] = None
 ) -> pyquil.gates.Gate:
     return TWO_QUBIT_CONTROLLED_GATES[type(gate)](*gate.qubits)
 
 
 @_convert_gate_to_pyquil.register(CPHASE)
-def convert_CPHASE_to_pyquil(gate: CPHASE, _program: Optional[pyquil.Program]) -> pyquil.gates.Gate:
+def convert_CPHASE_to_pyquil(
+    gate: CPHASE, _program: Optional[pyquil.Program]
+) -> pyquil.gates.Gate:
     return pyquil.gates.CPHASE(gate.angle, *gate.qubits)
 
 
 @_convert_gate_to_pyquil.register(SWAP)
-def convert_SWAP_gate_to_pyquil(gate: SWAP, _program: Optional[pyquil.Program]) -> pyquil.gates.Gate:
+def convert_SWAP_gate_to_pyquil(
+    gate: SWAP, _program: Optional[pyquil.Program]
+) -> pyquil.gates.Gate:
     return pyquil.gates.SWAP(*gate.qubits)
 
 
 @_convert_gate_to_pyquil.register(ControlledGate)
-def convert_controlled_gate_to_pyquil(gate: ControlledGate, _program: Optional[pyquil.Program]) -> pyquil.gates.Gate:
+def convert_controlled_gate_to_pyquil(
+    gate: ControlledGate, _program: Optional[pyquil.Program]
+) -> pyquil.gates.Gate:
     return convert_to_pyquil(gate.target_gate, _program).controlled(gate.control)
 
 
 @_convert_gate_to_pyquil.register(Dagger)
-def convert_dagger_to_pyquil(gate: Dagger, _program: Optional[pyquil.Program]) -> pyquil.gates.Gate:
+def convert_dagger_to_pyquil(
+    gate: Dagger, _program: Optional[pyquil.Program]
+) -> pyquil.gates.Gate:
     return convert_to_pyquil(gate.gate, _program).dagger()
 
 
 @_convert_gate_to_pyquil.register(CustomGate)
-def convert_custom_gate_to_pyquil(gate: CustomGate, program: Optional[pyquil.Program]) -> pyquil.gates.Gate:
+def convert_custom_gate_to_pyquil(
+    gate: CustomGate, program: Optional[pyquil.Program]
+) -> pyquil.gates.Gate:
     gate_definition = None
 
     for definition in program.defined_gates:
@@ -114,14 +147,18 @@ def convert_custom_gate_to_pyquil(gate: CustomGate, program: Optional[pyquil.Pro
             break
 
     if gate_definition is None:
-        gate_definition = pyquil.quil.DefGate(gate.name, np.array(gate.matrix.tolist(), dtype=complex))
+        gate_definition = pyquil.quil.DefGate(
+            gate.name, np.array(gate.matrix.tolist(), dtype=complex)
+        )
         program += gate_definition
 
     return gate_definition.get_constructor()(*gate.qubits)
 
 
 @convert_to_pyquil.register(Circuit)
-def convert_circuit_to_pyquil(circuit: Circuit, _program: Optional[pyquil.Program] = None) -> pyquil.Program:
+def convert_circuit_to_pyquil(
+    circuit: Circuit, _program: Optional[pyquil.Program] = None
+) -> pyquil.Program:
     program = pyquil.Program()
     for gate in circuit.gates:
         program += convert_to_pyquil(gate, program)

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -63,6 +63,10 @@ def convert_to_pyquil(obj, program: Optional[pyquil.Program] = None):
 def convert_gate_to_pyquil(
     gate: Gate, program: Optional[pyquil.Program] = None
 ) -> pyquil.gates.Gate:
+    required_declarations = (pyquil.quil.Declare(str(param), "REAL") for param in gate.symbolic_params)
+    for declaration in required_declarations:
+        if declaration not in program.instructions:
+            program += declaration
     return _convert_gate_to_pyquil(gate, program)
 
 

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -150,8 +150,20 @@ def convert_custom_gate_to_pyquil(
             break
 
     if gate_definition is None:
+        converted_matrix = [
+            [
+                translate_expression(expression_from_sympy(element), QUIL_DIALECT)
+                for element in row
+            ]
+            for row in gate.matrix.tolist()
+        ]
         gate_definition = pyquil.quil.DefGate(
-            gate.name, np.array(gate.matrix.tolist(), dtype=complex)
+            gate.name,
+            np.array(converted_matrix),
+            [
+                translate_expression(expression_from_sympy(param), QUIL_DIALECT)
+                for param in gate.symbolic_params
+            ]
         )
         program += gate_definition
 

--- a/src/python/zquantum/core/circuit/conversions/symbolic/sympy_expressions.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/sympy_expressions.py
@@ -1,5 +1,7 @@
 """Utilities for converting sympy expressions to our native Expression format."""
 from functools import singledispatch
+from numbers import Number
+
 import sympy
 from .expressions import Symbol, FunctionCall
 
@@ -21,6 +23,11 @@ def expression_from_sympy(expression):
     raise NotImplementedError(
         f"Expression {expression} of type {type(expression)} is currentlyl not supported"
     )
+
+
+@expression_from_sympy.register
+def identity(number: Number):
+    return number
 
 
 @expression_from_sympy.register

--- a/src/python/zquantum/core/circuit/conversions/symbolic/sympy_expressions_test.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/sympy_expressions_test.py
@@ -10,6 +10,10 @@ from .sympy_expressions import (
 
 
 class TestBuildingTreeFromSympyExpression:
+    @pytest.mark.parametrize("number", [3, 4.0, 1j, 3.0 - 2j])
+    def test_native_numbers_are_preserved(self, number):
+        assert expression_from_sympy(number) == number
+
     @pytest.mark.parametrize(
         "sympy_symbol, expected_symbol",
         [


### PR DESCRIPTION
This is a (hopefully) final step in our efforts to implement the conversion of arbitrary Orquestra gates to PyQuil gates.

At this stage, it should be possible to convert an Orquestra gate to PyQuil gate even if it contains symbolic parameters. The symbolic parameters are also collected, i.e. appropriate variable declarations are also added to the corresponding PyQuil program in which context's the conversion is happening.