### PR TITLE
Remove dependency on grove

### DIFF
--- a/docker/z-quantum-default/0.0.6/Dockerfile
+++ b/docker/z-quantum-default/0.0.6/Dockerfile
@@ -69,6 +69,7 @@ RUN python3 -m pip install rpcq==3.0.0 \
                     werkzeug==0.14.1 \
                     flask==1.1.1 \
                     pyyaml==5.1 \
+                    quantum-grove>=1.0.0 \
                     overrides>=3.1.0
 
 RUN python3 -m pip install qutip>=5.4.1

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setuptools.setup(
         "pyquil>=2.17.0",
         "cirq==0.9.0",
         "qiskit==0.18.3",
-        "quantum-grove>=1.0.0",
         "overrides>=3.1.0",
     ],
 )

--- a/src/python/zquantum/core/measurement.py
+++ b/src/python/zquantum/core/measurement.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import json
 from pyquil.wavefunction import Wavefunction
-from grove.pyvqe.vqe import parity_even_p
 import numpy as np
 from openfermion.ops import IsingOperator
 from .utils import (
@@ -323,8 +322,7 @@ def get_parities_from_measurements(
         values.append([0, 0])
         marked_qubits = [op[0] for op in term]
         for bitstring, count in bitstring_frequencies.items():
-            bitstring_int = convert_bitstring_to_int(bitstring)
-            if parity_even_p(bitstring_int, marked_qubits):
+            if check_parity(bitstring, marked_qubits):
                 values[-1][0] += count
             else:
                 values[-1][1] += count
@@ -336,9 +334,8 @@ def get_parities_from_measurements(
             marked_qubits_term1 = [op[0] for op in term1]
             marked_qubits_term2 = [op[0] for op in term2]
             for bitstring, count in bitstring_frequencies.items():
-                bitstring_int = convert_bitstring_to_int(bitstring)
-                parity1 = parity_even_p(bitstring_int, marked_qubits_term1)
-                parity2 = parity_even_p(bitstring_int, marked_qubits_term2)
+                parity1 = check_parity(bitstring, marked_qubits_term1)
+                parity2 = check_parity(bitstring, marked_qubits_term2)
                 if parity1 == parity2:
                     correlations[0][term1_index, term2_index][0] += count
                 else:
@@ -387,7 +384,7 @@ def check_parity(bitstring: Union[str, Tuple[int]], marked_qubits: Tuple[int]) -
     """Determine if the marked qubits have even parity for the given bitstring.
 
     Args:
-        bitstring: The bitstring.
+        bitstring: The bitstring, either as a tuple or little endian string.
         marked_qubits: The qubits whose parity is to be determined.
 
     Returns:
@@ -418,8 +415,7 @@ def get_expectation_value_from_frequencies(
     expectation = 0
     num_measurements = sum(bitstring_frequencies.values())
     for bitstring, count in bitstring_frequencies.items():
-        bitstring_int = convert_bitstring_to_int(bitstring)
-        if parity_even_p(bitstring_int, marked_qubits):
+        if check_parity(bitstring, marked_qubits):
             value = float(count) / num_measurements
         else:
             value = -float(count) / num_measurements

--- a/src/python/zquantum/core/measurement.py
+++ b/src/python/zquantum/core/measurement.py
@@ -383,8 +383,26 @@ def convert_bitstring_to_int(bitstring: Iterable[int]) -> int:
     return int("".join(str(bit) for bit in bitstring[::-1]), 2)
 
 
+def check_parity(bitstring: str, marked_qubits: Tuple[int]) -> bool:
+    """Determine if the marked qubits have even parity for the given bitstring.
+
+    Args:
+        bitstring: The bitstring.
+        marked_qubits: The qubits whose parity is to be determined.
+
+    Returns:
+        True if an even number of the marked qubits are in the 1 state, False
+            otherwise.
+    """
+    result = True
+    for qubit_index in marked_qubits:
+        if bitstring[qubit_index] == "1":
+            result = not result
+    return result
+
+
 def get_expectation_value_from_frequencies(
-    marked_qubits: Tuple[int], bitstring_frequencies: dict[str, int]
+    marked_qubits: Tuple[int], bitstring_frequencies: Dict[str, int]
 ) -> float:
     """Get the expectation value the product of Z operators on selected qubits
     from bitstring frequencies.

--- a/src/python/zquantum/core/measurement.py
+++ b/src/python/zquantum/core/measurement.py
@@ -383,7 +383,7 @@ def convert_bitstring_to_int(bitstring: Iterable[int]) -> int:
     return int("".join(str(bit) for bit in bitstring[::-1]), 2)
 
 
-def check_parity(bitstring: str, marked_qubits: Tuple[int]) -> bool:
+def check_parity(bitstring: Union[str, Tuple[int]], marked_qubits: Tuple[int]) -> bool:
     """Determine if the marked qubits have even parity for the given bitstring.
 
     Args:
@@ -396,7 +396,7 @@ def check_parity(bitstring: str, marked_qubits: Tuple[int]) -> bool:
     """
     result = True
     for qubit_index in marked_qubits:
-        if bitstring[qubit_index] == "1":
+        if bitstring[qubit_index] == "1" or bitstring[qubit_index] == 1:
             result = not result
     return result
 

--- a/src/python/zquantum/core/measurement_test.py
+++ b/src/python/zquantum/core/measurement_test.py
@@ -18,6 +18,7 @@ from .measurement import (
     get_expectation_values_from_parities,
     expectation_values_to_real,
     convert_bitstring_to_int,
+    check_parity,
     get_expectation_value_from_frequencies,
     Measurements,
     concatenate_expectation_values,

--- a/src/python/zquantum/core/measurement_test.py
+++ b/src/python/zquantum/core/measurement_test.py
@@ -179,15 +179,20 @@ class TestMeasurement(unittest.TestCase):
         self.assertEqual(len(expectation_values.estimator_covariances), 3)
         self.assertTrue(
             np.allclose(
-                expectation_values.estimator_covariances[0], np.array([[0.014705882352941176]])
+                expectation_values.estimator_covariances[0],
+                np.array([[0.014705882352941176]]),
             )
         )
         self.assertTrue(
-            np.allclose(expectation_values.estimator_covariances[1], np.array([[0.00428797]]))
+            np.allclose(
+                expectation_values.estimator_covariances[1], np.array([[0.00428797]])
+            )
         )
 
         self.assertTrue(
-            np.allclose(expectation_values.estimator_covariances[2], np.array([[0.0075706]]))
+            np.allclose(
+                expectation_values.estimator_covariances[2], np.array([[0.0075706]])
+            )
         )
 
     def test_expectation_values_to_real(self):
@@ -211,13 +216,23 @@ class TestMeasurement(unittest.TestCase):
         bitstring = (0, 1, 0, 1, 0, 1)
         self.assertEqual(convert_bitstring_to_int(bitstring), 42)
 
-    def test_check_parity_odd(self):
+    def test_check_parity_odd_string(self):
         bitstring = "01001"
         marked_qubits = (1, 2, 3)
         self.assertFalse(check_parity(bitstring, marked_qubits))
 
-    def test_check_parity_even(self):
+    def test_check_parity_even_string(self):
         bitstring = "01101"
+        marked_qubits = (1, 2, 3)
+        self.assertTrue(check_parity(bitstring, marked_qubits))
+
+    def test_check_parity_odd_tuple(self):
+        bitstring = (0, 1, 0, 0, 1)
+        marked_qubits = (1, 2, 3)
+        self.assertFalse(check_parity(bitstring, marked_qubits))
+
+    def test_check_parity_even_tuple(self):
+        bitstring = (0, 1, 1, 0, 1)
         marked_qubits = (1, 2, 3)
         self.assertTrue(check_parity(bitstring, marked_qubits))
 
@@ -718,7 +733,8 @@ class TestMeasurement(unittest.TestCase):
         self.assertEqual(len(combined_expectation_values.estimator_covariances), 3)
         self.assertTrue(
             np.allclose(
-                combined_expectation_values.estimator_covariances[0], [[0.1, 0.2], [0.3, 0.4]]
+                combined_expectation_values.estimator_covariances[0],
+                [[0.1, 0.2], [0.3, 0.4]],
             )
         )
         self.assertTrue(

--- a/src/python/zquantum/core/measurement_test.py
+++ b/src/python/zquantum/core/measurement_test.py
@@ -211,6 +211,16 @@ class TestMeasurement(unittest.TestCase):
         bitstring = (0, 1, 0, 1, 0, 1)
         self.assertEqual(convert_bitstring_to_int(bitstring), 42)
 
+    def test_check_parity_odd(self):
+        bitstring = "01001"
+        marked_qubits = (1, 2, 3)
+        self.assertFalse(check_parity(bitstring, marked_qubits))
+
+    def test_check_parity_even(self):
+        bitstring = "01101"
+        marked_qubits = (1, 2, 3)
+        self.assertTrue(check_parity(bitstring, marked_qubits))
+
     def test_get_expectation_value_from_frequencies(self):
         bitstrings = ["001", "001", "110", "000"]
         bitstring_frequencies = dict(Counter(bitstrings))

--- a/src/python/zquantum/core/utils.py
+++ b/src/python/zquantum/core/utils.py
@@ -227,7 +227,8 @@ def convert_bitstrings_to_tuples(bitstrings):
 
 
 def convert_tuples_to_bitstrings(tuples):
-    """Given a set of measurement tuples, convert each to bitstring format
+    """Given a set of measurement tuples, convert each to a little endian
+    string.
 
     Args:
         tuples (list of tuples): the measurement tuples

--- a/src/setup.py
+++ b/src/setup.py
@@ -26,7 +26,6 @@ setuptools.setup(
         "pyquil>=2.17.0",
         "cirq>=0.9.0",
         "qiskit==0.18.3",
-        "quantum-grove>=1.0.0",
         "overrides>=3.1.0",
     ],
 )


### PR DESCRIPTION
This PR removes grove as a dependency, since it was only being used for one small function. Note that although I removed grove from the `z-quantum-default` dockerfile, the dockerfile currently does not build for unrelated reasons.