### PR TITLE
Ansatz specs can now be provided as dict instead of string

### DIFF
--- a/steps/circuit.py
+++ b/steps/circuit.py
@@ -30,7 +30,10 @@ def generate_random_ansatz_params(
     seed: Union[str, int] = "None",
 ):
     if ansatz_specs != "None":  # TODO None issue in workflow v1
-        ansatz_specs_dict = json.loads(ansatz_specs)
+        if isinstance(ansatz_specs, str):
+            ansatz_specs_dict = json.loads(ansatz_specs)
+        else:
+            ansatz_specs_dict = ansatz_specs
         ansatz = create_object(ansatz_specs_dict)
         number_of_params = ansatz.number_of_params
     elif number_of_parameters != "None":


### PR DESCRIPTION
Workflows using the `generate_random_ansatz_params` can now provide the ansatz specs as a dict instead of string. See [updated VQE example](https://github.com/zapatacomputing/z-quantum-vqe/blob/e1e68d04203d695d6527903ca468e66f47e62b73/examples/hydrogen-vqe.yaml#L149-L154).