### PR TITLE
Reworked gates representation

### DIFF
--- a/src/python/zquantum/core/circuit/gates/_gate.py
+++ b/src/python/zquantum/core/circuit/gates/_gate.py
@@ -1,5 +1,6 @@
 """Base classes for implementing quantum gates."""
 from abc import abstractmethod, ABC
+import inspect
 import numpy as np
 import sympy
 import json
@@ -219,6 +220,24 @@ class Gate(ABC):
     def evaluate(self, symbols_map: Dict[str, Any]) -> "Gate":
         new_params = [_evaluate_parameter(param, symbols_map) for param in self.params]
         return type(self)(*self.qubits, *new_params)
+
+    def __str__(self):
+        args_reprs = [str(qubit) for qubit in self.qubits]
+        if self.params:
+            param_names = [
+                param.name
+                for param in inspect.signature(self.__init__).parameters.values()
+            ][-len(self.params):]
+
+            args_reprs += [
+                f"{param_name}={param_value}".replace(" ", "")
+                for param_name, param_value in zip(param_names, self.params)
+            ]
+
+        return f"{type(self).__name__}({', '.join(args_reprs)})"
+
+    def __repr__(self):
+        return str(self)
 
 
 class CustomGate(Gate):

--- a/src/python/zquantum/core/circuit/gates/_gate.py
+++ b/src/python/zquantum/core/circuit/gates/_gate.py
@@ -227,7 +227,7 @@ class Gate(ABC):
             param_names = [
                 param.name
                 for param in inspect.signature(self.__init__).parameters.values()
-            ][-len(self.params):]
+            ][-len(self.params) :]
 
             args_reprs += [
                 f"{param_name}={param_value}".replace(" ", "")

--- a/src/python/zquantum/core/circuit/gates/_single_qubit_gates_test.py
+++ b/src/python/zquantum/core/circuit/gates/_single_qubit_gates_test.py
@@ -252,7 +252,6 @@ class TestEvaluationOfSingleQubitGates:
 
 
 class TestStringRepresentationOfSingleQubitGates:
-
     @pytest.mark.parametrize(
         "gate, expected_representation",
         [
@@ -266,13 +265,11 @@ class TestStringRepresentationOfSingleQubitGates:
             (H(3), "H(3)"),
             (T(0), "T(0)"),
             (I(1), "I(1)"),
-            (I(5), "I(5)")
-        ]
+            (I(5), "I(5)"),
+        ],
     )
-    def test_representation_of_single_qubit_nonparametric_gates_looks_like_initiizer_call(
-        self,
-        gate,
-        expected_representation
+    def test_representation_of_single_qubit_nonparametric_gates_looks_like_initializer_call(
+        self, gate, expected_representation
     ):
         assert str(gate) == repr(gate) == expected_representation
 
@@ -283,12 +280,10 @@ class TestStringRepresentationOfSingleQubitGates:
             (RX(0, sympy.Symbol("x") + sympy.Symbol("y")), "RX(0, angle=x+y)"),
             (RY(1, sympy.Symbol("theta")), "RY(1, angle=theta)"),
             (RZ(2, sympy.Symbol("phi")), "RZ(2, angle=phi)"),
-            (RZ(3, np.pi), f"RZ(3, angle={np.pi})")
-        ]
+            (RZ(3, np.pi), f"RZ(3, angle={np.pi})"),
+        ],
     )
     def test_representation_of_single_qubit_rotations_looks_like_initializer_call_with_keyword_angle(
-        self,
-        gate,
-        expected_representation
+        self, gate, expected_representation
     ):
         assert str(gate) == repr(gate) == expected_representation

--- a/src/python/zquantum/core/circuit/gates/_single_qubit_gates_test.py
+++ b/src/python/zquantum/core/circuit/gates/_single_qubit_gates_test.py
@@ -249,3 +249,46 @@ class TestEvaluationOfSingleQubitGates:
         )
 
         assert gate.evaluate(symbol_map).params == expected_params
+
+
+class TestStringRepresentationOfSingleQubitGates:
+
+    @pytest.mark.parametrize(
+        "gate, expected_representation",
+        [
+            (X(0), "X(0)"),
+            (X(2), "X(2)"),
+            (Y(1), "Y(1)"),
+            (Y(3), "Y(3)"),
+            (Z(0), "Z(0)"),
+            (Z(1), "Z(1)"),
+            (H(2), "H(2)"),
+            (H(3), "H(3)"),
+            (T(0), "T(0)"),
+            (I(1), "I(1)"),
+            (I(5), "I(5)")
+        ]
+    )
+    def test_representation_of_single_qubit_nonparametric_gates_looks_like_initiizer_call(
+        self,
+        gate,
+        expected_representation
+    ):
+        assert str(gate) == repr(gate) == expected_representation
+
+    @pytest.mark.parametrize(
+        "gate, expected_representation",
+        [
+            (RX(0, 0.5), "RX(0, angle=0.5)"),
+            (RX(0, sympy.Symbol("x") + sympy.Symbol("y")), "RX(0, angle=x+y)"),
+            (RY(1, sympy.Symbol("theta")), "RY(1, angle=theta)"),
+            (RZ(2, sympy.Symbol("phi")), "RZ(2, angle=phi)"),
+            (RZ(3, np.pi), f"RZ(3, angle={np.pi})")
+        ]
+    )
+    def test_representation_of_single_qubit_rotations_looks_like_initializer_call_with_keyword_angle(
+        self,
+        gate,
+        expected_representation
+    ):
+        assert str(gate) == repr(gate) == expected_representation

--- a/src/python/zquantum/core/circuit/gates/_two_qubit_gates.py
+++ b/src/python/zquantum/core/circuit/gates/_two_qubit_gates.py
@@ -9,7 +9,7 @@ class TwoQubitRotationGate(SpecializedGate, ABC):
         self,
         first_qubit: int,
         second_qubit: int,
-        angle: Union[float, sympy.Symbol] = sympy.Symbol("theta"),
+        angle: Union[float, sympy.Expr] = sympy.Symbol("theta"),
     ):
         super().__init__((first_qubit, second_qubit))
         self.angle = angle
@@ -40,7 +40,7 @@ class CPHASE(ControlledGate):
         self,
         control: int,
         target: int,
-        angle: Union[float, sympy.Symbol] = sympy.Symbol("theta"),
+        angle: Union[float, sympy.Expr] = sympy.Symbol("theta"),
     ):
         super().__init__(PHASE(target, angle), control)
         self.angle = angle

--- a/src/python/zquantum/core/circuit/gates/_two_qubit_gates_test.py
+++ b/src/python/zquantum/core/circuit/gates/_two_qubit_gates_test.py
@@ -97,3 +97,38 @@ def test_nonparametric_two_qubit_gates_have_no_params(gate_cls):
 @pytest.mark.parametrize("angle", [sympy.Symbol("alpha"), np.pi / 2])
 def test_rotation_gates_have_a_single_parameter_equal_to_their_angle(gate_cls, angle):
     assert gate_cls(1, 4, angle).params == (angle,)
+
+
+class TestStringRepresentationOfTwoQubitGates:
+
+    @pytest.mark.parametrize(
+        "gate, expected_representation",
+        [
+            (SWAP(0, 1), "SWAP(0, 1)"),
+            (CZ(4, 2), "CZ(4, 2)"),
+            (CNOT(1, 3), "CNOT(1, 3)")
+        ]
+    )
+    def test_representation_of_two_qubit_nonparametric_gates_looks_like_initiizer_call(
+        self, gate, expected_representation
+    ):
+        assert str(gate) == repr(gate) == expected_representation
+
+
+    @pytest.mark.parametrize(
+        "gate, expected_representation",
+        [
+            (XX(0, 1), "XX(0, 1, angle=theta)"),
+            (XX(1, 2, sympy.pi), "XX(1, 2, angle=pi)"),
+            (YY(0, 1, sympy.pi / 2), "YY(0, 1, angle=pi/2)"),
+            (YY(3, 1, 0.1), f"YY(3, 1, angle={0.1})"),
+            (ZZ(4, 0, sympy.Symbol("x") + sympy.Symbol("y")), "ZZ(4, 0, angle=x+y)"),
+            (ZZ(0, 1, np.pi / 4), f"ZZ(0, 1, angle={np.pi/4})"),
+            (CPHASE(0, 1, np.pi / 5), f"CPHASE(0, 1, angle={np.pi/5})"),
+            (CPHASE(4, 1, sympy.cos(sympy.Symbol("x"))), f"CPHASE(4, 1, angle=cos(x))")
+        ]
+    )
+    def test_representation_of_two_qubit_rotations_looks_like_initializer_call_with_keyword_angle(
+        self, gate, expected_representation
+    ):
+        assert str(gate) == repr(gate) == expected_representation

--- a/src/python/zquantum/core/circuit/gates/_two_qubit_gates_test.py
+++ b/src/python/zquantum/core/circuit/gates/_two_qubit_gates_test.py
@@ -100,20 +100,18 @@ def test_rotation_gates_have_a_single_parameter_equal_to_their_angle(gate_cls, a
 
 
 class TestStringRepresentationOfTwoQubitGates:
-
     @pytest.mark.parametrize(
         "gate, expected_representation",
         [
             (SWAP(0, 1), "SWAP(0, 1)"),
             (CZ(4, 2), "CZ(4, 2)"),
-            (CNOT(1, 3), "CNOT(1, 3)")
-        ]
+            (CNOT(1, 3), "CNOT(1, 3)"),
+        ],
     )
-    def test_representation_of_two_qubit_nonparametric_gates_looks_like_initiizer_call(
+    def test_representation_of_two_qubit_nonparametric_gates_looks_like_initializer_call(
         self, gate, expected_representation
     ):
         assert str(gate) == repr(gate) == expected_representation
-
 
     @pytest.mark.parametrize(
         "gate, expected_representation",
@@ -125,8 +123,8 @@ class TestStringRepresentationOfTwoQubitGates:
             (ZZ(4, 0, sympy.Symbol("x") + sympy.Symbol("y")), "ZZ(4, 0, angle=x+y)"),
             (ZZ(0, 1, np.pi / 4), f"ZZ(0, 1, angle={np.pi/4})"),
             (CPHASE(0, 1, np.pi / 5), f"CPHASE(0, 1, angle={np.pi/5})"),
-            (CPHASE(4, 1, sympy.cos(sympy.Symbol("x"))), f"CPHASE(4, 1, angle=cos(x))")
-        ]
+            (CPHASE(4, 1, sympy.cos(sympy.Symbol("x"))), f"CPHASE(4, 1, angle=cos(x))"),
+        ],
     )
     def test_representation_of_two_qubit_rotations_looks_like_initializer_call_with_keyword_angle(
         self, gate, expected_representation


### PR DESCRIPTION
This adds textual representation (`__str__` and `__repr__` methods) for builtin-gate classes. 

The representation should look like an initializer call, in which all gate params except qubits are passed as keyword arguments e.g. `"X(0)"`, `"XX(2, 3, angle=pi)"` etc.