### PR TITLE
175497446 make docstrings consistent across codebase

### DIFF
--- a/src/python/zquantum/core/history/artifact_storage_test.py
+++ b/src/python/zquantum/core/history/artifact_storage_test.py
@@ -1,4 +1,4 @@
-"""Test cases for storing artifacts."""
+"""Test cases for storing artifacts and recording functions that store them."""
 import numpy as np
 import pytest
 from ..interfaces.functions import CallableStoringArtifacts

--- a/src/python/zquantum/core/history/example_functions.py
+++ b/src/python/zquantum/core/history/example_functions.py
@@ -4,17 +4,23 @@ Note that none of this use ValueEstimate as a return value. This is because
 recorders can work with callable objects of any return type.
 """
 from typing import Optional
-
 import numpy as np
 from ..interfaces.functions import FunctionWithGradient, StoreArtifact
 
 
 def sum_of_squares(params):
-    """Multidimensional sum of squares."""
+    """Multidimensional sum of squares.
+
+    Args:
+        params: numbers to be squared and summed.
+
+    Returns:
+        Sum of squares of numbers in params.
+    """
     return sum(x ** 2 for x in params)
 
 
-# f(x, y) = x ** 2  - x * y
+# The below implements function: f(x, y) = x ** 2  - x * y
 function_1 = FunctionWithGradient(
     function=lambda params: params[0] ** 2 - params[0] * params[1],
     gradient=lambda params: np.array([2 * params[0] - params[1], -params[0]]),
@@ -22,20 +28,56 @@ function_1 = FunctionWithGradient(
 
 
 class Function2:
-    """Another example of function with gradient, this time implemented as a class."""
+    """Example of function with gradient, this time implemented as a class.
+
+    This function is f((x, y, z)) = multiplier * (x - xy + z ** 2),
+    where multiplier is fixed.
+
+    Args:
+        multiplier: fixed multiplier, see equation above.
+    """
 
     def __init__(self, multiplier):
         self.multiplier = multiplier
 
     def __call__(self, params):
+        """Compute value of this function.
+
+        Args:
+            params: parameters of the function. Their expected length is 3.
+
+        Returns:
+            self.multiplier * (x - xy + z ** 2) where x, y, z = params.
+        """
         return self.multiplier * (params[0] - params[0] * params[1] + params[2] ** 2)
 
     def gradient(self, params):
+        """Compute value of gradient of this function for given params.
+
+        Args:
+            params: parameters of the gradient. The expected length is 3.
+
+        Returns:
+            self.multiplier * [1 - y, -x, 2z] where x, y, z = params.
+        """
         return self.multiplier * np.array([1 - params[1], -params[0], 2 * params[2]])
 
 
 def function_3(params: int, store_artifact=None):
-    """An example of function that stores artifacts."""
+    """An example of function that stores artifacts.
+
+    Args:
+        params: parameters for the function. Note that the name `params` is
+          to follow the general conversion, but the function expectes
+          integer.
+        store_artifact: callback for storing artifacts. See StoreArtifact
+          protocol for explanation.
+
+    Returns:
+        The input argument multiplied by 2. As a side effect, binary
+        representation of the input argument is stored as "bitstring"
+        artifact.
+    """
     bitstring = bin(params)[2:]
     if store_artifact:
         store_artifact("bitstring", bitstring)
@@ -43,7 +85,11 @@ def function_3(params: int, store_artifact=None):
 
 
 def function_4(params: int, store_artifact: Optional[StoreArtifact] = None) -> int:
-    """Another example of function that stores artifacts, but forces store for some condition."""
+    """Another example of function that stores artifacts, but occasionally forces store.
+
+    This function is identical to function_3, except the artifact is forcefully
+    stored if input parameter is divisible by 2.
+    """
     bitstring = bin(params)[2:]
     if store_artifact:
         store_artifact("bitstring", bitstring, force=params % 2 == 0)
@@ -51,17 +97,39 @@ def function_4(params: int, store_artifact: Optional[StoreArtifact] = None) -> i
 
 
 class Function5:
-    """Example of a function that stores artifacts and has gradient. Full service."""
+    """Example of a function that stores artifacts and has gradient. Full service.
+
+    This function is f((x, y, z)) = alpha * xyz, where alpha is fixed.
+
+    Args:
+        alpha: parameter for this function, see equation above.
+    """
 
     def __init__(self, alpha):
         self.alpha = alpha
 
     def __call__(self, params: np.ndarray, store_artifact=None):
+        """Compute value of this function.
+
+        Args:
+            params: parameters of the function. The expected length is 3.
+
+        Returns:
+            self.alpha * x * y * z, where x, y, z = params
+        """
         if params[0] > 0 and store_artifact:
             store_artifact("something", params[0] + params[1])
         return self.alpha * params[0] * params[1] * params[2]
 
     def gradient(self, params):
+        """Compute value of gradient of this function for given params.
+
+        Args:
+            params: parameters of the gradient. The expected length is 3.
+
+        Returns:
+            self.alpha * [yz, xz, xy] where x, y, z = params.
+        """
         return self.alpha * np.ndarray(
             [params[1] * params[2], params[0] * params[2], params[0] * params[1]]
         )

--- a/src/python/zquantum/core/history/recording_functions_test.py
+++ b/src/python/zquantum/core/history/recording_functions_test.py
@@ -1,7 +1,7 @@
+"""Test cases for recording basic functions."""
 from unittest.mock import Mock, call
 import numpy as np
 import pytest
-
 from .example_functions import sum_of_squares, function_1, Function2
 from .recorder import recorder
 from .save_conditions import every_nth, SaveCondition

--- a/src/python/zquantum/core/history/recording_functions_with_gradient_test.py
+++ b/src/python/zquantum/core/history/recording_functions_with_gradient_test.py
@@ -1,4 +1,4 @@
-"""Test cases for functions with gradients."""
+"""Test cases for recording functions with gradients."""
 import pytest
 import numpy as np
 from .example_functions import function_1, Function2, Function5

--- a/src/python/zquantum/core/history/save_conditions.py
+++ b/src/python/zquantum/core/history/save_conditions.py
@@ -1,6 +1,5 @@
 """Save conditions possible to use with recorder."""
 from typing import Any
-
 from typing_extensions import Protocol
 
 
@@ -15,25 +14,38 @@ class SaveCondition(Protocol):
         evaluation of the function, the value of __call__(y, x, n) determines
         if current call should be saved to the history.
 
-        :param value: current value of the function.
-        :param params: parameters passed to the function.
-        :param call_number: a natural number determining how many times the target
-         function has been called.
-        :return: A boolean indicating whether the call being processed should be saved to
-        history.
+        Args:
+            value: current value of the function.
+            params: parameters passed to the function.
+            call_number: a natural number determining how many times the target
+              function has been called.
+
+        Returns:
+            A boolean indicating whether the call being processed should be
+            saved to history.
         """
         pass
 
 
 def always(value: Any, params: Any, call_number: int) -> bool:
-    """Default save condition: save always."""
+    """Default save condition: save always.
+
+    See parameters in SaveCondition.__call__ for explanation."""
     return True
 
 
 def every_nth(n: int) -> SaveCondition:
     """Save condition: every n-th step, counting from zero-th one.
 
-    Note: this is factory function, i.e. it returns the actual save condition for given n.
+    Note: this is factory function, i.e. it returns the actual save condition
+    for given n.
+
+    Args:
+        n: the integer determining which steps should be saved in history.
+
+    Returns:
+        Function `f` implementing the SaveCondition protocol, such that
+        f(y, x, k) is True if and only if k = 0 (mod n).
     """
 
     def _save_condition(value: Any, params: Any, call_number: int) -> bool:


### PR DESCRIPTION
This converts docstrings in `history` package to Google-style ones (see [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html).