### PR TITLE
julia v1.5 dockerfile

### DIFF
--- a/docker/z-quantum-julia/Dockerfile
+++ b/docker/z-quantum-julia/Dockerfile
@@ -1,10 +1,15 @@
 # Dockerfile for the default OpenPack docker image
 FROM zapatacomputing/z-quantum-default:latest
 
+ARG JULIA_MINOR_VERSION=1.5
+ARG JULIA_PATCH_VERSION=1.5.3
+WORKDIR /root
+
 # get julia
-RUN wget https://julialang-s3.julialang.org/bin/linux/x64/1.3/julia-1.3.0-linux-x86_64.tar.gz && \
-    tar xf julia-1.3.0-linux-x86_64.tar.gz && \
-    ln -s ~/julia-1.3.0/bin/julia /usr/local/bin/julia
+RUN wget https://julialang-s3.julialang.org/bin/linux/x64/${JULIA_MINOR_VERSION}/julia-${JULIA_PATCH_VERSION}-linux-x86_64.tar.gz && \
+    tar xf julia-${JULIA_PATCH_VERSION}-linux-x86_64.tar.gz && \
+    ln -s /root/julia-${JULIA_PATCH_VERSION}/bin/julia /usr/local/bin/julia && \
+    rm julia-${JULIA_PATCH_VERSION}-linux-x86_64.tar.gz
     
 WORKDIR /app
 ENTRYPOINT bash


### PR DESCRIPTION
Bumping Julia to v1.5 and fixing the symlink. Julia is now installed in /root rather than /app, in line with what z-quantum-default does.

FIRST ZAPATA PR
![](https://i.imgur.com/7drHiqr.gif)
