### PR TITLE
175540559 converting pyquil custom gates and programs

### DIFF
--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
@@ -469,7 +469,7 @@ class TestCustomGateFactoryFromPyquilDefgate:
             )
         ]
     )
-    def test_factory_created_form_nonparametrized_pyquil_defgate_produces_correct_gates(
+    def test_factory_created_from_nonparametrized_pyquil_defgate_produces_correct_gates(
         self, name, matrix, qubits
     ):
         gate_definition = pyquil.quil.DefGate(name, matrix)

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversion_test.py
@@ -516,9 +516,9 @@ class TestCustomGateFactoryFromPyquilDefgate:
             0,
             3,
             1.0,
-            pyquil.quil.Parameter("theta"),
-            pyquil.quil.Parameter('x') + pyquil.quil.Parameter("y"),
-            pyquil.quilatom.quil_cos(pyquil.quil.Parameter("theta"))
+            sympy.Symbol("theta"),
+            sympy.Symbol('x') + sympy.Symbol("y"),
+            sympy.cos(sympy.Symbol("theta"))
         ) == expected_orquestra_gate
 
 

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -234,7 +234,7 @@ def convert_circuit_to_pyquil(
 
 
 @singledispatch
-def convert_from_pyquil(obj: Union[pyquil.Program, pyquil.quil.Gate]):
+def convert_from_pyquil(obj: Union[pyquil.Program, pyquil.quil.Gate], custom_gates=None):
     raise NotImplementedError(
         f"Conversion from pyquil to orquestra not implemented for {obj}"
     )
@@ -271,13 +271,8 @@ def custom_gate_factory_from_pyquil_defgate(gate: pyquil.quil.DefGate):
             sympy_matrix, qubits=tuple(qubits), name=gate.name
         )
         if len(args) != num_qubits:
-            parameters = [
-                translate_expression(
-                    expression_from_pyquil(arg),
-                    SYMPY_DIALECT
-                )
-                for arg in args[num_qubits:]
-            ]
+            parameters = args[num_qubits:]
+
             orquestra_gate = orquestra_gate.evaluate(
                 {symbol: value for symbol, value in zip(symbols, parameters)}
             )

--- a/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/circuit/conversions/pyquil_conversions.py
@@ -1,4 +1,5 @@
 """Utilities for converting gates and circuits to and from Pyquil objects."""
+from copy import copy
 from functools import singledispatch
 import math
 from typing import Union, Optional, overload, Iterable
@@ -281,7 +282,7 @@ def custom_gate_factory_from_pyquil_defgate(gate: pyquil.quil.DefGate):
 
 
 @convert_from_pyquil.register
-def convert_gate_from_pyquil(gate: pyquil.quil.Gate) -> Gate:
+def convert_gate_from_pyquil(gate: pyquil.quil.Gate, custom_gates=None) -> Gate:
     number_of_control_modifiers = gate.modifiers.count("CONTROLLED")
 
     all_qubits = pyquil_qubits_to_numbers(gate.qubits)
@@ -296,8 +297,13 @@ def convert_gate_from_pyquil(gate: pyquil.quil.Gate) -> Gate:
         for param in gate.params
     )
 
+    pyquil_name_to_orquestra_cls = copy(PYQUIL_NAME_TO_ORQUESTRA_CLS)
+
+    if custom_gates is not None:
+        pyquil_name_to_orquestra_cls.update(custom_gates)
+
     try:
-        gate_cls = PYQUIL_NAME_TO_ORQUESTRA_CLS[gate.name]
+        gate_cls = pyquil_name_to_orquestra_cls[gate.name]
         result = gate_cls(*target_qubits, *orquestra_params)
 
         # Control qubits need to be applied in reverse because in PyQuil they
@@ -319,5 +325,25 @@ def convert_gate_from_pyquil(gate: pyquil.quil.Gate) -> Gate:
         )
     except KeyError:
         raise ValueError(
-            f"Conversion to Orquestra is not supported for {gate.name} gate"
+            f"Conversion to Orquestra is not supported for {gate.name} gate. "
+            "If this is a custom gate, make sure to convert it together with "
+            "a corresponding PyQuil program."
         )
+
+
+@convert_from_pyquil.register
+def convert_pyquil_program_to_orquestra(program: pyquil.Program, custom_gates=None):
+    custom_gates = {
+        definition.name: custom_gate_factory_from_pyquil_defgate(definition)
+        for definition in program.defined_gates
+    }
+
+    gates_in_program = [
+        instruction
+        for instruction in program.instructions
+        if isinstance(instruction, pyquil.quil.Gate)
+    ]
+
+    return Circuit(
+        [convert_from_pyquil(gate, custom_gates) for gate in gates_in_program]
+    )

--- a/src/python/zquantum/core/circuit/conversions/symbolic/helpers.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/helpers.py
@@ -1,0 +1,8 @@
+"""Helper functions for use with symbolic expressions."""
+from functools import reduce, partial
+
+
+def reduction(operator):
+    def _reduction(*args):
+        return reduce(operator, args)
+    return _reduction

--- a/src/python/zquantum/core/circuit/conversions/symbolic/pyquil_expressions.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/pyquil_expressions.py
@@ -5,7 +5,7 @@ from numbers import Number
 import pyquil
 from pyquil import quilatom
 from .expressions import ExpressionDialect, Symbol, FunctionCall
-
+from .helpers import reduction
 
 QUIL_BINARY_EXPRESSION_NAMES = {
     quilatom.Add: "add",
@@ -63,8 +63,8 @@ QUIL_DIALECT = ExpressionDialect(
     symbol_factory=lambda symbol: pyquil.quil.Parameter(symbol.name),
     number_factory=lambda number: number,
     known_functions={
-        "add": operator.add,
-        "mul": operator.mul,
+        "add": reduction(operator.add),
+        "mul": reduction(operator.mul),
         "div": operator.truediv,
         "sub": operator.sub,
         "pow": operator.pow,

--- a/src/python/zquantum/core/circuit/conversions/symbolic/translations_test.py
+++ b/src/python/zquantum/core/circuit/conversions/symbolic/translations_test.py
@@ -64,6 +64,7 @@ from .pyquil_expressions import QUIL_DIALECT, expression_from_pyquil
             sympy.sqrt(sympy.Symbol("x") - sympy.Symbol("y")),
             quilatom.quil_sqrt(quil.Parameter("x") - quil.Parameter("y")),
         ),
+        (-5 * sympy.Symbol("x") * sympy.Symbol("y"), -5 * quil.Parameter("x") * quil.Parameter("y")),
     ],
 )
 def test_translating_tree_from_sympy_to_quil_gives_expected_result(
@@ -122,7 +123,7 @@ def test_translating_tree_from_sympy_to_quil_gives_expected_result(
         ),
     ],
 )
-def test_translating_tree_from_sympy_to_quil_gives_expected_result(
+def test_translating_tree_from_quil_to_sympy_gives_expected_result(
     quil_expression, sympy_expression
 ):
     expression = expression_from_pyquil(quil_expression)


### PR DESCRIPTION
The final step of conversion between PyQuil objects and orquestra objects. `convert_from_pyquil` variant implemented here allows for converting whole PyQuil program, including ones with custom gates.