### PR TITLE
175540559 implement conversion from pyquil to orquestra

### DIFF
--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
@@ -458,6 +458,20 @@ def test_converting_gate_with_the_same_name_multiple_times_adds_only_a_single_de
     ]
 
 
+@pytest.mark.parametrize(
+    "gate",
+    [
+        pyquil.gates.Gate("X", (0.5, 0.2), (pyquil.quil.Qubit(0),)),
+        pyquil.gates.Gate("SWAP", (), (pyquil.quil.Qubit(1),))
+    ]
+)
+def test_passing_manually_constructed_gate_with_mismatching_properties_raises_value_error(gate):
+    with pytest.raises(ValueError) as error_info:
+        convert_from_pyquil(gate)
+
+    assert str(gate) in str(error_info.value)
+
+
 def test_converting_circuit_to_pyquil_gives_program_with_the_same_gates():
     # The goal of the program constructed below is to include a diverse range
     # of gates.

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
@@ -237,13 +237,13 @@ class TestSWAPGateConversion:
         self, qubit_indices
     ):
         assert pyquil.gates.SWAP(*qubit_indices) == convert_to_pyquil(
-            SWAP(qubit_indices)
+            SWAP(*qubit_indices)
         )
 
     def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
         self, qubit_indices
     ):
-        assert SWAP(qubit_indices) == convert_from_pyquil(
+        assert SWAP(*qubit_indices) == convert_from_pyquil(
             pyquil.gates.SWAP(*qubit_indices)
         )
 
@@ -285,7 +285,7 @@ class TestCorrectnessOfGateTypeAndMatrix:
             RZ(0, 0.0),
             CNOT(0, 1),
             CZ(2, 12),
-            SWAP((2, 4)),
+            SWAP(2, 4),
             CPHASE(2, 4, np.pi / 4),
         ],
     )
@@ -479,7 +479,7 @@ def test_converting_circuit_to_pyquil_gives_program_with_the_same_gates():
             X(0),
             Y(1).dagger,
             Z(3),
-            ControlledGate(SWAP((0, 2)), 1),
+            ControlledGate(SWAP(0, 2), 1),
             CustomGate(
                 sympy.Matrix(
                     [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, -1j], [0, 0, -1j, 0]]

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
@@ -278,15 +278,25 @@ class TestSWAPGateConversion:
 
 
 @pytest.mark.parametrize("control, target", [(0, 1), (2, 3), (0, 10)])
-@pytest.mark.parametrize("gate_cls", [CZ, CNOT])
-def test_converting_two_qubit_controlled_gate_to_pyquil_preserves_qubit_indices(
-    control, target, gate_cls
-):
-    pyquil_gate = convert_to_pyquil(gate_cls(control, target))
+class TestTwoQubitPredefinedControlledGatesConversion:
 
-    assert len(pyquil_gate.qubits) == 2
-    assert pyquil_gate.qubits[0].index == control
-    assert pyquil_gate.qubits[1].index == target
+    @pytest.mark.parametrize("orquestra_gate_cls", [CZ, CNOT])
+    def test_conversion_from_orquestra_to_qubit_preserves_qubit_indices(
+        self, control, target, orquestra_gate_cls
+    ):
+        pyquil_gate = convert_to_pyquil(orquestra_gate_cls(control, target))
+
+        assert pyquil_gate.qubits == [
+            pyquil.quil.Qubit(control), pyquil.quil.Qubit(target)
+        ]
+
+    @pytest.mark.parametrize("pyquil_gate_func", [pyquil.gates.CZ, pyquil.gates.CNOT])
+    def test_conversion_from_pyquil_to_orquestra_preserves_qubit_indices(
+        self, control, target, pyquil_gate_func
+    ):
+        orquestra_gate = convert_from_pyquil(pyquil_gate_func(control, target))
+
+        assert orquestra_gate.qubits == (control, target)
 
 
 @pytest.mark.parametrize(

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
@@ -6,7 +6,7 @@ import sympy
 from pyquil.simulation.matrices import QUANTUM_GATES
 from ..circuit import Circuit
 from ...circuit.gates import ControlledGate, CustomGate
-from ...circuit.conversions.pyquil_conversions import convert_to_pyquil
+from ...circuit.conversions.pyquil_conversions import convert_to_pyquil, convert_from_pyquil
 from ...circuit.gates import (
     X,
     Y,
@@ -66,15 +66,34 @@ def pyquil_gate_matrix(gate: pyquil.gates.Gate) -> np.ndarray:
         return QUANTUM_GATES[gate.name]
 
 
-@pytest.mark.parametrize("qubit", [0, 1, 5, 13])
-@pytest.mark.parametrize("gate_cls", [X, Y, Z, T, I, H])
-def test_converting_single_qubit_nonparametric_gate_to_pyquil_preserves_qubit_index(
-    qubit, gate_cls
-):
-    pyquil_gate = convert_to_pyquil(gate_cls(qubit))
+@pytest.mark.parametrize("qubit_index", [0, 1, 5, 13])
+class TestSingleQubitNonParametricGatesConversion:
 
-    assert len(pyquil_gate.qubits) == 1
-    assert pyquil_gate.qubits[0].index == qubit
+    @pytest.mark.parametrize("orquestra_gate_cls", [X, Y, Z, T, I, H])
+    def test_conversion_from_orquestra_to_pyquil_preserves_qubit_index(
+        self, qubit_index, orquestra_gate_cls
+    ):
+        pyquil_gate = convert_to_pyquil(orquestra_gate_cls(qubit_index))
+
+        assert pyquil_gate.qubits == [pyquil.quil.Qubit(qubit_index)]
+
+    @pytest.mark.parametrize(
+        "pyquil_gate_func",
+        [
+            pyquil.gates.X,
+            pyquil.gates.Y,
+            pyquil.gates.Z,
+            pyquil.gates.T,
+            pyquil.gates.I,
+            pyquil.gates.H
+        ]
+    )
+    def test_converting_single_qubit_nonparametric_gate_from_pyquil_preserves_qubit_index(
+        self, qubit_index, pyquil_gate_func
+    ):
+        orquestra_gate = convert_from_pyquil(pyquil_gate_func(qubit_index))
+
+        assert orquestra_gate.qubits == (qubit_index,)
 
 
 @pytest.mark.parametrize("qubit", [0, 4, 10, 11])

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
@@ -7,7 +7,10 @@ import sympy
 from pyquil.simulation.matrices import QUANTUM_GATES
 from ..circuit import Circuit
 from ...circuit.gates import ControlledGate, CustomGate
-from ...circuit.conversions.pyquil_conversions import convert_to_pyquil, convert_from_pyquil
+from ...circuit.conversions.pyquil_conversions import (
+    convert_to_pyquil,
+    convert_from_pyquil,
+)
 from ...circuit.gates import (
     X,
     Y,
@@ -77,25 +80,22 @@ def pyquil_gate_matrix(gate: pyquil.gates.Gate) -> np.ndarray:
         (Z, pyquil.gates.Z),
         (T, pyquil.gates.T),
         (I, pyquil.gates.I),
-        (H, pyquil.gates.H)
-    ]
+        (H, pyquil.gates.H),
+    ],
 )
 class TestSingleQubitNonParametricGatesConversion:
-
     def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
         self, qubit_index, orquestra_gate_cls, pyquil_gate_func
     ):
-        assert (
-            convert_to_pyquil(orquestra_gate_cls(qubit_index)) ==
-            pyquil_gate_func(qubit_index)
+        assert convert_to_pyquil(orquestra_gate_cls(qubit_index)) == pyquil_gate_func(
+            qubit_index
         )
 
     def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
         self, qubit_index, orquestra_gate_cls, pyquil_gate_func
     ):
-        assert (
-            convert_from_pyquil(pyquil_gate_func(qubit_index)) ==
-            orquestra_gate_cls(qubit_index)
+        assert convert_from_pyquil(pyquil_gate_func(qubit_index)) == orquestra_gate_cls(
+            qubit_index
         )
 
 
@@ -107,26 +107,24 @@ class TestSingleQubitNonParametricGatesConversion:
         (RX, pyquil.gates.RX),
         (RY, pyquil.gates.RY),
         (RZ, pyquil.gates.RZ),
-        (PHASE, pyquil.gates.PHASE)
-    ]
+        (PHASE, pyquil.gates.PHASE),
+    ],
 )
 class TestSingleQubitRotationGatesConversion:
-
     def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
         self, qubit_index, angle, orquestra_gate_cls, pyquil_gate_func
     ):
-        assert (
-            pyquil_gate_func(angle, qubit_index) ==
-            convert_to_pyquil(orquestra_gate_cls(qubit_index, angle))
+        assert pyquil_gate_func(angle, qubit_index) == convert_to_pyquil(
+            orquestra_gate_cls(qubit_index, angle)
         )
 
     def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
         self, qubit_index, angle, orquestra_gate_cls, pyquil_gate_func
     ):
-        assert (
-            orquestra_gate_cls(qubit_index, angle) ==
-            convert_from_pyquil(pyquil_gate_func(angle, qubit_index))
+        assert orquestra_gate_cls(qubit_index, angle) == convert_from_pyquil(
+            pyquil_gate_func(angle, qubit_index)
         )
+
 
 @pytest.mark.parametrize("qubit_index", [0, 4, 10, 11])
 @pytest.mark.parametrize("orquestra_angle, pyquil_angle", EXAMPLE_PARAMETRIZED_ANGLES)
@@ -136,28 +134,31 @@ class TestSingleQubitRotationGatesConversion:
         (RX, pyquil.gates.RX),
         (RY, pyquil.gates.RY),
         (RZ, pyquil.gates.RZ),
-        (PHASE, pyquil.gates.PHASE)
-    ]
+        (PHASE, pyquil.gates.PHASE),
+    ],
 )
 class TestSingleQubitRotationGatesWithSymbolicParamsConversion:
-
     def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
         self,
         qubit_index,
         orquestra_angle,
         pyquil_angle,
         orquestra_gate_cls,
-        pyquil_gate_func
+        pyquil_gate_func,
     ):
         program = pyquil.Program()
 
-        assert (
-            pyquil_gate_func(pyquil_angle, qubit_index) ==
-            convert_to_pyquil(orquestra_gate_cls(qubit_index, orquestra_angle), program)
+        assert pyquil_gate_func(pyquil_angle, qubit_index) == convert_to_pyquil(
+            orquestra_gate_cls(qubit_index, orquestra_angle), program
         )
 
     def test_translated_angle_expression_from_orquestra_gate_is_added_to_program(
-        self, qubit_index, orquestra_angle, pyquil_angle, orquestra_gate_cls, pyquil_gate_func
+        self,
+        qubit_index,
+        orquestra_angle,
+        pyquil_angle,
+        orquestra_gate_cls,
+        pyquil_gate_func,
     ):
         program = pyquil.Program()
         orquestra_gate = orquestra_gate_cls(qubit_index, orquestra_angle)
@@ -169,48 +170,45 @@ class TestSingleQubitRotationGatesWithSymbolicParamsConversion:
         ]
 
     def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
-        self, qubit_index, orquestra_angle, pyquil_angle, orquestra_gate_cls, pyquil_gate_func
+        self,
+        qubit_index,
+        orquestra_angle,
+        pyquil_angle,
+        orquestra_gate_cls,
+        pyquil_gate_func,
     ):
-        assert (
-            orquestra_gate_cls(qubit_index, orquestra_angle) ==
-            convert_from_pyquil(
-                pyquil_gate_func(pyquil_angle, qubit_index)
-            )
+        assert orquestra_gate_cls(qubit_index, orquestra_angle) == convert_from_pyquil(
+            pyquil_gate_func(pyquil_angle, qubit_index)
         )
 
 
 @pytest.mark.parametrize("qubit_indices", [[0, 1], [2, 10], [4, 7]])
 @pytest.mark.parametrize("angle", [0, np.pi / 4, np.pi / 2, np.pi, 2 * np.pi])
 class TestCPHASEGateConversion:
-
     def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
         self, qubit_indices, angle
     ):
-        assert (
-            pyquil.gates.CPHASE(angle, *qubit_indices) ==
-            convert_to_pyquil(CPHASE(*qubit_indices, angle))
+        assert pyquil.gates.CPHASE(angle, *qubit_indices) == convert_to_pyquil(
+            CPHASE(*qubit_indices, angle)
         )
 
     def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
         self, qubit_indices, angle
     ):
-        assert (
-            CPHASE(*qubit_indices, angle) ==
-            convert_from_pyquil(pyquil.gates.CPHASE(angle, *qubit_indices))
+        assert CPHASE(*qubit_indices, angle) == convert_from_pyquil(
+            pyquil.gates.CPHASE(angle, *qubit_indices)
         )
 
 
 @pytest.mark.parametrize("qubit_indices", [[0, 1], [2, 10], [4, 7]])
 @pytest.mark.parametrize("orquestra_angle, pyquil_angle", EXAMPLE_PARAMETRIZED_ANGLES)
 class TestCPHASEGateWithSymbolicParamsConversion:
-
     def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
         self, qubit_indices, orquestra_angle, pyquil_angle
     ):
         program = pyquil.Program()
-        assert (
-            pyquil.gates.CPHASE(pyquil_angle, *qubit_indices) ==
-            convert_to_pyquil(CPHASE(*qubit_indices, orquestra_angle), program)
+        assert pyquil.gates.CPHASE(pyquil_angle, *qubit_indices) == convert_to_pyquil(
+            CPHASE(*qubit_indices, orquestra_angle), program
         )
 
     def test_translated_angle_from_orquestra_gate_is_added_to_program(
@@ -228,62 +226,50 @@ class TestCPHASEGateWithSymbolicParamsConversion:
     def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
         self, qubit_indices, orquestra_angle, pyquil_angle
     ):
-        assert(
-            CPHASE(*qubit_indices, orquestra_angle) ==
-            convert_from_pyquil(
-                pyquil.gates.CPHASE(pyquil_angle, *qubit_indices)
-            )
+        assert CPHASE(*qubit_indices, orquestra_angle) == convert_from_pyquil(
+            pyquil.gates.CPHASE(pyquil_angle, *qubit_indices)
         )
 
 
 @pytest.mark.parametrize("qubit_indices", [[0, 1], [2, 10], [4, 7]])
 class TestSWAPGateConversion:
-
     def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
         self, qubit_indices
     ):
-        assert (
-            pyquil.gates.SWAP(*qubit_indices) ==
-            convert_to_pyquil(SWAP(qubit_indices))
+        assert pyquil.gates.SWAP(*qubit_indices) == convert_to_pyquil(
+            SWAP(qubit_indices)
         )
 
     def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
         self, qubit_indices
     ):
-        assert (
-            SWAP(qubit_indices) ==
-            convert_from_pyquil(pyquil.gates.SWAP(*qubit_indices))
+        assert SWAP(qubit_indices) == convert_from_pyquil(
+            pyquil.gates.SWAP(*qubit_indices)
         )
 
 
 @pytest.mark.parametrize("control, target", [(0, 1), (2, 3), (0, 10)])
 @pytest.mark.parametrize(
-    "orquestra_gate_cls, pyquil_gate_func", [
-        (CZ, pyquil.gates.CZ),
-        (CNOT, pyquil.gates.CNOT)
-    ]
+    "orquestra_gate_cls, pyquil_gate_func",
+    [(CZ, pyquil.gates.CZ), (CNOT, pyquil.gates.CNOT)],
 )
 class TestTwoQubitPredefinedControlledGatesConversion:
-
     def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
         self, control, target, orquestra_gate_cls, pyquil_gate_func
     ):
-        assert (
-            pyquil_gate_func(control, target) ==
-            convert_to_pyquil(orquestra_gate_cls(control, target))
+        assert pyquil_gate_func(control, target) == convert_to_pyquil(
+            orquestra_gate_cls(control, target)
         )
 
     def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
         self, control, target, orquestra_gate_cls, pyquil_gate_func
     ):
-        assert (
-            orquestra_gate_cls(control, target) ==
-            convert_from_pyquil(pyquil_gate_func(control, target))
+        assert orquestra_gate_cls(control, target) == convert_from_pyquil(
+            pyquil_gate_func(control, target)
         )
 
 
 class TestCorrectnessOfGateTypeAndMatrix:
-
     @pytest.mark.parametrize(
         "gate",
         [
@@ -310,7 +296,8 @@ class TestCorrectnessOfGateTypeAndMatrix:
 
         assert pyquil_gate.name == ORQUESTRA_GATE_TYPE_TO_PYQUIL_NAME[type(gate)]
         assert np.allclose(
-            pyquil_gate_matrix(pyquil_gate), np.array(gate.matrix.tolist(), dtype=complex)
+            pyquil_gate_matrix(pyquil_gate),
+            np.array(gate.matrix.tolist(), dtype=complex),
         )
 
 
@@ -325,9 +312,9 @@ class TestCorrectnessOfGateTypeAndMatrix:
         (X(2), pyquil.gates.X(2), (1,)),
         (Y(1), pyquil.gates.Y(1), (0,)),
         (PHASE(4, np.pi), pyquil.gates.PHASE(np.pi, 4), (1, 2, 3)),
-        (CZ(2, 12), pyquil.gates.CZ(2, 12), (0, 3))
+        (CZ(2, 12), pyquil.gates.CZ(2, 12), (0, 3)),
     ],
-    scope="function"
+    scope="function",
 )
 class TestControlledGateConversion:
     def make_orquestra_controlled_gate(self, gate, control_qubits):
@@ -351,26 +338,23 @@ class TestControlledGateConversion:
     def test_converting_nested_controlled_gate_gives_pyquil_gate_with_applied_controlled_modifiers(
         self, orquestra_gate, pyquil_gate, control_qubits
     ):
-        assert (
-            self.make_pyquil_controlled_gate(pyquil_gate, control_qubits) ==
-            convert_to_pyquil(
-                self.make_orquestra_controlled_gate(orquestra_gate, control_qubits)
-            )
+        assert self.make_pyquil_controlled_gate(
+            pyquil_gate, control_qubits
+        ) == convert_to_pyquil(
+            self.make_orquestra_controlled_gate(orquestra_gate, control_qubits)
         )
 
     def test_converting_pyquil_gate_with_controlled_modifiers_gives_nested_controlled_gate(
         self, orquestra_gate, pyquil_gate, control_qubits
     ):
-        assert (
-            self.make_orquestra_controlled_gate(orquestra_gate, control_qubits) ==
-            convert_from_pyquil(
-                self.make_pyquil_controlled_gate(pyquil_gate, control_qubits)
-            )
+        assert self.make_orquestra_controlled_gate(
+            orquestra_gate, control_qubits
+        ) == convert_from_pyquil(
+            self.make_pyquil_controlled_gate(pyquil_gate, control_qubits)
         )
 
 
 class TestGatesWithDaggerConversion:
-
     def test_dagger_object_gets_converted_to_gate_with_dagger_modifier(self):
         assert convert_to_pyquil(Dagger(X(1))) == pyquil.gates.X(1).dagger()
 
@@ -380,15 +364,15 @@ class TestGatesWithDaggerConversion:
             pyquil.gates.RX(np.pi / 4, 0),
             pyquil.gates.PHASE(0.5, 2),
             pyquil.gates.RX(0.5, 1).controlled(3),
-        ]
+        ],
     )
     def test_dagger_of_orquestra_gate_is_taken_when_converting_gate_with_dagger_modifier(
         self, pyquil_gate
     ):
         pyquil_dagger = deepcopy(pyquil_gate).dagger()
         assert (
-            convert_from_pyquil(pyquil_dagger) ==
-            convert_from_pyquil(pyquil_gate).dagger
+            convert_from_pyquil(pyquil_dagger)
+            == convert_from_pyquil(pyquil_gate).dagger
         )
 
 

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
@@ -77,166 +77,151 @@ def pyquil_gate_matrix(gate: pyquil.gates.Gate) -> np.ndarray:
 
 
 @pytest.mark.parametrize("qubit_index", [0, 1, 5, 13])
+@pytest.mark.parametrize(
+    "orquestra_gate_cls, pyquil_gate_func",
+    [
+        (X, pyquil.gates.X),
+        (Y, pyquil.gates.Y),
+        (Z, pyquil.gates.Z),
+        (T, pyquil.gates.T),
+        (I, pyquil.gates.I),
+        (H, pyquil.gates.H)
+    ]
+)
 class TestSingleQubitNonParametricGatesConversion:
 
-    @pytest.mark.parametrize("orquestra_gate_cls", [X, Y, Z, T, I, H])
-    def test_conversion_from_orquestra_to_pyquil_preserves_qubit_index(
-        self, qubit_index, orquestra_gate_cls
+    def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
+        self, qubit_index, orquestra_gate_cls, pyquil_gate_func
     ):
-        pyquil_gate = convert_to_pyquil(orquestra_gate_cls(qubit_index))
+        assert (
+            convert_to_pyquil(orquestra_gate_cls(qubit_index)) ==
+            pyquil_gate_func(qubit_index)
+        )
 
-        assert pyquil_gate.qubits == [pyquil.quil.Qubit(qubit_index)]
-
-    @pytest.mark.parametrize(
-        "pyquil_gate_func",
-        [
-            pyquil.gates.X,
-            pyquil.gates.Y,
-            pyquil.gates.Z,
-            pyquil.gates.T,
-            pyquil.gates.I,
-            pyquil.gates.H
-        ]
-    )
-    def test_converting_single_qubit_nonparametric_gate_from_pyquil_preserves_qubit_index(
-        self, qubit_index, pyquil_gate_func
+    def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
+        self, qubit_index, orquestra_gate_cls, pyquil_gate_func
     ):
-        orquestra_gate = convert_from_pyquil(pyquil_gate_func(qubit_index))
-
-        assert orquestra_gate.qubits == (qubit_index,)
+        assert (
+            convert_from_pyquil(pyquil_gate_func(qubit_index)) ==
+            orquestra_gate_cls(qubit_index)
+        )
 
 
 @pytest.mark.parametrize("qubit_index", [0, 4, 10, 11])
 @pytest.mark.parametrize("angle", [np.pi, np.pi / 2, 0.4])
+@pytest.mark.parametrize(
+    "orquestra_gate_cls, pyquil_gate_func",
+    [
+        (RX, pyquil.gates.RX),
+        (RY, pyquil.gates.RY),
+        (RZ, pyquil.gates.RZ),
+        (PHASE, pyquil.gates.PHASE)
+    ]
+)
 class TestSingleQubitRotationGatesConversion:
 
-    @pytest.mark.parametrize("orquestra_gate_cls", [RX, RY, RZ, PHASE])
-    def test_conversion_from_orquestra_to_pyquil_preserves_qubit_index(
-        self, qubit_index, angle, orquestra_gate_cls
+    def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
+        self, qubit_index, angle, orquestra_gate_cls, pyquil_gate_func
     ):
-        pyquil_gate = convert_to_pyquil(orquestra_gate_cls(qubit_index, angle))
+        assert (
+            pyquil_gate_func(angle, qubit_index) ==
+            convert_to_pyquil(orquestra_gate_cls(qubit_index, angle))
+        )
 
-        assert pyquil_gate.qubits == [pyquil.quil.Qubit(qubit_index)]
-
-    @pytest.mark.parametrize(
-        "orquestra_gate_cls", ORQUESTRA_SINGLE_QUBIT_ROTATION_GATES
-    )
-    def test_conversion_from_orquestra_to_pyquil_preserves_angle(
-        self, qubit_index, angle, orquestra_gate_cls
+    def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
+        self, qubit_index, angle, orquestra_gate_cls, pyquil_gate_func
     ):
-        pyquil_gate = convert_to_pyquil(orquestra_gate_cls(qubit_index, angle))
-
-        assert pyquil_gate.params == [angle]
-
-    @pytest.mark.parametrize(
-        "pyquil_gate_func", PYQUIL_SINGLE_QUBIT_ROTATION_GATES
-    )
-    def test_conversion_from_pyquil_to_orquestra_preserves_qubit_index(
-        self, qubit_index, angle, pyquil_gate_func
-    ):
-        orquestra_gate = convert_from_pyquil(pyquil_gate_func(angle, qubit_index))
-
-        assert orquestra_gate.qubits == (qubit_index,)
-
-    @pytest.mark.parametrize(
-        "pyquil_gate_func", PYQUIL_SINGLE_QUBIT_ROTATION_GATES
-    )
-    def test_conversion_from_pyquil_to_orquestra_preserves_angle(
-        self, qubit_index, angle, pyquil_gate_func
-    ):
-        orquestra_gate = convert_from_pyquil(pyquil_gate_func(angle, qubit_index))
-
-        assert orquestra_gate.angle == angle
-
+        assert (
+            orquestra_gate_cls(qubit_index, angle) ==
+            convert_from_pyquil(pyquil_gate_func(angle, qubit_index))
+        )
 
 @pytest.mark.parametrize("qubit_index", [0, 4, 10, 11])
 @pytest.mark.parametrize("orquestra_angle, pyquil_angle", EXAMPLE_PARAMETRIZED_ANGLES)
+@pytest.mark.parametrize(
+    "orquestra_gate_cls, pyquil_gate_func",
+    [
+        (RX, pyquil.gates.RX),
+        (RY, pyquil.gates.RY),
+        (RZ, pyquil.gates.RZ),
+        (PHASE, pyquil.gates.PHASE)
+    ]
+)
 class TestSingleQubitRotationGatesWithSymbolicParamsConversion:
 
-    @pytest.mark.parametrize(
-        "orquestra_gate_cls",
-        ORQUESTRA_SINGLE_QUBIT_ROTATION_GATES
-    )
-    def test_angle_expression_is_translated_when_converting_from_orquestra_to_pyquil(
-        self, qubit_index, orquestra_angle, pyquil_angle, orquestra_gate_cls
+    def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
+        self,
+        qubit_index,
+        orquestra_angle,
+        pyquil_angle,
+        orquestra_gate_cls,
+        pyquil_gate_func
     ):
         program = pyquil.Program()
-        pyquil_gate = convert_to_pyquil(orquestra_gate_cls(qubit_index, orquestra_angle), program)
-        assert pyquil_gate.params == [pyquil_angle]
 
-    @pytest.mark.parametrize(
-        "orquestra_gate_cls",
-        ORQUESTRA_SINGLE_QUBIT_ROTATION_GATES
-    )
-    def test_translated_angle_expression_is_added_to_program(
-        self, qubit_index, orquestra_angle, pyquil_angle, orquestra_gate_cls
+        assert (
+            pyquil_gate_func(pyquil_angle, qubit_index) ==
+            convert_to_pyquil(orquestra_gate_cls(qubit_index, orquestra_angle), program)
+        )
+
+    def test_translated_angle_expression_from_orquestra_gate_is_added_to_program(
+        self, qubit_index, orquestra_angle, pyquil_angle, orquestra_gate_cls, pyquil_gate_func
     ):
         program = pyquil.Program()
-        zquantum_gate = orquestra_gate_cls(qubit_index, orquestra_angle)
-        convert_to_pyquil(zquantum_gate, program)
+        orquestra_gate = orquestra_gate_cls(qubit_index, orquestra_angle)
+        convert_to_pyquil(orquestra_gate, program)
 
         assert program.instructions == [
             pyquil.quil.Declare(str(param), "REAL")
-            for param in zquantum_gate.symbolic_params
+            for param in orquestra_gate.symbolic_params
         ]
 
-    @pytest.mark.parametrize("pyquil_gate_func", PYQUIL_SINGLE_QUBIT_ROTATION_GATES)
-    def test_angle_expression_is_translated_when_converting_from_pyquil_to_orquestra(
-        self, qubit_index, orquestra_angle, pyquil_angle, pyquil_gate_func
+    def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
+        self, qubit_index, orquestra_angle, pyquil_angle, orquestra_gate_cls, pyquil_gate_func
     ):
-        orquestra_gate = convert_from_pyquil(
-            pyquil_gate_func(pyquil_angle, qubit_index)
+        assert (
+            orquestra_gate_cls(qubit_index, orquestra_angle) ==
+            convert_from_pyquil(
+                pyquil_gate_func(pyquil_angle, qubit_index)
+            )
         )
-
-        assert orquestra_gate.angle == orquestra_angle
 
 
 @pytest.mark.parametrize("qubit_indices", [[0, 1], [2, 10], [4, 7]])
 @pytest.mark.parametrize("angle", [0, np.pi / 4, np.pi / 2, np.pi, 2 * np.pi])
 class TestCPHASEGateConversion:
 
-    def test_conversion_from_orquestra_to_pyquil_preserves_qubit_indices(
+    def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
         self, qubit_indices, angle
     ):
-        pyquil_gate = convert_to_pyquil(CPHASE(*qubit_indices, angle))
+        assert (
+            pyquil.gates.CPHASE(angle, *qubit_indices) ==
+            convert_to_pyquil(CPHASE(*qubit_indices, angle))
+        )
 
-        assert pyquil_gate.qubits == [pyquil.quil.Qubit(i) for i in qubit_indices]
-
-    def test_conversion_from_orquestra_to_pyquil_preserves_angle(
+    def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
         self, qubit_indices, angle
     ):
-        pyquil_gate = convert_to_pyquil(CPHASE(*qubit_indices, angle))
-
-        assert pyquil_gate.params == [angle]
-
-    def test_conversion_from_pyquil_to_orquestra_preserves_qubit_indices(
-        self, qubit_indices, angle
-    ):
-        orquestra_gate = convert_from_pyquil(pyquil.gates.CPHASE(angle, *qubit_indices))
-
-        assert orquestra_gate.qubits == tuple(qubit_indices)
-
-    def test_conversion_from_pyquil_to_orquestra_preserves_angle(
-        self, qubit_indices, angle
-    ):
-        orquestra_gate = convert_from_pyquil(pyquil.gates.CPHASE(angle, *qubit_indices))
-
-        assert orquestra_gate.angle == angle
+        assert (
+            CPHASE(*qubit_indices, angle) ==
+            convert_from_pyquil(pyquil.gates.CPHASE(angle, *qubit_indices))
+        )
 
 
 @pytest.mark.parametrize("qubit_indices", [[0, 1], [2, 10], [4, 7]])
 @pytest.mark.parametrize("orquestra_angle, pyquil_angle", EXAMPLE_PARAMETRIZED_ANGLES)
 class TestCPHASEGateWithSymbolicParamsConversion:
 
-    def test_angle_is_translated_when_converting_from_orquestra_to_pyquil(
+    def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
         self, qubit_indices, orquestra_angle, pyquil_angle
     ):
         program = pyquil.Program()
-        pyquil_gate = convert_to_pyquil(CPHASE(*qubit_indices, orquestra_angle), program)
+        assert (
+            pyquil.gates.CPHASE(pyquil_angle, *qubit_indices) ==
+            convert_to_pyquil(CPHASE(*qubit_indices, orquestra_angle), program)
+        )
 
-        assert pyquil_gate.params == [pyquil_angle]
-
-    def test_translated_angle_is_added_to_program(
+    def test_translated_angle_from_orquestra_gate_is_added_to_program(
         self, qubit_indices, orquestra_angle, pyquil_angle
     ):
         program = pyquil.Program()
@@ -248,34 +233,35 @@ class TestCPHASEGateWithSymbolicParamsConversion:
             for param in orquestra_gate.symbolic_params
         ]
 
-    def test_angle_is_translated_when_converting_from_pyquil_to_orquestra(
+    def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
         self, qubit_indices, orquestra_angle, pyquil_angle
     ):
-        orquestra_gate = convert_from_pyquil(
-            pyquil.gates.CPHASE(pyquil_angle, *qubit_indices)
+        assert(
+            CPHASE(*qubit_indices, orquestra_angle) ==
+            convert_from_pyquil(
+                pyquil.gates.CPHASE(pyquil_angle, *qubit_indices)
+            )
         )
-
-        assert orquestra_gate.angle == orquestra_angle
 
 
 @pytest.mark.parametrize("qubit_indices", [[0, 1], [2, 10], [4, 7]])
 class TestSWAPGateConversion:
 
-    def test_conversion_from_pyquil_to_orquestra_preserves_qubit_indices(
+    def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
         self, qubit_indices
     ):
-        pyquil_gate = convert_to_pyquil(SWAP(qubit_indices))
+        assert (
+            pyquil.gates.SWAP(*qubit_indices) ==
+            convert_to_pyquil(SWAP(qubit_indices))
+        )
 
-        assert pyquil_gate.qubits == [
-            pyquil.quil.Qubit(i) for i in qubit_indices
-        ]
-
-    def test_conversion_from_orquestra_to_pyquil_preserves_qubit_indices(
+    def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
         self, qubit_indices
     ):
-        orquestra_gate = convert_from_pyquil(pyquil.gates.SWAP(*qubit_indices))
-
-        assert orquestra_gate.qubits == tuple(qubit_indices)
+        assert (
+            SWAP(qubit_indices) ==
+            convert_from_pyquil(pyquil.gates.SWAP(*qubit_indices))
+        )
 
 
 @pytest.mark.parametrize("control, target", [(0, 1), (2, 3), (0, 10)])

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
@@ -190,54 +190,91 @@ class TestSingleQubitRotationGatesWithSymbolicParamsConversion:
         assert orquestra_gate.angle == orquestra_angle
 
 
-@pytest.mark.parametrize("qubits", [[0, 1], [2, 10], [4, 7]])
+@pytest.mark.parametrize("qubit_indices", [[0, 1], [2, 10], [4, 7]])
 @pytest.mark.parametrize("angle", [0, np.pi / 4, np.pi / 2, np.pi, 2 * np.pi])
-def test_pyquil_gate_created_from_zquantum_cphase_gate_has_the_same_qubits_and_angle_as_the_original_one(
-    qubits, angle
-):
-    program = pyquil.Program()
+class TestCPHASEGateConversion:
 
-    pyquil_gate = convert_to_pyquil(CPHASE(*qubits, angle), program)
+    def test_conversion_from_orquestra_to_pyquil_preserves_qubit_indices(
+        self, qubit_indices, angle
+    ):
+        pyquil_gate = convert_to_pyquil(CPHASE(*qubit_indices, angle))
 
-    assert len(pyquil_gate.qubits) == 2
-    assert pyquil_gate.qubits[0].index == qubits[0]
-    assert pyquil_gate.qubits[1].index == qubits[1]
+        assert pyquil_gate.qubits == [pyquil.quil.Qubit(i) for i in qubit_indices]
 
-    assert len(pyquil_gate.params) == 1
-    assert pyquil_gate.params[0] == angle
+    def test_conversion_from_orquestra_to_pyquil_preserves_angle(
+        self, qubit_indices, angle
+    ):
+        pyquil_gate = convert_to_pyquil(CPHASE(*qubit_indices, angle))
 
+        assert pyquil_gate.params == [angle]
 
-@pytest.mark.parametrize("qubits", [[0, 1], [2, 10], [4, 7]])
-@pytest.mark.parametrize("zquantum_angle, pyquil_angle", EXAMPLE_PARAMETRIZED_ANGLES)
-def test_angle_of_parametrized_cphase_gate_is_translated_when_converting_to_pyquil(
-    qubits, zquantum_angle, pyquil_angle
-):
-    program = pyquil.Program()
-    pyquil_gate = convert_to_pyquil(CPHASE(*qubits, zquantum_angle), program)
-    assert pyquil_gate.params[0] == pyquil_angle
+    def test_conversion_from_pyquil_to_orquestra_preserves_qubit_indices(
+        self, qubit_indices, angle
+    ):
+        orquestra_gate = convert_from_pyquil(pyquil.gates.CPHASE(angle, *qubit_indices))
 
+        assert orquestra_gate.qubits == tuple(qubit_indices)
 
-@pytest.mark.parametrize("qubits", [[0, 1], [2, 10], [4, 7]])
-@pytest.mark.parametrize("zquantum_angle, pyquil_angle", EXAMPLE_PARAMETRIZED_ANGLES)
-def test_converting_parametrized_cphase_gate_to_pyquil_adds_its_symbolic_params_to_program(
-    qubits, zquantum_angle, pyquil_angle
-):
-    zquantum_gate = CPHASE(*qubits, zquantum_angle)
-    program = pyquil.Program()
-    convert_to_pyquil(zquantum_gate, program)
+    def test_conversion_from_pyquil_to_orquestra_preserves_angle(
+        self, qubit_indices, angle
+    ):
+        orquestra_gate = convert_from_pyquil(pyquil.gates.CPHASE(angle, *qubit_indices))
 
-    assert program.instructions == [
-        pyquil.quil.Declare(str(param), "REAL")
-        for param in zquantum_gate.symbolic_params
-    ]
+        assert orquestra_gate.angle == angle
 
 
-@pytest.mark.parametrize("qubits", [[0, 1], [2, 10], [4, 7]])
-def test_converting_swap_gate_to_pyquil_preserves_qubits(qubits):
-    pyquil_gate = convert_to_pyquil(SWAP(qubits))
+@pytest.mark.parametrize("qubit_indices", [[0, 1], [2, 10], [4, 7]])
+@pytest.mark.parametrize("orquestra_angle, pyquil_angle", EXAMPLE_PARAMETRIZED_ANGLES)
+class TestCPHASEGateWithSymbolicParamsConversion:
 
-    assert pyquil_gate.qubits[0].index == qubits[0]
-    assert pyquil_gate.qubits[1].index == qubits[1]
+    def test_angle_is_translated_when_converting_from_orquestra_to_pyquil(
+        self, qubit_indices, orquestra_angle, pyquil_angle
+    ):
+        program = pyquil.Program()
+        pyquil_gate = convert_to_pyquil(CPHASE(*qubit_indices, orquestra_angle), program)
+
+        assert pyquil_gate.params == [pyquil_angle]
+
+    def test_translated_angle_is_added_to_program(
+        self, qubit_indices, orquestra_angle, pyquil_angle
+    ):
+        program = pyquil.Program()
+        orquestra_gate = CPHASE(*qubit_indices, orquestra_angle)
+        convert_to_pyquil(orquestra_gate, program)
+
+        assert program.instructions == [
+            pyquil.quil.Declare(str(param), "REAL")
+            for param in orquestra_gate.symbolic_params
+        ]
+
+    def test_angle_is_translated_when_converting_from_pyquil_to_orquestra(
+        self, qubit_indices, orquestra_angle, pyquil_angle
+    ):
+        orquestra_gate = convert_from_pyquil(
+            pyquil.gates.CPHASE(pyquil_angle, *qubit_indices)
+        )
+
+        assert orquestra_gate.angle == orquestra_angle
+
+
+@pytest.mark.parametrize("qubit_indices", [[0, 1], [2, 10], [4, 7]])
+class TestSWAPGateConversion:
+
+    def test_conversion_from_pyquil_to_orquestra_preserves_qubit_indices(
+        self, qubit_indices
+    ):
+        pyquil_gate = convert_to_pyquil(SWAP(qubit_indices))
+
+        assert pyquil_gate.qubits == [
+            pyquil.quil.Qubit(i) for i in qubit_indices
+        ]
+
+    def test_conversion_from_orquestra_to_pyquil_preserves_qubit_indices(
+        self, qubit_indices
+    ):
+        orquestra_gate = convert_from_pyquil(pyquil.gates.SWAP(*qubit_indices))
+
+        assert orquestra_gate.qubits == tuple(qubit_indices)
 
 
 @pytest.mark.parametrize("control, target", [(0, 1), (2, 3), (0, 10)])

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
@@ -46,14 +46,6 @@ ORQUESTRA_GATE_TYPE_TO_PYQUIL_NAME = {
     CPHASE: "CPHASE",
 }
 
-ORQUESTRA_SINGLE_QUBIT_ROTATION_GATES = [RX, RY, RZ, PHASE]
-
-PYQUIL_SINGLE_QUBIT_ROTATION_GATES = [
-    pyquil.gates.RX,
-    pyquil.gates.RY,
-    pyquil.gates.RZ,
-    pyquil.gates.PHASE
-]
 
 EXAMPLE_PARAMETRIZED_ANGLES = [
     (sympy.Symbol("theta"), pyquil.quil.Parameter("theta")),
@@ -265,25 +257,29 @@ class TestSWAPGateConversion:
 
 
 @pytest.mark.parametrize("control, target", [(0, 1), (2, 3), (0, 10)])
+@pytest.mark.parametrize(
+    "orquestra_gate_cls, pyquil_gate_func", [
+        (CZ, pyquil.gates.CZ),
+        (CNOT, pyquil.gates.CNOT)
+    ]
+)
 class TestTwoQubitPredefinedControlledGatesConversion:
 
-    @pytest.mark.parametrize("orquestra_gate_cls", [CZ, CNOT])
-    def test_conversion_from_orquestra_to_qubit_preserves_qubit_indices(
-        self, control, target, orquestra_gate_cls
+    def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
+        self, control, target, orquestra_gate_cls, pyquil_gate_func
     ):
-        pyquil_gate = convert_to_pyquil(orquestra_gate_cls(control, target))
+        assert (
+            pyquil_gate_func(control, target) ==
+            convert_to_pyquil(orquestra_gate_cls(control, target))
+        )
 
-        assert pyquil_gate.qubits == [
-            pyquil.quil.Qubit(control), pyquil.quil.Qubit(target)
-        ]
-
-    @pytest.mark.parametrize("pyquil_gate_func", [pyquil.gates.CZ, pyquil.gates.CNOT])
-    def test_conversion_from_pyquil_to_orquestra_preserves_qubit_indices(
-        self, control, target, pyquil_gate_func
+    def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
+        self, control, target, orquestra_gate_cls, pyquil_gate_func
     ):
-        orquestra_gate = convert_from_pyquil(pyquil_gate_func(control, target))
-
-        assert orquestra_gate.qubits == (control, target)
+        assert (
+            orquestra_gate_cls(control, target) ==
+            convert_from_pyquil(pyquil_gate_func(control, target))
+        )
 
 
 class TestCorrectnessOfGateTypeAndMatrix:

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -1,6 +1,5 @@
 """Utilities for converting gates and circuits to and from Pyquil objects."""
 from functools import singledispatch
-from itertools import chain
 from typing import Union, Optional, overload, Iterable
 import numpy as np
 import pyquil

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -52,11 +52,10 @@ ROTATION_GATES = {
 TWO_QUBIT_CONTROLLED_GATES = {
     CZ: pyquil.gates.CZ,
     CNOT: pyquil.gates.CNOT,
-    SWAP: pyquil.gates.SWAP,
 }
 
 
-PYQUIL_NAME_TO_ORQUESTRA_NAME = {
+PYQUIL_NAME_TO_ORQUESTRA_CLS = {
     cls.__name__: cls
     for cls in chain(
         SINGLE_QUBIT_NONPARAMETRIC_GATES,
@@ -64,6 +63,9 @@ PYQUIL_NAME_TO_ORQUESTRA_NAME = {
         ROTATION_GATES
     )
 }
+
+PYQUIL_NAME_TO_ORQUESTRA_CLS["CPHASE"] = CPHASE
+PYQUIL_NAME_TO_ORQUESTRA_CLS["SWAP"] = SWAP
 
 
 def pyquil_qubits_to_numbers(qubits: Iterable[pyquil.quil.Qubit]):
@@ -229,7 +231,7 @@ def convert_from_pyquil(obj: Union[pyquil.Program, pyquil.quil.Gate]):
 @convert_from_pyquil.register
 def convert_gate_from_pyquil(gate: pyquil.quil.Gate) -> Gate:
     try:
-        gate_cls = PYQUIL_NAME_TO_ORQUESTRA_NAME[gate.name]
+        gate_cls = PYQUIL_NAME_TO_ORQUESTRA_CLS[gate.name]
         if (
             gate_cls in SINGLE_QUBIT_NONPARAMETRIC_GATES
             or gate_cls in TWO_QUBIT_CONTROLLED_GATES
@@ -243,6 +245,9 @@ def convert_gate_from_pyquil(gate: pyquil.quil.Gate) -> Gate:
                     SYMPY_DIALECT
                 )
             )
+        elif gate_cls == SWAP:
+            return gate_cls(pyquil_qubits_to_numbers(gate.qubits))
+
     except KeyError:
         raise ValueError(
             f"Conversion to Orquestra is not supported for {gate.name} gate"

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -49,7 +49,7 @@ ROTATION_GATES = {
 }
 
 
-TWO_QUBIT_CONTROLLED_GATES = {
+TWO_QUBIT_CONTROLLED_NONPARAMETRIC_GATES = {
     CZ: pyquil.gates.CZ,
     CNOT: pyquil.gates.CNOT,
 }
@@ -58,7 +58,7 @@ TWO_QUBIT_CONTROLLED_GATES = {
 PYQUIL_NAME_TO_ORQUESTRA_CLS = {
     cls.__name__: cls
     for cls in chain(
-        SINGLE_QUBIT_NONPARAMETRIC_GATES, TWO_QUBIT_CONTROLLED_GATES, ROTATION_GATES
+        SINGLE_QUBIT_NONPARAMETRIC_GATES, TWO_QUBIT_CONTROLLED_NONPARAMETRIC_GATES, ROTATION_GATES
     )
 }
 
@@ -138,7 +138,7 @@ def convert_single_qubit_rotation_gate_to_pyquil(
 def convert_two_qubit_nonparametric_gate_to_pyquil(
     gate: Union[CZ], _program: Optional[pyquil.Program] = None
 ) -> pyquil.gates.Gate:
-    return TWO_QUBIT_CONTROLLED_GATES[type(gate)](*gate.qubits)
+    return TWO_QUBIT_CONTROLLED_NONPARAMETRIC_GATES[type(gate)](*gate.qubits)
 
 
 @_convert_gate_to_pyquil.register(CPHASE)
@@ -242,7 +242,7 @@ def convert_gate_from_pyquil(gate: pyquil.quil.Gate) -> Gate:
         gate_cls = PYQUIL_NAME_TO_ORQUESTRA_CLS[gate.name]
         if (
             gate_cls in SINGLE_QUBIT_NONPARAMETRIC_GATES
-            or gate_cls in TWO_QUBIT_CONTROLLED_GATES
+            or gate_cls in TWO_QUBIT_CONTROLLED_NONPARAMETRIC_GATES
         ):
             result = gate_cls(*target_qubits)
         elif gate_cls in ROTATION_GATES or gate_cls == CPHASE:

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -262,6 +262,8 @@ def convert_gate_from_pyquil(gate: pyquil.quil.Gate) -> Gate:
                 "please file a bugreport."
             )
 
+        # Control qubits need to be applied in reverse because in PyQuil they
+        # are prepended to the list when applying control modifier.
         for qubit in reversed(control_qubits):
             result = ControlledGate(result, qubit)
 

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -234,7 +234,7 @@ def convert_gate_from_pyquil(gate: pyquil.quil.Gate) -> Gate:
 
     all_qubits = pyquil_qubits_to_numbers(gate.qubits)
     control_qubits = all_qubits[:number_of_control_modifiers]
-    original_qubits = all_qubits[number_of_control_modifiers:]
+    target_qubits = all_qubits[number_of_control_modifiers:]
 
     try:
         gate_cls = PYQUIL_NAME_TO_ORQUESTRA_CLS[gate.name]
@@ -242,16 +242,16 @@ def convert_gate_from_pyquil(gate: pyquil.quil.Gate) -> Gate:
             gate_cls in SINGLE_QUBIT_NONPARAMETRIC_GATES
             or gate_cls in TWO_QUBIT_CONTROLLED_GATES
         ):
-            result = gate_cls(*original_qubits)
+            result = gate_cls(*target_qubits)
         elif gate_cls in ROTATION_GATES or gate_cls == CPHASE:
             result = gate_cls(
-                *original_qubits,
+                *target_qubits,
                 translate_expression(
                     expression_from_pyquil(gate.params[0]), SYMPY_DIALECT
                 ),
             )
         elif gate_cls == SWAP:
-            result = gate_cls(original_qubits)
+            result = gate_cls(target_qubits)
         else:
             raise RuntimeError(
                 f"Error converting gate {gate}. If you see this message, "

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -77,7 +77,7 @@ def convert_to_pyquil(obj: Circuit) -> pyquil.Program:
 
 @overload
 def convert_to_pyquil(
-    obj: Gate, program: Optional[pyquil.Program]
+    obj: Gate, program: Optional[pyquil.Program] = None
 ) -> pyquil.quil.Gate:
     pass
 

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -54,18 +54,24 @@ TWO_QUBIT_CONTROLLED_NONPARAMETRIC_GATES = {
     CNOT: pyquil.gates.CNOT,
 }
 
-# This is basically a reverse mapping of dictionaries defined above.
-# The following works because name of Orquestra classes for
-# predefined gates correspond to gate names used by PyQuil.
-PYQUIL_NAME_TO_ORQUESTRA_CLS = {
-    cls.__name__: cls
-    for cls in chain(
-        SINGLE_QUBIT_NONPARAMETRIC_GATES, TWO_QUBIT_CONTROLLED_NONPARAMETRIC_GATES, ROTATION_GATES
-    )
-}
 
-PYQUIL_NAME_TO_ORQUESTRA_CLS["CPHASE"] = CPHASE
-PYQUIL_NAME_TO_ORQUESTRA_CLS["SWAP"] = SWAP
+# A Mapping from PyQuil gate names to the Orquestra classes.
+PYQUIL_NAME_TO_ORQUESTRA_CLS = {
+    "X": X,
+    "Y": Y,
+    "Z": Z,
+    "T": T,
+    "I": I,
+    "H": H,
+    "RX": RX,
+    "RY": RY,
+    "RZ": RZ,
+    "PHASE": PHASE,
+    "CZ": CZ,
+    "CNOT": CNOT,
+    "CPHASE": CPHASE,
+    "SWAP": SWAP
+}
 
 
 def pyquil_qubits_to_numbers(qubits: Iterable[pyquil.quil.Qubit]):

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -267,6 +267,9 @@ def convert_gate_from_pyquil(gate: pyquil.quil.Gate) -> Gate:
         for qubit in reversed(control_qubits):
             result = ControlledGate(result, qubit)
 
+        # PyQuil allows multiple DAGGER modifiers in gate's definition.
+        # Since two daggers cancel out, we only need to apply it if
+        # the total number of DAGGER modifiers is odd.
         if gate.modifiers.count("DAGGER") % 2 == 1:
             result = result.dagger
 

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -54,7 +54,9 @@ TWO_QUBIT_CONTROLLED_NONPARAMETRIC_GATES = {
     CNOT: pyquil.gates.CNOT,
 }
 
-
+# This is basically a reverse mapping of dictionaries defined above.
+# The following works because name of Orquestra classes for
+# predefined gates correspond to gate names used by PyQuil.
 PYQUIL_NAME_TO_ORQUESTRA_CLS = {
     cls.__name__: cls
     for cls in chain(

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -58,9 +58,7 @@ TWO_QUBIT_CONTROLLED_GATES = {
 PYQUIL_NAME_TO_ORQUESTRA_CLS = {
     cls.__name__: cls
     for cls in chain(
-        SINGLE_QUBIT_NONPARAMETRIC_GATES,
-        TWO_QUBIT_CONTROLLED_GATES,
-        ROTATION_GATES
+        SINGLE_QUBIT_NONPARAMETRIC_GATES, TWO_QUBIT_CONTROLLED_GATES, ROTATION_GATES
     )
 }
 
@@ -93,7 +91,9 @@ def convert_to_pyquil(obj, program: Optional[pyquil.Program] = None):
 def convert_gate_to_pyquil(
     gate: Gate, program: Optional[pyquil.Program] = None
 ) -> pyquil.gates.Gate:
-    required_declarations = (pyquil.quil.Declare(str(param), "REAL") for param in gate.symbolic_params)
+    required_declarations = (
+        pyquil.quil.Declare(str(param), "REAL") for param in gate.symbolic_params
+    )
     for declaration in required_declarations:
         if declaration not in program.instructions:
             program += declaration
@@ -233,7 +233,6 @@ def convert_gate_from_pyquil(gate: pyquil.quil.Gate) -> Gate:
     number_of_control_modifiers = gate.modifiers.count("CONTROLLED")
 
     all_qubits = pyquil_qubits_to_numbers(gate.qubits)
-
     control_qubits = all_qubits[:number_of_control_modifiers]
     original_qubits = all_qubits[number_of_control_modifiers:]
 
@@ -248,9 +247,8 @@ def convert_gate_from_pyquil(gate: pyquil.quil.Gate) -> Gate:
             result = gate_cls(
                 *original_qubits,
                 translate_expression(
-                    expression_from_pyquil(gate.params[0]),
-                    SYMPY_DIALECT
-                )
+                    expression_from_pyquil(gate.params[0]), SYMPY_DIALECT
+                ),
             )
         elif gate_cls == SWAP:
             result = gate_cls(original_qubits)

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -250,21 +250,7 @@ def convert_gate_from_pyquil(gate: pyquil.quil.Gate) -> Gate:
 
     try:
         gate_cls = PYQUIL_NAME_TO_ORQUESTRA_CLS[gate.name]
-        if (
-            gate_cls in SINGLE_QUBIT_NONPARAMETRIC_GATES
-            or gate_cls in TWO_QUBIT_CONTROLLED_NONPARAMETRIC_GATES
-        ):
-            result = gate_cls(*target_qubits)
-        elif gate_cls in ROTATION_GATES or gate_cls == CPHASE or gate_cls == SWAP:
-            result = gate_cls(
-                *target_qubits,
-                *orquestra_params
-            )
-        else:
-            raise RuntimeError(
-                f"Error converting gate {gate}. If you see this message, "
-                "please file a bugreport."
-            )
+        result = gate_cls(*target_qubits, *orquestra_params)
 
         # Control qubits need to be applied in reverse because in PyQuil they
         # are prepended to the list when applying control modifier.
@@ -278,6 +264,11 @@ def convert_gate_from_pyquil(gate: pyquil.quil.Gate) -> Gate:
             result = result.dagger
 
         return result
+    except TypeError:
+        raise ValueError(
+            f"Cannot convert {gate}. Please check that you haven't reimplemented "
+            "predefined gate. If this is not the case, contact Orquestra support."
+        )
     except KeyError:
         raise ValueError(
             f"Conversion to Orquestra is not supported for {gate.name} gate"

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -225,7 +225,9 @@ def convert_circuit_to_pyquil(
 
 @singledispatch
 def convert_from_pyquil(obj: Union[pyquil.Program, pyquil.quil.Gate]):
-    pass
+    raise NotImplementedError(
+        f"Conversion from pyquil to orquestra not implemented for {obj}"
+    )
 
 
 @convert_from_pyquil.register

--- a/src/python/zquantum/core/circuit/gates/_dagger_test.py
+++ b/src/python/zquantum/core/circuit/gates/_dagger_test.py
@@ -75,6 +75,6 @@ def test_dagger_of_hermitian_controlled_two_qubit_gates_is_the_same_as_original_
 
 
 def test_dagger_of_swap_gate_is_the_same_as_the_original_gate():
-    swap = SWAP((0, 2))
+    swap = SWAP(0, 2)
 
     assert swap.dagger is swap

--- a/src/python/zquantum/core/circuit/gates/_dagger_test.py
+++ b/src/python/zquantum/core/circuit/gates/_dagger_test.py
@@ -52,7 +52,7 @@ class TestBasicPropertiesOfDaggerOperations:
 
 
 def test_applying_dagger_to_controlled_gate_gives_controlled_gate_of_target_gates_dagger():
-    dagger = ControlledGate(EXAMPLE_CUSTOM_GATE, 0)
+    dagger = ControlledGate(EXAMPLE_CUSTOM_GATE, 0).dagger
     assert isinstance(dagger,  ControlledGate)
     assert dagger.target_gate == EXAMPLE_CUSTOM_GATE.dagger
 

--- a/src/python/zquantum/core/circuit/gates/_gate.py
+++ b/src/python/zquantum/core/circuit/gates/_gate.py
@@ -330,7 +330,7 @@ class Dagger(SpecializedGate):
         return self.gate
 
     def _create_matrix(self) -> sympy.Matrix:
-        return self.gate.matrix
+        return self.gate.matrix.conjugate().T
 
 
 class HermitianMixin:

--- a/src/python/zquantum/core/circuit/gates/_two_qubit_gates.py
+++ b/src/python/zquantum/core/circuit/gates/_two_qubit_gates.py
@@ -33,8 +33,8 @@ class CPHASE(ControlledGate):
 class SWAP(HermitianMixin, SpecializedGate):
     """Quantum SWAP gate."""
 
-    def __init__(self, qubits: Tuple[int, int]):
-        super().__init__(qubits)
+    def __init__(self, first_qubit: int, second_qubit: int):
+        super().__init__((first_qubit, second_qubit))
 
     def _create_matrix(self) -> sympy.Matrix:
         return sympy.Matrix([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])


### PR DESCRIPTION
This adds conversion of basic gates from PyQuil to Orquestra and simplifies already present conversion tests.

Changes from this PR don't include

- Conversion of custom gates
- Conversion of a whole program
- Proper docstrings

The above mentioned missing parts will be added in the next PR.