### PR TITLE
Adding function to convert QubitOp to list of Pauli string gate circuits

### DIFF
--- a/src/python/zquantum/core/openfermion/_utils.py
+++ b/src/python/zquantum/core/openfermion/_utils.py
@@ -13,7 +13,13 @@ import random
 import copy
 from typing import List, Union, Optional
 
-from zquantum.core.circuit import build_ansatz_circuit
+from zquantum.core.circuit import (
+    build_ansatz_circuit,
+    Circuit,
+    Gate,
+    Qubit,
+)
+
 from zquantum.core.utils import bin2dec, dec2bin, ValueEstimate
 from zquantum.core.measurement import ExpectationValues, expectation_values_to_real
 from openfermion import count_qubits
@@ -239,8 +245,8 @@ def evaluate_operator_for_parameter_grid(
         ansatz (dict): the ansatz
         grid (zquantum.core.circuit.ParameterGrid): The parameter grid containing
             the parameters for the last layer of the ansatz
-        backend (zquantum.core.interfaces.backend.QuantumSimulator): the backend 
-            to run the circuits on 
+        backend (zquantum.core.interfaces.backend.QuantumSimulator): the backend
+            to run the circuits on
         operator (openfermion.ops.QubitOperator): the operator
         previous_layer_params (array): A list of the parameters for previous layers
             of the ansatz
@@ -248,8 +254,8 @@ def evaluate_operator_for_parameter_grid(
     Returns:
         value_estimate (zquantum.core.utils.ValueEstimate): stores the value of the expectation and its
              precision
-        optimal_parameters (numpy array): the ansatz parameters representing the ansatz parameters 
-            resulting in the best minimum evaluation. If multiple sets of parameters evaluate to the same value, 
+        optimal_parameters (numpy array): the ansatz parameters representing the ansatz parameters
+            resulting in the best minimum evaluation. If multiple sets of parameters evaluate to the same value,
             the first set of parameters is chosen as the optimal.
     """
     parameter_grid_evaluation = []
@@ -296,7 +302,7 @@ def reverse_qubit_order(qubit_operator: QubitOperator, n_qubits: Optional[int] =
 
     Args:
         qubit_operator (openfermion.QubitOperator): the operator
-        n_qubits (int): total number of qubits. Needs to be provided when 
+        n_qubits (int): total number of qubits. Needs to be provided when
                     the size of the system of interest is greater than the size of qubit operator (optional)
 
     Returns:
@@ -401,7 +407,7 @@ def _get_diagonal_component_polynomial_tensor(polynomial_tensor):
     as products of number operators).
     Args:
         interaction_operator (openfermion.ops.InteractionOperator): the operator
-    
+
     Returns:
         tuple: two openfermion.ops.InteractionOperator objects. The first is the
             diagonal component, and the second is the remainder.
@@ -462,7 +468,7 @@ def _get_diagonal_component_interaction_operator(interaction_operator):
     as products of number operators).
     Args:
         interaction_operator (openfermion.ops.InteractionOperator): the operator
-    
+
     Returns:
         tuple: two openfermion.ops.InteractionOperator objects. The first is the
             diagonal component, and the second is the remainder.
@@ -511,7 +517,7 @@ def get_polynomial_tensor(fermion_operator, n_qubits=None):
             PolynomialTensor. Must be at least equal to the number of qubits
             that are acted on by fermion_operator. If None, then the number of
             qubits is inferred from fermion_operator.
-    
+
     Returns:
         openfermion.ops.PolynomialTensor: The tensor representation of the
             operator.
@@ -558,7 +564,7 @@ def qubitop_to_paulisum(
         qubits()
 
     Returns:
-        cirq.PauliSum 
+        cirq.PauliSum
     """
     operator_map = {"X": cirq.X, "Y": cirq.Y, "Z": cirq.Z}
 
@@ -580,3 +586,38 @@ def qubitop_to_paulisum(
 
     return converted_sum
 
+
+def create_circuits_from_qubit_operator(qubit_operator: QubitOperator) -> List[Circuit]:
+    """Creates a list of zquantum.core.Circuit objects from the Pauli terms of a QubitOperator
+    Args:
+        qubit_operator: QubitOperator: qubit operator for which the Pauli terms are converted into Circuits
+
+    Return:
+        circuit_set: a list of Pauli string gate circuits
+    """
+
+    # Get the Pauli terms, ignoring coefficients
+    pauli_terms = list(qubit_operator.terms.keys())
+
+    circuit_set = []
+
+    # Loop over Pauli terms and populate circuit set list
+    for term in pauli_terms:
+
+        circuit = Circuit()
+        pauli_gates = []
+        qubits = []
+
+        # Loop over Pauli factors in Pauli term and construct Pauli term circuit
+        for pauli in term:  # loop over pauli operators in an n qubit pauli term
+            pauli_index = pauli[0]
+            pauli_factor = pauli[1]
+            pauli_gates.append(Gate(pauli_factor, qubits=[Qubit(pauli_index)]))
+            qubits.append(Qubit(pauli[0]))
+
+        circuit.gates = pauli_gates
+        circuit.qubits += qubits
+
+        circuit_set += [circuit]
+
+    return circuit_set

--- a/src/python/zquantum/core/openfermion/_utils_test.py
+++ b/src/python/zquantum/core/openfermion/_utils_test.py
@@ -22,6 +22,12 @@ from openfermion.transforms import (
 )
 from openfermion.utils import qubit_operator_sparse
 
+from zquantum.core.circuit import (
+    Circuit,
+    Gate,
+    Qubit,
+)
+
 from ._io import convert_qubitop_to_dict, save_qubit_operator, load_qubit_operator
 from ._utils import (
     generate_random_qubitop,
@@ -36,6 +42,7 @@ from ._utils import (
     get_diagonal_component,
     get_polynomial_tensor,
     qubitop_to_paulisum,
+    create_circuits_from_qubit_operator,
 )
 
 
@@ -244,6 +251,42 @@ class TestQubitOperator(unittest.TestCase):
 
         # Then
         self.assertEqual(number_operator, correct_operator)
+
+    def test_create_circuits_from_qubit_operator(self):
+        # Initialize target
+        qubits = [Qubit(i) for i in range(0, 2)]
+
+        gate_Z0 = Gate("Z", [qubits[0]])
+        gate_X1 = Gate("X", [qubits[1]])
+
+        gate_Y0 = Gate("Y", [qubits[0]])
+        gate_Z1 = Gate("Z", [qubits[1]])
+
+        circuit1 = Circuit()
+        circuit1.qubits = qubits
+        circuit1.gates = [gate_Z0, gate_X1]
+
+        circuit2 = Circuit()
+        circuit2.qubits = qubits
+        circuit2.gates = [gate_Y0, gate_Z1]
+
+        target_circuits_list = [circuit1, circuit2]
+
+        # Given
+        qubit_op = QubitOperator("Z0 X1") + QubitOperator("Y0 Z1")
+
+        # When
+        pauli_circuits = create_circuits_from_qubit_operator(qubit_op)
+
+        # Then
+        self.assertEqual(pauli_circuits[0].gates, target_circuits_list[0].gates)
+        self.assertEqual(pauli_circuits[1].gates, target_circuits_list[1].gates)
+        self.assertEqual(
+            str(pauli_circuits[0].qubits), str(target_circuits_list[0].qubits)
+        )
+        self.assertEqual(
+            str(pauli_circuits[1].qubits), str(target_circuits_list[1].qubits)
+        )
 
 
 class TestOtherUtils(unittest.TestCase):


### PR DESCRIPTION
I chatted with William about where this function should live. This pull request deprecates the previous pull request from pauli_circuit to dev, which can now be closed.