### PR TITLE
175540559 pyquil expressions to orquestra expressions

### DIFF
--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
@@ -67,6 +67,23 @@ def test_converting_rotation_gate_to_pyquil_preserves_qubit_index_and_angle(
     assert pyquil_gate.params[0] == angle
 
 
+@pytest.mark.parametrize("qubit", [0, 4, 10, 11])
+@pytest.mark.parametrize(
+    "native_angle, pyquil_angle",
+    [
+        (sympy.Symbol("theta"), pyquil.quil.Parameter("theta")),
+        (sympy.Symbol("x") + sympy.Symbol("y"), pyquil.quil.Parameter("x") + pyquil.quil.Parameter("y")),
+        (2 * sympy.Symbol("phi"), 2 * pyquil.quil.Parameter("phi"))
+    ]
+)
+@pytest.mark.parametrize("gate_cls", [RX, RY, RZ, PHASE])
+def test_converting_parametrized_rotation_gate_to_pyquil_translates_angle_expression(
+    qubit, native_angle, pyquil_angle, gate_cls
+):
+    pyquil_gate = convert_to_pyquil(gate_cls(qubit, native_angle))
+    assert pyquil_gate.params[0] == pyquil_angle
+
+
 @pytest.mark.parametrize("qubits", [[0, 1], [2, 10], [4, 7]])
 @pytest.mark.parametrize("angle", [0, np.pi / 4, np.pi / 2, np.pi, 2 * np.pi])
 def test_pyquil_gate_created_from_zquantum_cphase_gate_has_the_same_qubits_and_angle_as_the_original_one(

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
@@ -119,6 +119,25 @@ def test_pyquil_gate_created_from_zquantum_cphase_gate_has_the_same_qubits_and_a
 
 
 @pytest.mark.parametrize("qubits", [[0, 1], [2, 10], [4, 7]])
+@pytest.mark.parametrize(
+    "zquantum_angle, pyquil_angle",
+    [
+        (sympy.Symbol("theta"), pyquil.quil.Parameter("theta")),
+        (
+            sympy.Symbol("x") + sympy.Symbol("y"),
+            pyquil.quil.Parameter("x") + pyquil.quil.Parameter("y"),
+        ),
+        (2 * sympy.Symbol("phi"), 2 * pyquil.quil.Parameter("phi")),
+    ],
+)
+def test_angle_of_parametrized_cphase_gate_is_translated_when_converting_to_pyquil(
+    qubits, zquantum_angle, pyquil_angle
+):
+    pyquil_gate = convert_to_pyquil(CPHASE(*qubits, zquantum_angle))
+    assert pyquil_gate.params[0] == pyquil_angle
+
+
+@pytest.mark.parametrize("qubits", [[0, 1], [2, 10], [4, 7]])
 def test_converting_swap_gate_to_pyquil_preserves_qubits(qubits):
     pyquil_gate = convert_to_pyquil(SWAP(qubits))
 

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
@@ -45,6 +45,15 @@ ORQUESTRA_GATE_TYPE_TO_PYQUIL_NAME = {
     CPHASE: "CPHASE",
 }
 
+EXAMPLE_PARAMETRIZED_ANGLES = [
+    (sympy.Symbol("theta"), pyquil.quil.Parameter("theta")),
+    (
+        sympy.Symbol("x") + sympy.Symbol("y"),
+        pyquil.quil.Parameter("x") + pyquil.quil.Parameter("y"),
+    ),
+    (2 * sympy.Symbol("phi"), 2 * pyquil.quil.Parameter("phi")),
+]
+
 
 def pyquil_gate_matrix(gate: pyquil.gates.Gate) -> np.ndarray:
     """Get numpy matrix corresponding to pyquil Gate.
@@ -85,21 +94,14 @@ def test_converting_rotation_gate_to_pyquil_preserves_qubit_index_and_angle(
 
 @pytest.mark.parametrize("qubit", [0, 4, 10, 11])
 @pytest.mark.parametrize(
-    "native_angle, pyquil_angle",
-    [
-        (sympy.Symbol("theta"), pyquil.quil.Parameter("theta")),
-        (
-            sympy.Symbol("x") + sympy.Symbol("y"),
-            pyquil.quil.Parameter("x") + pyquil.quil.Parameter("y"),
-        ),
-        (2 * sympy.Symbol("phi"), 2 * pyquil.quil.Parameter("phi")),
-    ],
+    "zquantum_angle, pyquil_angle",
+    EXAMPLE_PARAMETRIZED_ANGLES
 )
 @pytest.mark.parametrize("gate_cls", [RX, RY, RZ, PHASE])
 def test_converting_parametrized_rotation_gate_to_pyquil_translates_angle_expression(
-    qubit, native_angle, pyquil_angle, gate_cls
+    qubit, zquantum_angle, pyquil_angle, gate_cls
 ):
-    pyquil_gate = convert_to_pyquil(gate_cls(qubit, native_angle))
+    pyquil_gate = convert_to_pyquil(gate_cls(qubit, zquantum_angle))
     assert pyquil_gate.params[0] == pyquil_angle
 
 
@@ -121,14 +123,7 @@ def test_pyquil_gate_created_from_zquantum_cphase_gate_has_the_same_qubits_and_a
 @pytest.mark.parametrize("qubits", [[0, 1], [2, 10], [4, 7]])
 @pytest.mark.parametrize(
     "zquantum_angle, pyquil_angle",
-    [
-        (sympy.Symbol("theta"), pyquil.quil.Parameter("theta")),
-        (
-            sympy.Symbol("x") + sympy.Symbol("y"),
-            pyquil.quil.Parameter("x") + pyquil.quil.Parameter("y"),
-        ),
-        (2 * sympy.Symbol("phi"), 2 * pyquil.quil.Parameter("phi")),
-    ],
+    EXAMPLE_PARAMETRIZED_ANGLES
 )
 def test_angle_of_parametrized_cphase_gate_is_translated_when_converting_to_pyquil(
     qubits, zquantum_angle, pyquil_angle

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -111,7 +111,10 @@ def convert_two_qubit_nonparametric_gate_to_pyquil(
 def convert_CPHASE_to_pyquil(
     gate: CPHASE, _program: Optional[pyquil.Program]
 ) -> pyquil.gates.Gate:
-    return pyquil.gates.CPHASE(gate.angle, *gate.qubits)
+    return pyquil.gates.CPHASE(
+        translate_expression(expression_from_sympy(gate.angle), QUIL_DIALECT),
+        *gate.qubits,
+    )
 
 
 @_convert_gate_to_pyquil.register(SWAP)

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -7,6 +7,10 @@ import pyquil.gates
 from ...circuit import Gate, ControlledGate
 from ..circuit import Circuit
 from ...circuit.gates import X, Y, Z, RX, RY, RZ, PHASE, T, I, H, Dagger, CZ, CNOT, CPHASE, SWAP, CustomGate
+from .symbolic.sympy_expressions import expression_from_sympy
+from .symbolic.translations import translate_expression
+from .symbolic.pyquil_expressions import QUIL_DIALECT
+
 
 SINGLE_QUBIT_NONPARAMETRIC_GATES = {
     X: pyquil.gates.X,
@@ -35,8 +39,6 @@ def convert_to_pyquil(obj, program: Optional[pyquil.Program] = None):
 
 @convert_to_pyquil.register
 def convert_gate_to_pyquil(gate: Gate, program: Optional[pyquil.Program] = None) -> pyquil.gates.Gate:
-    if gate.symbolic_params:
-        raise NotImplementedError(f"Cannot convert gate with symbolic params to PyQuil object.")
     return _convert_gate_to_pyquil(gate, program)
 
 
@@ -66,7 +68,10 @@ def convert_single_qubit_rotation_gate_to_pyquil(
     gate: Union[RX, RY, RZ, PHASE],
     _program: Optional[pyquil.Program] = None
 ) -> pyquil.gates.Gate:
-    return ROTATION_GATES[type(gate)](gate.angle, gate.qubit)
+    return ROTATION_GATES[type(gate)](
+        translate_expression(expression_from_sympy(gate.angle), QUIL_DIALECT),
+        gate.qubit
+    )
 
 
 @_convert_gate_to_pyquil.register(CNOT)

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -6,7 +6,24 @@ import pyquil
 import pyquil.gates
 from ...circuit import Gate, ControlledGate
 from ..circuit import Circuit
-from ...circuit.gates import X, Y, Z, RX, RY, RZ, PHASE, T, I, H, Dagger, CZ, CNOT, CPHASE, SWAP, CustomGate
+from ...circuit.gates import (
+    X,
+    Y,
+    Z,
+    RX,
+    RY,
+    RZ,
+    PHASE,
+    T,
+    I,
+    H,
+    Dagger,
+    CZ,
+    CNOT,
+    CPHASE,
+    SWAP,
+    CustomGate,
+)
 from .symbolic.sympy_expressions import expression_from_sympy
 from .symbolic.translations import translate_expression
 from .symbolic.pyquil_expressions import QUIL_DIALECT
@@ -18,17 +35,22 @@ SINGLE_QUBIT_NONPARAMETRIC_GATES = {
     Z: pyquil.gates.Z,
     I: pyquil.gates.I,
     T: pyquil.gates.T,
-    H: pyquil.gates.H
+    H: pyquil.gates.H,
 }
 
 
 ROTATION_GATES = {
-    RX: pyquil.gates.RX, RY: pyquil.gates.RY, RZ: pyquil.gates.RZ, PHASE: pyquil.gates.PHASE
+    RX: pyquil.gates.RX,
+    RY: pyquil.gates.RY,
+    RZ: pyquil.gates.RZ,
+    PHASE: pyquil.gates.PHASE,
 }
 
 
 TWO_QUBIT_CONTROLLED_GATES = {
-    CZ: pyquil.gates.CZ, CNOT: pyquil.gates.CNOT, SWAP: pyquil.gates.SWAP
+    CZ: pyquil.gates.CZ,
+    CNOT: pyquil.gates.CNOT,
+    SWAP: pyquil.gates.SWAP,
 }
 
 
@@ -38,12 +60,16 @@ def convert_to_pyquil(obj, program: Optional[pyquil.Program] = None):
 
 
 @convert_to_pyquil.register
-def convert_gate_to_pyquil(gate: Gate, program: Optional[pyquil.Program] = None) -> pyquil.gates.Gate:
+def convert_gate_to_pyquil(
+    gate: Gate, program: Optional[pyquil.Program] = None
+) -> pyquil.gates.Gate:
     return _convert_gate_to_pyquil(gate, program)
 
 
 @singledispatch
-def _convert_gate_to_pyquil(gate: Gate, _program: Optional[pyquil.Program] = None) -> pyquil.gates.Gate:
+def _convert_gate_to_pyquil(
+    gate: Gate, _program: Optional[pyquil.Program] = None
+) -> pyquil.gates.Gate:
     raise NotImplementedError(f"Cannot convert gate {gate} to PyQUil.")
 
 
@@ -54,8 +80,7 @@ def _convert_gate_to_pyquil(gate: Gate, _program: Optional[pyquil.Program] = Non
 @_convert_gate_to_pyquil.register(T)
 @_convert_gate_to_pyquil.register(H)
 def convert_single_qubit_nonparametric_gate_to_pyquil(
-    gate: Union[X, Y, Z],
-    _program: Optional[pyquil.Program] = None
+    gate: Union[X, Y, Z], _program: Optional[pyquil.Program] = None
 ) -> pyquil.gates.Gate:
     return SINGLE_QUBIT_NONPARAMETRIC_GATES[type(gate)](gate.qubit)
 
@@ -65,12 +90,11 @@ def convert_single_qubit_nonparametric_gate_to_pyquil(
 @_convert_gate_to_pyquil.register(RZ)
 @_convert_gate_to_pyquil.register(PHASE)
 def convert_single_qubit_rotation_gate_to_pyquil(
-    gate: Union[RX, RY, RZ, PHASE],
-    _program: Optional[pyquil.Program] = None
+    gate: Union[RX, RY, RZ, PHASE], _program: Optional[pyquil.Program] = None
 ) -> pyquil.gates.Gate:
     return ROTATION_GATES[type(gate)](
         translate_expression(expression_from_sympy(gate.angle), QUIL_DIALECT),
-        gate.qubit
+        gate.qubit,
     )
 
 
@@ -78,34 +102,43 @@ def convert_single_qubit_rotation_gate_to_pyquil(
 @_convert_gate_to_pyquil.register(CZ)
 @_convert_gate_to_pyquil.register(SWAP)
 def convert_two_qubit_nonparametric_gate_to_pyquil(
-    gate: Union[CZ],
-    _program: Optional[pyquil.Program] = None
+    gate: Union[CZ], _program: Optional[pyquil.Program] = None
 ) -> pyquil.gates.Gate:
     return TWO_QUBIT_CONTROLLED_GATES[type(gate)](*gate.qubits)
 
 
 @_convert_gate_to_pyquil.register(CPHASE)
-def convert_CPHASE_to_pyquil(gate: CPHASE, _program: Optional[pyquil.Program]) -> pyquil.gates.Gate:
+def convert_CPHASE_to_pyquil(
+    gate: CPHASE, _program: Optional[pyquil.Program]
+) -> pyquil.gates.Gate:
     return pyquil.gates.CPHASE(gate.angle, *gate.qubits)
 
 
 @_convert_gate_to_pyquil.register(SWAP)
-def convert_SWAP_gate_to_pyquil(gate: SWAP, _program: Optional[pyquil.Program]) -> pyquil.gates.Gate:
+def convert_SWAP_gate_to_pyquil(
+    gate: SWAP, _program: Optional[pyquil.Program]
+) -> pyquil.gates.Gate:
     return pyquil.gates.SWAP(*gate.qubits)
 
 
 @_convert_gate_to_pyquil.register(ControlledGate)
-def convert_controlled_gate_to_pyquil(gate: ControlledGate, _program: Optional[pyquil.Program]) -> pyquil.gates.Gate:
+def convert_controlled_gate_to_pyquil(
+    gate: ControlledGate, _program: Optional[pyquil.Program]
+) -> pyquil.gates.Gate:
     return convert_to_pyquil(gate.target_gate, _program).controlled(gate.control)
 
 
 @_convert_gate_to_pyquil.register(Dagger)
-def convert_dagger_to_pyquil(gate: Dagger, _program: Optional[pyquil.Program]) -> pyquil.gates.Gate:
+def convert_dagger_to_pyquil(
+    gate: Dagger, _program: Optional[pyquil.Program]
+) -> pyquil.gates.Gate:
     return convert_to_pyquil(gate.gate, _program).dagger()
 
 
 @_convert_gate_to_pyquil.register(CustomGate)
-def convert_custom_gate_to_pyquil(gate: CustomGate, program: Optional[pyquil.Program]) -> pyquil.gates.Gate:
+def convert_custom_gate_to_pyquil(
+    gate: CustomGate, program: Optional[pyquil.Program]
+) -> pyquil.gates.Gate:
     gate_definition = None
 
     for definition in program.defined_gates:
@@ -114,14 +147,18 @@ def convert_custom_gate_to_pyquil(gate: CustomGate, program: Optional[pyquil.Pro
             break
 
     if gate_definition is None:
-        gate_definition = pyquil.quil.DefGate(gate.name, np.array(gate.matrix.tolist(), dtype=complex))
+        gate_definition = pyquil.quil.DefGate(
+            gate.name, np.array(gate.matrix.tolist(), dtype=complex)
+        )
         program += gate_definition
 
     return gate_definition.get_constructor()(*gate.qubits)
 
 
 @convert_to_pyquil.register(Circuit)
-def convert_circuit_to_pyquil(circuit: Circuit, _program: Optional[pyquil.Program] = None) -> pyquil.Program:
+def convert_circuit_to_pyquil(
+    circuit: Circuit, _program: Optional[pyquil.Program] = None
+) -> pyquil.Program:
     program = pyquil.Program()
     for gate in circuit.gates:
         program += convert_to_pyquil(gate, program)

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -150,8 +150,20 @@ def convert_custom_gate_to_pyquil(
             break
 
     if gate_definition is None:
+        converted_matrix = [
+            [
+                translate_expression(expression_from_sympy(element), QUIL_DIALECT)
+                for element in row
+            ]
+            for row in gate.matrix.tolist()
+        ]
         gate_definition = pyquil.quil.DefGate(
-            gate.name, np.array(gate.matrix.tolist(), dtype=complex)
+            gate.name,
+            np.array(converted_matrix),
+            [
+                translate_expression(expression_from_sympy(param), QUIL_DIALECT)
+                for param in gate.symbolic_params
+            ]
         )
         program += gate_definition
 

--- a/src/python/zquantum/core/circuit/conversions/symbolic/pyquil_expressions.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/pyquil_expressions.py
@@ -1,8 +1,23 @@
 """Utilities related to Quil based symbolic expressions."""
+from functools import singledispatch
 import operator
+from numbers import Number
 import pyquil
 from pyquil import quilatom
 from .expressions import ExpressionDialect
+
+
+@singledispatch
+def expression_from_pyquil(expression):
+    raise NotImplementedError(
+        f"Expression {expression} of type {type(expression)} is currently not supported"
+    )
+
+
+@expression_from_pyquil.register
+def identity(number: Number):
+    return number
+
 
 # Dialect defining conversion of intermediate expression tree to
 # the expression based on quil functions/parameters.

--- a/src/python/zquantum/core/circuit/conversions/symbolic/pyquil_expressions.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/pyquil_expressions.py
@@ -4,7 +4,7 @@ import operator
 from numbers import Number
 import pyquil
 from pyquil import quilatom
-from .expressions import ExpressionDialect, Symbol
+from .expressions import ExpressionDialect, Symbol, FunctionCall
 
 
 @singledispatch
@@ -22,6 +22,14 @@ def identity(number: Number):
 @expression_from_pyquil.register
 def symbol_from_quil_parameter(parameter: pyquil.quil.Parameter):
     return Symbol(parameter.name)
+
+
+@expression_from_pyquil.register
+def function_call_from_pyquil_function(function: pyquil.quilatom.Function):
+    return FunctionCall(
+        function.name.lower(),
+        (expression_from_pyquil(function.expression),)
+    )
 
 
 # Dialect defining conversion of intermediate expression tree to

--- a/src/python/zquantum/core/circuit/conversions/symbolic/pyquil_expressions.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/pyquil_expressions.py
@@ -7,6 +7,15 @@ from pyquil import quilatom
 from .expressions import ExpressionDialect, Symbol, FunctionCall
 
 
+QUIL_BINARY_EXPRESSION_NAMES = {
+    quilatom.Add: "add",
+    quilatom.Sub: "sub",
+    quilatom.Mul: "mul",
+    quilatom.Div: "div",
+    quilatom.Pow: "pow"
+}
+
+
 @singledispatch
 def expression_from_pyquil(expression):
     raise NotImplementedError(
@@ -29,6 +38,21 @@ def function_call_from_pyquil_function(function: pyquil.quilatom.Function):
     return FunctionCall(
         function.name.lower(),
         (expression_from_pyquil(function.expression),)
+    )
+
+
+@expression_from_pyquil.register(quilatom.Add)
+@expression_from_pyquil.register(quilatom.Sub)
+@expression_from_pyquil.register(quilatom.Mul)
+@expression_from_pyquil.register(quilatom.Div)
+@expression_from_pyquil.register(quilatom.Pow)
+def function_call_from_pyquil_binary_expression(expression):
+    return FunctionCall(
+        QUIL_BINARY_EXPRESSION_NAMES[type(expression)],
+        (
+            expression_from_pyquil(expression.op1),
+            expression_from_pyquil(expression.op2)
+        )
     )
 
 

--- a/src/python/zquantum/core/circuit/conversions/symbolic/pyquil_expressions.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/pyquil_expressions.py
@@ -4,7 +4,7 @@ import operator
 from numbers import Number
 import pyquil
 from pyquil import quilatom
-from .expressions import ExpressionDialect
+from .expressions import ExpressionDialect, Symbol
 
 
 @singledispatch
@@ -17,6 +17,11 @@ def expression_from_pyquil(expression):
 @expression_from_pyquil.register
 def identity(number: Number):
     return number
+
+
+@expression_from_pyquil.register
+def symbol_from_quil_parameter(parameter: pyquil.quil.Parameter):
+    return Symbol(parameter.name)
 
 
 # Dialect defining conversion of intermediate expression tree to

--- a/src/python/zquantum/core/circuit/conversions/symbolic/pyquil_expressions_test.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/pyquil_expressions_test.py
@@ -8,7 +8,7 @@ from .pyquil_expressions import expression_from_pyquil
 
 
 @pytest.mark.parametrize("number", [3, 4.0, 1j, 3.0 - 2j])
-def test_native_numbers_are_preserved_when_decomposing_pyquil_expression(number):
+def test_native_numbers_are_preserved(number):
     assert expression_from_pyquil(number) == number
 
 
@@ -16,9 +16,9 @@ def test_native_numbers_are_preserved_when_decomposing_pyquil_expression(number)
     "pyquil_parameter, expected_symbol",
     [
         (quil.Parameter("theta"), Symbol("theta")),
-        (quil.Parameter("x"),  Symbol("x")),
-        (quil.Parameter("x_1"), Symbol("x_1"))
-    ]
+        (quil.Parameter("x"), Symbol("x")),
+        (quil.Parameter("x_1"), Symbol("x_1")),
+    ],
 )
 def test_quil_parameters_are_converted_to_instance_of_symbol_with_correct_name(
     pyquil_parameter, expected_symbol
@@ -29,11 +29,14 @@ def test_quil_parameters_are_converted_to_instance_of_symbol_with_correct_name(
 @pytest.mark.parametrize(
     "pyquil_function_call, expected_function_call",
     [
-        (quilatom.quil_cos(2), FunctionCall("cos",(2,))),
-        (quilatom.quil_sin(quil.Parameter("theta")), FunctionCall("sin", (Symbol("theta"),))),
+        (quilatom.quil_cos(2), FunctionCall("cos", (2,))),
+        (
+            quilatom.quil_sin(quil.Parameter("theta")),
+            FunctionCall("sin", (Symbol("theta"),)),
+        ),
         (quilatom.quil_exp(quil.Parameter("x")), FunctionCall("exp", (Symbol("x"),))),
-        (quilatom.quil_sqrt(np.pi), FunctionCall("sqrt", (np.pi,)))
-    ]
+        (quilatom.quil_sqrt(np.pi), FunctionCall("sqrt", (np.pi,))),
+    ],
 )
 def test_pyquil_function_calls_are_converted_to_equivalent_function_call(
     pyquil_function_call, expected_function_call
@@ -46,22 +49,24 @@ def test_pyquil_function_calls_are_converted_to_equivalent_function_call(
     [
         (
             quil.Parameter("x") + quil.Parameter("y"),
-            FunctionCall("add", (Symbol("x"), Symbol("y")))
+            FunctionCall("add", (Symbol("x"), Symbol("y"))),
         ),
         (
             quilatom.quil_cos(quil.Parameter("theta")) * 2,
-            FunctionCall("mul", (FunctionCall("cos", (Symbol("theta"),)), 2))
+            FunctionCall("mul", (FunctionCall("cos", (Symbol("theta"),)), 2)),
         ),
         (
             quilatom.quil_sqrt(quil.Parameter("phi")) / quil.Parameter("psi"),
-            FunctionCall("div", (FunctionCall("sqrt", (Symbol("phi"),)), Symbol("psi")))
+            FunctionCall(
+                "div", (FunctionCall("sqrt", (Symbol("phi"),)), Symbol("psi"))
+            ),
         ),
         (
             quil.Parameter("a") - quil.Parameter("b"),
-            FunctionCall("sub", (Symbol("a"), Symbol("b")))
+            FunctionCall("sub", (Symbol("a"), Symbol("b"))),
         ),
-        (2 ** quil.Parameter("N"), FunctionCall("pow", (2, Symbol("N"))))
-    ]
+        (2 ** quil.Parameter("N"), FunctionCall("pow", (2, Symbol("N")))),
+    ],
 )
 def test_pyquil_binary_expressions_are_converted_to_appropriate_function_call(
     pyquil_expression, expected_function_call

--- a/src/python/zquantum/core/circuit/conversions/symbolic/pyquil_expressions_test.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/pyquil_expressions_test.py
@@ -1,0 +1,8 @@
+"""Test cases for decomposing PyQuil expression into our native expressions."""
+import pytest
+from .pyquil_expressions import expression_from_pyquil
+
+
+@pytest.mark.parametrize("number", [3, 4.0, 1j, 3.0 - 2j])
+def test_native_numbers_are_preserved_when_decomposing_pyquil_expression(number):
+    assert expression_from_pyquil(number) == number

--- a/src/python/zquantum/core/circuit/conversions/symbolic/pyquil_expressions_test.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/pyquil_expressions_test.py
@@ -1,8 +1,24 @@
 """Test cases for decomposing PyQuil expression into our native expressions."""
+from pyquil import quil, quilatom
 import pytest
+from .expressions import Symbol
 from .pyquil_expressions import expression_from_pyquil
 
 
 @pytest.mark.parametrize("number", [3, 4.0, 1j, 3.0 - 2j])
 def test_native_numbers_are_preserved_when_decomposing_pyquil_expression(number):
     assert expression_from_pyquil(number) == number
+
+
+@pytest.mark.parametrize(
+    "pyquil_parameter, expected_symbol",
+    [
+        (quil.Parameter("theta"), Symbol("theta")),
+        (quil.Parameter("x"),  Symbol("x")),
+        (quil.Parameter("x_1"), Symbol("x_1"))
+    ]
+)
+def test_quil_parameters_are_converted_to_instance_of_symbol_with_correct_name(
+    pyquil_parameter, expected_symbol
+):
+    assert expression_from_pyquil(pyquil_parameter) == expected_symbol

--- a/src/python/zquantum/core/circuit/conversions/symbolic/pyquil_expressions_test.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/pyquil_expressions_test.py
@@ -39,3 +39,31 @@ def test_pyquil_function_calls_are_converted_to_equivalent_function_call(
     pyquil_function_call, expected_function_call
 ):
     assert expression_from_pyquil(pyquil_function_call) == expected_function_call
+
+
+@pytest.mark.parametrize(
+    "pyquil_expression, expected_function_call",
+    [
+        (
+            quil.Parameter("x") + quil.Parameter("y"),
+            FunctionCall("add", (Symbol("x"), Symbol("y")))
+        ),
+        (
+            quilatom.quil_cos(quil.Parameter("theta")) * 2,
+            FunctionCall("mul", (FunctionCall("cos", (Symbol("theta"),)), 2))
+        ),
+        (
+            quilatom.quil_sqrt(quil.Parameter("phi")) / quil.Parameter("psi"),
+            FunctionCall("div", (FunctionCall("sqrt", (Symbol("phi"),)), Symbol("psi")))
+        ),
+        (
+            quil.Parameter("a") - quil.Parameter("b"),
+            FunctionCall("sub", (Symbol("a"), Symbol("b")))
+        ),
+        (2 ** quil.Parameter("N"), FunctionCall("pow", (2, Symbol("N"))))
+    ]
+)
+def test_pyquil_binary_expressions_are_converted_to_appropriate_function_call(
+    pyquil_expression, expected_function_call
+):
+    assert expression_from_pyquil(pyquil_expression) == expected_function_call

--- a/src/python/zquantum/core/circuit/conversions/symbolic/pyquil_expressions_test.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/pyquil_expressions_test.py
@@ -1,7 +1,9 @@
 """Test cases for decomposing PyQuil expression into our native expressions."""
+import numpy as np
 from pyquil import quil, quilatom
 import pytest
-from .expressions import Symbol
+from .expressions import Symbol, FunctionCall
+
 from .pyquil_expressions import expression_from_pyquil
 
 
@@ -22,3 +24,18 @@ def test_quil_parameters_are_converted_to_instance_of_symbol_with_correct_name(
     pyquil_parameter, expected_symbol
 ):
     assert expression_from_pyquil(pyquil_parameter) == expected_symbol
+
+
+@pytest.mark.parametrize(
+    "pyquil_function_call, expected_function_call",
+    [
+        (quilatom.quil_cos(2), FunctionCall("cos",(2,))),
+        (quilatom.quil_sin(quil.Parameter("theta")), FunctionCall("sin", (Symbol("theta"),))),
+        (quilatom.quil_exp(quil.Parameter("x")), FunctionCall("exp", (Symbol("x"),))),
+        (quilatom.quil_sqrt(np.pi), FunctionCall("sqrt", (np.pi,)))
+    ]
+)
+def test_pyquil_function_calls_are_converted_to_equivalent_function_call(
+    pyquil_function_call, expected_function_call
+):
+    assert expression_from_pyquil(pyquil_function_call) == expected_function_call

--- a/src/python/zquantum/core/circuit/conversions/symbolic/sympy_expressions.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/sympy_expressions.py
@@ -1,5 +1,7 @@
 """Utilities for converting sympy expressions to our native Expression format."""
 from functools import singledispatch
+from numbers import Number
+
 import sympy
 from .expressions import Symbol, FunctionCall
 
@@ -21,6 +23,11 @@ def expression_from_sympy(expression):
     raise NotImplementedError(
         f"Expression {expression} of type {type(expression)} is currentlyl not supported"
     )
+
+
+@expression_from_sympy.register
+def identity(number: Number):
+    return number
 
 
 @expression_from_sympy.register

--- a/src/python/zquantum/core/circuit/conversions/symbolic/sympy_expressions.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/sympy_expressions.py
@@ -1,9 +1,10 @@
 """Utilities for converting sympy expressions to our native Expression format."""
+import operator
 from functools import singledispatch
 from numbers import Number
 
 import sympy
-from .expressions import Symbol, FunctionCall
+from .expressions import Symbol, FunctionCall, ExpressionDialect
 
 
 def is_multiplication_by_reciprocal(sympy_mul: sympy.Mul) -> bool:
@@ -100,3 +101,24 @@ def function_call_from_sympy_function(function: sympy.Function):
 @expression_from_sympy.register
 def expression_tuple_from_tuple_of_sympy_args(args: tuple):
     return tuple(expression_from_sympy(arg) for arg in args)
+
+
+# Dialect defining conversion of intermediate expression tree to
+# the expression based on Sympy functions/Symbols
+# This is intended to be passed by a `dialect` argument of `translate_expression`.
+SYMPY_DIALECT = ExpressionDialect(
+    symbol_factory=sympy.Symbol,
+    number_factory=lambda number: number,
+    known_functions={
+        "add": operator.add,
+        "mul": operator.mul,
+        "div": operator.truediv,
+        "sub": operator.sub,
+        "pow": operator.pow,
+        "cos": sympy.cos,
+        "sin": sympy.sin,
+        "exp": sympy.exp,
+        "sqrt": sympy.sqrt,
+        "tan": sympy.tan,
+    },
+)

--- a/src/python/zquantum/core/circuit/conversions/symbolic/sympy_expressions.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/sympy_expressions.py
@@ -21,7 +21,7 @@ def is_addition_of_negation(sympy_add: sympy.Add) -> bool:
 @singledispatch
 def expression_from_sympy(expression):
     raise NotImplementedError(
-        f"Expression {expression} of type {type(expression)} is currentlyl not supported"
+        f"Expression {expression} of type {type(expression)} is currently not supported"
     )
 
 

--- a/src/python/zquantum/core/circuit/conversions/symbolic/sympy_expressions.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/sympy_expressions.py
@@ -107,7 +107,7 @@ def expression_tuple_from_tuple_of_sympy_args(args: tuple):
 # the expression based on Sympy functions/Symbols
 # This is intended to be passed by a `dialect` argument of `translate_expression`.
 SYMPY_DIALECT = ExpressionDialect(
-    symbol_factory=sympy.Symbol,
+    symbol_factory=lambda symbol: sympy.Symbol(symbol.name),
     number_factory=lambda number: number,
     known_functions={
         "add": operator.add,

--- a/src/python/zquantum/core/circuit/conversions/symbolic/sympy_expressions_test.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/sympy_expressions_test.py
@@ -10,6 +10,10 @@ from .sympy_expressions import (
 
 
 class TestBuildingTreeFromSympyExpression:
+    @pytest.mark.parametrize("number", [3, 4.0, 1j, 3.0 - 2j])
+    def test_native_numbers_are_preserved(self, number):
+        assert expression_from_sympy(number) == number
+
     @pytest.mark.parametrize(
         "sympy_symbol, expected_symbol",
         [

--- a/src/python/zquantum/core/circuit/conversions/symbolic/sympy_expressions_test.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/sympy_expressions_test.py
@@ -9,221 +9,230 @@ from .sympy_expressions import (
 )
 
 
-class TestBuildingTreeFromSympyExpression:
-    @pytest.mark.parametrize("number", [3, 4.0, 1j, 3.0 - 2j])
-    def test_native_numbers_are_preserved(self, number):
-        assert expression_from_sympy(number) == number
+@pytest.mark.parametrize("number", [3, 4.0, 1j, 3.0 - 2j])
+def test_native_numbers_are_preserved(number):
+    assert expression_from_sympy(number) == number
 
-    @pytest.mark.parametrize(
-        "sympy_symbol, expected_symbol",
-        [
-            (sympy.Symbol("theta"), Symbol("theta")),
-            (sympy.Symbol("x"), Symbol("x")),
-            (sympy.Symbol("c_i"), Symbol("c_i")),
-        ],
-    )
-    def test_symbols_are_converted_to_instance_of_symbol_class(
-        self, sympy_symbol, expected_symbol
-    ):
-        assert expression_from_sympy(sympy_symbol) == expected_symbol
 
-    @pytest.mark.parametrize(
-        "sympy_number, expected_number, expected_class",
-        [
-            (sympy.sympify(2), 2, int),
-            (sympy.sympify(-2.5), -2.5, float),
-            (sympy.Rational(3, 8), 0.375, float),
-        ],
-    )
-    def test_sympy_numbers_are_converted_to_corresponding_native_number(
-        self, sympy_number, expected_number, expected_class
-    ):
-        native_number = expression_from_sympy(sympy_number)
-        assert native_number == expected_number
-        assert isinstance(native_number, expected_class)
+@pytest.mark.parametrize(
+    "sympy_symbol, expected_symbol",
+    [
+        (sympy.Symbol("theta"), Symbol("theta")),
+        (sympy.Symbol("x"), Symbol("x")),
+        (sympy.Symbol("c_i"), Symbol("c_i")),
+    ],
+)
+def test_symbols_are_converted_to_instance_of_symbol_class(
+    sympy_symbol, expected_symbol
+):
+    assert expression_from_sympy(sympy_symbol) == expected_symbol
 
-    def test_imaginary_unit_is_converted_to_1j(self):
-        assert expression_from_sympy(sympy.I) == 1j
 
-    # In below methods we explicitly construct Add and Mul objects
-    # because arithmetic operations on sympy expressions may perform
-    # additional evaluation which may circumvent our expectations.
-    @pytest.mark.parametrize(
-        "sympy_add, expected_args",
-        [
-            (sympy.Add(1, 2, 3, evaluate=False), (1, 2, 3)),
-            (sympy.Add(sympy.Symbol("x"), 1, evaluate=False), (Symbol("x"), 1)),
-            (
-                sympy.Add(
-                    sympy.Symbol("x"),
-                    sympy.Symbol("y"),
-                    sympy.Symbol("z"),
-                    evaluate=False,
-                ),
-                (Symbol("x"), Symbol("y"), Symbol("z")),
+@pytest.mark.parametrize(
+    "sympy_number, expected_number, expected_class",
+    [
+        (sympy.sympify(2), 2, int),
+        (sympy.sympify(-2.5), -2.5, float),
+        (sympy.Rational(3, 8), 0.375, float),
+    ],
+)
+def test_sympy_numbers_are_converted_to_corresponding_native_number(
+    sympy_number, expected_number, expected_class
+):
+    native_number = expression_from_sympy(sympy_number)
+    assert native_number == expected_number
+    assert isinstance(native_number, expected_class)
+
+
+def test_imaginary_unit_is_converted_to_1j():
+    assert expression_from_sympy(sympy.I) == 1j
+
+
+# In below functions we explicitly construct Add and Mul objects
+# because arithmetic operations on sympy expressions may perform
+# additional evaluation which may circumvent our expectations.
+@pytest.mark.parametrize(
+    "sympy_add, expected_args",
+    [
+        (sympy.Add(1, 2, 3, evaluate=False), (1, 2, 3)),
+        (sympy.Add(sympy.Symbol("x"), 1, evaluate=False), (Symbol("x"), 1)),
+        (
+            sympy.Add(
+                sympy.Symbol("x"),
+                sympy.Symbol("y"),
+                sympy.Symbol("z"),
+                evaluate=False,
             ),
-        ],
-    )
-    def test_sympy_add_is_converted_to_function_call_with_add_operation(
-        self, sympy_add, expected_args
-    ):
-        assert expression_from_sympy(sympy_add) == FunctionCall("add", expected_args)
+            (Symbol("x"), Symbol("y"), Symbol("z")),
+        ),
+    ],
+)
+def test_sympy_add_is_converted_to_function_call_with_add_operation(
+    sympy_add, expected_args
+):
+    assert expression_from_sympy(sympy_add) == FunctionCall("add", expected_args)
 
-    @pytest.mark.parametrize(
-        "sympy_mul, expected_args",
-        [
-            (sympy.Mul(4, 2, 3, evaluate=False), (4, 2, 3)),
-            (sympy.Mul(sympy.Symbol("x"), 2, evaluate=False), (Symbol("x"), 2)),
-            (
-                sympy.Mul(
-                    sympy.Symbol("x"),
-                    sympy.Symbol("y"),
-                    sympy.Symbol("z"),
-                    evaluate=False,
-                ),
-                (Symbol("x"), Symbol("y"), Symbol("z")),
+
+@pytest.mark.parametrize(
+    "sympy_mul, expected_args",
+    [
+        (sympy.Mul(4, 2, 3, evaluate=False), (4, 2, 3)),
+        (sympy.Mul(sympy.Symbol("x"), 2, evaluate=False), (Symbol("x"), 2)),
+        (
+            sympy.Mul(
+                sympy.Symbol("x"),
+                sympy.Symbol("y"),
+                sympy.Symbol("z"),
+                evaluate=False,
             ),
-        ],
-    )
-    def test_sympy_mul_is_converted_to_function_call_with_mul_operation(
-        self, sympy_mul, expected_args
-    ):
-        assert expression_from_sympy(sympy_mul) == FunctionCall("mul", expected_args)
+            (Symbol("x"), Symbol("y"), Symbol("z")),
+        ),
+    ],
+)
+def test_sympy_mul_is_converted_to_function_call_with_mul_operation(
+    sympy_mul, expected_args
+):
+    assert expression_from_sympy(sympy_mul) == FunctionCall("mul", expected_args)
 
-    @pytest.mark.parametrize(
-        "sympy_multiplication",
-        [
-            sympy.Symbol("x") / sympy.Symbol("y"),
-            sympy.Symbol("x") / (sympy.Symbol("z") + 1),
-        ],
-    )
-    def test_mul_resulting_from_division_is_classified_as_multiplication_by_reciprocal(
-        self, sympy_multiplication
-    ):
-        assert is_multiplication_by_reciprocal(sympy_multiplication)
 
-    @pytest.mark.parametrize(
-        "sympy_multiplication",
-        [
-            sympy.Symbol("x") * sympy.Symbol("y"),
-            2 * sympy.Symbol("theta"),
-            sympy.Symbol("x") * sympy.Symbol("y") * sympy.Symbol("z"),
-        ],
-    )
-    def test_mul_not_resulting_from_division_is_not_classified_as_multiplication_by_reciprocal(
-        self, sympy_multiplication
-    ):
-        # Note: obviously you can manually construct multiplication that would
-        # be classified as multiplication by reciprocal. The bottom line of this
-        # test is: usual, simple multiplications are multiplications, not divisions.
-        assert not is_multiplication_by_reciprocal(sympy_multiplication)
+@pytest.mark.parametrize(
+    "sympy_multiplication",
+    [
+        sympy.Symbol("x") / sympy.Symbol("y"),
+        sympy.Symbol("x") / (sympy.Symbol("z") + 1),
+    ],
+)
+def test_mul_resulting_from_division_is_classified_as_multiplication_by_reciprocal(
+    sympy_multiplication,
+):
+    assert is_multiplication_by_reciprocal(sympy_multiplication)
 
-    @pytest.mark.parametrize(
-        "sympy_multiplication, expected_args",
-        [
-            (sympy.Symbol("x") / sympy.Symbol("y"), (Symbol("x"), Symbol("y"))),
-            (
-                sympy.Symbol("x") / (sympy.Add(sympy.Symbol("z"), 1, evaluate=False)),
-                (Symbol("x"), FunctionCall("add", (Symbol("z"), 1))),
+
+@pytest.mark.parametrize(
+    "sympy_multiplication",
+    [
+        sympy.Symbol("x") * sympy.Symbol("y"),
+        2 * sympy.Symbol("theta"),
+        sympy.Symbol("x") * sympy.Symbol("y") * sympy.Symbol("z"),
+    ],
+)
+def test_mul_not_resulting_from_division_is_not_classified_as_multiplication_by_reciprocal(
+    sympy_multiplication,
+):
+    # Note: obviously you can manually construct multiplication that would
+    # be classified as multiplication by reciprocal. The bottom line of this
+    # test is: usual, simple multiplications are multiplications, not divisions.
+    assert not is_multiplication_by_reciprocal(sympy_multiplication)
+
+
+@pytest.mark.parametrize(
+    "sympy_multiplication, expected_args",
+    [
+        (sympy.Symbol("x") / sympy.Symbol("y"), (Symbol("x"), Symbol("y"))),
+        (
+            sympy.Symbol("x") / (sympy.Add(sympy.Symbol("z"), 1, evaluate=False)),
+            (Symbol("x"), FunctionCall("add", (Symbol("z"), 1))),
+        ),
+    ],
+)
+def test_division_is_converted_into_div_function_call_instead_of_multiplication_by_reciprocal(
+    sympy_multiplication, expected_args
+):
+    # Important note about sympy: there is no Div operator (as opposed to
+    # e.g. Mul). The division on sympy expressions actually produces Mul
+    # objects, in which second operand is a reciprocal of the original one.
+    # We need to deal with this case, otherwise converting anything that
+    # contains division will result in very confusing expressions.
+    assert expression_from_sympy(sympy_multiplication) == FunctionCall(
+        "div", expected_args
+    )
+
+
+@pytest.mark.parametrize(
+    "sympy_addition",
+    [
+        sympy.Symbol("x") - sympy.Symbol("y"),
+        sympy.Symbol("x") - 1 / sympy.Symbol("y"),
+        1 - sympy.Symbol("x")
+        # Note: negation of previous case would fail, since in that case
+        # sympy would make Add(-1, Symbol("x")) out of it, unlike in other
+        # cases where it produces e.g.
+        # Add(Symbol("x", Mul(Symbol("y"), -1))).
+    ],
+)
+def test_add_resulting_from_subtraction_is_classified_as_addition_of_negation(
+    sympy_addition,
+):
+    assert is_addition_of_negation(sympy_addition)
+
+
+@pytest.mark.parametrize(
+    "sympy_addition",
+    [sympy.Symbol("x") + sympy.Symbol("y"), sympy.Symbol("x") + 10],
+)
+def test_add_not_resulting_from_subtraction_is_not_classified_as_addition_of_negation(
+    sympy_addition,
+):
+    assert not is_addition_of_negation(sympy_addition)
+
+
+@pytest.mark.parametrize(
+    "sympy_addition, expected_args",
+    [
+        (sympy.Symbol("x") - sympy.Symbol("y"), (Symbol("x"), Symbol("y"))),
+        (1 - sympy.Symbol("x"), (1, Symbol("x"))),
+    ],
+)
+def test_add_resulting_from_subtraction_is_converted_to_sub_function_call(
+    sympy_addition, expected_args
+):
+    assert expression_from_sympy(sympy_addition) == FunctionCall("sub", expected_args)
+
+
+@pytest.mark.parametrize(
+    "sympy_power, expected_args",
+    [
+        (sympy.Pow(sympy.Symbol("x"), 2), (Symbol("x"), 2)),
+        (sympy.Pow(2, sympy.Symbol("x")), (2, Symbol("x"))),
+        (
+            sympy.Pow(sympy.Symbol("x"), sympy.Symbol("y")),
+            (Symbol("x"), Symbol("y")),
+        ),
+    ],
+)
+def test_sympy_pow_is_converted_to_pow_function_call(sympy_power, expected_args):
+    assert expression_from_sympy(sympy_power) == FunctionCall("pow", expected_args)
+
+
+@pytest.mark.parametrize(
+    "sympy_power, expected_denominator",
+    [
+        (sympy.Pow(sympy.Symbol("x"), -1), Symbol("x")),
+        (
+            sympy.Pow(
+                sympy.Add(sympy.Symbol("x"), sympy.Symbol("y"), evaluate=False), -1
             ),
-        ],
+            FunctionCall("add", (Symbol("x"), Symbol("y"))),
+        ),
+    ],
+)
+def test_sympy_power_with_negative_one_exponent_gets_converted_to_division(
+    sympy_power, expected_denominator
+):
+    assert expression_from_sympy(sympy_power) == FunctionCall(
+        "div", (1, expected_denominator)
     )
-    def test_division_is_converted_into_div_function_call_instead_of_multiplication_by_reciprocal(
-        self, sympy_multiplication, expected_args
-    ):
-        # Important note about sympy: there is no Div operator (as opposed to
-        # e.g. Mul). The division on sympy expressions actually produces Mul
-        # objects, in which second operand is a reciprocal of the original one.
-        # We need to deal with this case, otherwise converting anything that
-        # contains division will result in very confusing expressions.
-        assert expression_from_sympy(sympy_multiplication) == FunctionCall(
-            "div", expected_args
-        )
 
-    @pytest.mark.parametrize(
-        "sympy_addition",
-        [
-            sympy.Symbol("x") - sympy.Symbol("y"),
-            sympy.Symbol("x") - 1 / sympy.Symbol("y"),
-            1 - sympy.Symbol("x")
-            # Note: negation of previous case would fail, since in that case
-            # sympy would make Add(-1, Symbol("x")) out of it, unlike in other
-            # cases where it produces e.g.
-            # Add(Symbol("x", Mul(Symbol("y"), -1))).
-        ],
-    )
-    def test_add_resulting_from_subtraction_is_classified_as_addition_of_negation(
-        self, sympy_addition
-    ):
-        assert is_addition_of_negation(sympy_addition)
 
-    @pytest.mark.parametrize(
-        "sympy_addition",
-        [sympy.Symbol("x") + sympy.Symbol("y"), sympy.Symbol("x") + 10],
-    )
-    def test_add_not_resulting_from_subtraction_is_not_classified_as_addition_of_negation(
-        self, sympy_addition
-    ):
-        assert not is_addition_of_negation(sympy_addition)
-
-    @pytest.mark.parametrize(
-        "sympy_addition, expected_args",
-        [
-            (sympy.Symbol("x") - sympy.Symbol("y"), (Symbol("x"), Symbol("y"))),
-            (1 - sympy.Symbol("x"), (1, Symbol("x"))),
-        ],
-    )
-    def test_add_resulting_from_subtraction_is_converted_to_sub_function_call(
-        self, sympy_addition, expected_args
-    ):
-        assert expression_from_sympy(sympy_addition) == FunctionCall(
-            "sub", expected_args
-        )
-
-    @pytest.mark.parametrize(
-        "sympy_power, expected_args",
-        [
-            (sympy.Pow(sympy.Symbol("x"), 2), (Symbol("x"), 2)),
-            (sympy.Pow(2, sympy.Symbol("x")), (2, Symbol("x"))),
-            (
-                sympy.Pow(sympy.Symbol("x"), sympy.Symbol("y")),
-                (Symbol("x"), Symbol("y")),
-            ),
-        ],
-    )
-    def test_sympy_pow_is_converted_to_pow_function_call(
-        self, sympy_power, expected_args
-    ):
-        assert expression_from_sympy(sympy_power) == FunctionCall("pow", expected_args)
-
-    @pytest.mark.parametrize(
-        "sympy_power, expected_denominator",
-        [
-            (sympy.Pow(sympy.Symbol("x"), -1), Symbol("x")),
-            (
-                sympy.Pow(
-                    sympy.Add(sympy.Symbol("x"), sympy.Symbol("y"), evaluate=False), -1
-                ),
-                FunctionCall("add", (Symbol("x"), Symbol("y"))),
-            ),
-        ],
-    )
-    def test_sympy_power_with_negative_one_exponent_gets_converted_to_division(
-        self, sympy_power, expected_denominator
-    ):
-        assert expression_from_sympy(sympy_power) == FunctionCall(
-            "div", (1, expected_denominator)
-        )
-
-    @pytest.mark.parametrize(
-        "sympy_function_call, expected_function_call",
-        [
-            (sympy.cos(2), FunctionCall("cos", (2,))),
-            (sympy.sin(sympy.Symbol("theta")), FunctionCall("sin", (Symbol("theta"),))),
-            (sympy.exp(sympy.Symbol("x")), FunctionCall("exp", (Symbol("x"),))),
-        ],
-    )
-    def test_sympy_function_calls_are_converted_to_function_call_object_with_appropriate_function_name(
-        self, sympy_function_call, expected_function_call
-    ):
-        assert expression_from_sympy(sympy_function_call) == expected_function_call
+@pytest.mark.parametrize(
+    "sympy_function_call, expected_function_call",
+    [
+        (sympy.cos(2), FunctionCall("cos", (2,))),
+        (sympy.sin(sympy.Symbol("theta")), FunctionCall("sin", (Symbol("theta"),))),
+        (sympy.exp(sympy.Symbol("x")), FunctionCall("exp", (Symbol("x"),))),
+    ],
+)
+def test_sympy_function_calls_are_converted_to_function_call_object_with_appropriate_function_name(
+    sympy_function_call, expected_function_call
+):
+    assert expression_from_sympy(sympy_function_call) == expected_function_call

--- a/src/python/zquantum/core/circuit/conversions/symbolic/translations_test.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/translations_test.py
@@ -79,9 +79,12 @@ def test_translating_tree_from_sympy_to_quil_gives_expected_result(
         (quil.Parameter("theta"), sympy.Symbol("theta")),
         (
             quil.Parameter("theta") * quil.Parameter("gamma"),
-            sympy.Symbol("theta") * sympy.Symbol("gamma")
+            sympy.Symbol("theta") * sympy.Symbol("gamma"),
         ),
-        (quilatom.quil_cos(quil.Parameter("theta")), sympy.cos(sympy.Symbol("theta")), ),
+        (
+            quilatom.quil_cos(quil.Parameter("theta")),
+            sympy.cos(sympy.Symbol("theta")),
+        ),
         (
             quilatom.quil_cos(2 * quil.Parameter("theta")),
             sympy.cos(2 * sympy.Symbol("theta")),
@@ -93,10 +96,7 @@ def test_translating_tree_from_sympy_to_quil_gives_expected_result(
         (
             quilatom.quil_cos(quil.Parameter("phi"))
             + 1j * quilatom.quil_sin(quil.Parameter("phi")),
-            (
-                    sympy.cos(sympy.Symbol("phi")) +
-                    sympy.I * sympy.sin(sympy.Symbol("phi"))
-            )
+            (sympy.cos(sympy.Symbol("phi")) + sympy.I * sympy.sin(sympy.Symbol("phi"))),
         ),
         (
             quil.Parameter("x") + quil.Parameter("y") * (2 + 3j),

--- a/src/python/zquantum/core/circuit/conversions/symbolic/translations_test.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/translations_test.py
@@ -2,9 +2,9 @@
 from pyquil import quil, quilatom
 import sympy
 import pytest
-from .sympy_expressions import expression_from_sympy
+from .sympy_expressions import expression_from_sympy, SYMPY_DIALECT
 from .translations import translate_expression
-from .pyquil_expressions import QUIL_DIALECT
+from .pyquil_expressions import QUIL_DIALECT, expression_from_pyquil
 
 
 @pytest.mark.parametrize(
@@ -71,3 +71,59 @@ def test_translating_tree_from_sympy_to_quil_gives_expected_result(
 ):
     expression = expression_from_sympy(sympy_expression)
     assert translate_expression(expression, QUIL_DIALECT) == quil_expression
+
+
+@pytest.mark.parametrize(
+    "quil_expression, sympy_expression",
+    [
+        (quil.Parameter("theta"), sympy.Symbol("theta")),
+        (
+            quil.Parameter("theta") * quil.Parameter("gamma"),
+            sympy.Symbol("theta") * sympy.Symbol("gamma")
+        ),
+        (quilatom.quil_cos(quil.Parameter("theta")), sympy.cos(sympy.Symbol("theta")), ),
+        (
+            quilatom.quil_cos(2 * quil.Parameter("theta")),
+            sympy.cos(2 * sympy.Symbol("theta")),
+        ),
+        (
+            quilatom.quil_exp(quil.Parameter("x") - quil.Parameter("y")),
+            sympy.exp(sympy.Symbol("x") - sympy.Symbol("y")),
+        ),
+        (
+            quilatom.quil_cos(quil.Parameter("phi"))
+            + 1j * quilatom.quil_sin(quil.Parameter("phi")),
+            (
+                    sympy.cos(sympy.Symbol("phi")) +
+                    sympy.I * sympy.sin(sympy.Symbol("phi"))
+            )
+        ),
+        (
+            quil.Parameter("x") + quil.Parameter("y") * (2 + 3j),
+            sympy.Symbol("x") + sympy.Symbol("y") * (2 + 3j),
+        ),
+        (
+            quilatom.quil_cos(quilatom.quil_sin(quil.Parameter("tau"))),
+            sympy.cos(sympy.sin(sympy.Symbol("tau"))),
+        ),
+        (
+            quil.Parameter("x") / quil.Parameter("y"),
+            sympy.Symbol("x") / sympy.Symbol("y"),
+        ),
+        (2 ** quil.Parameter("x"), 2 ** sympy.Symbol("x")),
+        (
+            quil.Parameter("y") ** quil.Parameter("x"),
+            sympy.Symbol("y") ** sympy.Symbol("x"),
+        ),
+        (quil.Parameter("x") ** 2, sympy.Symbol("x") ** 2),
+        (
+            quilatom.quil_sqrt(quil.Parameter("x") - quil.Parameter("y")),
+            sympy.sqrt(sympy.Symbol("x") - sympy.Symbol("y")),
+        ),
+    ],
+)
+def test_translating_tree_from_sympy_to_quil_gives_expected_result(
+    quil_expression, sympy_expression
+):
+    expression = expression_from_pyquil(quil_expression)
+    assert translate_expression(expression, SYMPY_DIALECT) - sympy_expression == 0


### PR DESCRIPTION
This implements translating PyQuil expressions into Sympy expressions. Included are:

- Single-dispatch function for constructing intermediate tree representation of PyQuil expression.
- SYMPY_DIALECT for use with `translate_expression`

Additionally, the structure of already present translation tests is flattened (the classes were used to group tests together, which is no longer needed because we split the translation module into several smaller ones).