### PR TITLE
Qiskit circuit translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ dmypy.json
 .pyre/
 
 # End of https://www.gitignore.io/api/python
+
+# virtual env kept in project dir
+venv

--- a/src/python/zquantum/core/wip/circuit/_circuit.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit.py
@@ -1,9 +1,9 @@
 import json
-from typing import List, Dict, Union, TextIO, Iterable, Any
+from typing import Dict, Union, TextIO, Iterable
+from functools import reduce
+
 from .gates import Gate
 from ...utils import SCHEMA_VERSION
-
-import sympy
 
 
 class Circuit:
@@ -27,17 +27,8 @@ class Circuit:
 
     @property
     def symbolic_params(self):
-        """ The set of symbolic parameters used in the circuit
-
-        Returns:
-            set: set of all the sympy symbols used as params of gates in the circuit.
-        """
-        symbolic_params = []
-        for gate in self.gates:
-            symbolic_params_per_gate = gate.symbolic_params
-            symbolic_params += symbolic_params_per_gate
-
-        return set(symbolic_params)
+        """Set of all the sympy symbols used as params of gates in the circuit."""
+        return reduce(set.union, (set(gate.symbolic_params) for gate in self._gates))
 
     def __eq__(self, other: "Circuit"):
         if not isinstance(other, type(self)):
@@ -58,8 +49,8 @@ class Circuit:
         new_circuit.gates = self.gates + other_circuit.gates
         return new_circuit
 
-    def evaluate(self, symbols_map: Dict["sympy.Symbol", Any]):
-        """Create a copy of the current Circuit with the parameters of each gate evaluated to the values
+    def evaluate(self, symbols_map: Dict):
+        """ Create a copy of the current Circuit with the parameters of each gate evaluated to the values 
         provided in the input symbols map
 
         Args:

--- a/src/python/zquantum/core/wip/circuit/_circuit.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit.py
@@ -113,3 +113,6 @@ class Circuit:
 
         gates = [Gate.load(gate_data) for gate_data in data["gates"]]
         return cls(gates=gates)
+
+    def __repr__(self):
+        return f"{type(self).__name__}(gates={self.gates}, n_qubits={self.n_qubits})"

--- a/src/python/zquantum/core/wip/circuit/_circuit.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit.py
@@ -1,46 +1,29 @@
 import json
+from typing import List, Dict, Union, TextIO, Iterable, Any
 from .gates import Gate
 from ...utils import SCHEMA_VERSION
-from typing import List, Dict, Union, TextIO, Any
 
 import sympy
 
 
-class Circuit(object):
-    """Base class for quantum circuits.
-    
-    Attributes:
-        gates (List[Gate]): The sequence of gates to be applied
-        qubits (tuple(int)): The set of qubits that the circuit acts on
-        symbolic_params (set(sympy.Symbol)): A set of the parameter names used in the circuit. If the circuit
-            does not contain parameterized gates, this value is the empty set.
-    """
+class Circuit:
+    """Orquestra representation of a quantum circuit."""
 
-    def __init__(self, gates: List[Gate] = None):
-        """Initialize a quantum circuit 
-
-        Args:
-            gates (List[Gate]): See class definition
-            qubits (tuple(int)): See class definition
-        """
-        if gates is None:
-            self.gates = []
-        else:
-            self.gates = gates
+    def __init__(self, gates: Iterable[Gate], n_qubits: int):
+        self._gates = gates
+        self._n_qubits = n_qubits
 
     @property
-    def qubits(self):
-        """ The qubits that are used by the gates in the circuit
+    def gates(self):
+        """Sequence of quantum gates to apply to qubits in this circuit."""
+        return self._gates
 
-        Returns:
-            tuple(int)
+    @property
+    def n_qubits(self):
+        """Number of qubits in this circuit.
+        Not every qubit has to be used by a gate.
         """
-        qubits = {
-            qubit
-            for gate in self.gates
-            for qubit in gate.qubits
-        }
-        return tuple(sorted(qubits))
+        return self._n_qubits
 
     @property
     def symbolic_params(self):
@@ -56,22 +39,14 @@ class Circuit(object):
 
         return set(symbolic_params)
 
-    def __eq__(self, another_circuit):
-        """Comparison between two Circuit objects.
-        """
-        # TODO: figure out if this check is redundant when reworking Circuit
-        if self.qubits != another_circuit.qubits:
+    def __eq__(self, other: "Circuit"):
+        if not isinstance(other, type(self)):
             return False
 
-        if len(self.gates) != len(another_circuit.gates):
+        if self.n_qubits != other.n_qubits:
             return False
 
-        for i in range(len(self.gates)):
-            if self.gates[i] != another_circuit.gates[i]:
-                return False
-
-        # TODO: figure out if this check is redundant when reworking Circuit
-        if len(self.symbolic_params) != len(another_circuit.symbolic_params):
+        if list(self.gates) != list(other.gates):
             return False
 
         return True

--- a/src/python/zquantum/core/wip/circuit/_circuit.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 from typing import Dict, Union, TextIO, Iterable, Optional, Any
 from functools import reduce, singledispatch
 
@@ -105,7 +104,7 @@ class Circuit:
             f.write(json.dumps(self.to_dict(), indent=2))
 
     @classmethod
-    def load(cls, data: Union[Dict, TextIO, str, Path]):
+    def load(cls, data: Union[Dict, TextIO]):
         """Load a Circuit object from either a file/file-like object or a dictionary
 
         Args:

--- a/src/python/zquantum/core/wip/circuit/_circuit.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit.py
@@ -1,17 +1,27 @@
 import json
-from typing import Dict, Union, TextIO, Iterable
+from typing import Dict, Union, TextIO, Iterable, Optional
 from functools import reduce
 
 from .gates import Gate
 from ...utils import SCHEMA_VERSION
 
 
+def _circuit_size_by_gates(gates):
+    return (
+        0
+        if not gates
+        else max(qubit_index for gate in gates for qubit_index in gate.qubits) + 1
+    )
+
+
 class Circuit:
     """Orquestra representation of a quantum circuit."""
 
-    def __init__(self, gates: Iterable[Gate], n_qubits: int):
+    def __init__(self, gates: Iterable[Gate], n_qubits: Optional[int] = None):
         self._gates = gates
-        self._n_qubits = n_qubits
+        self._n_qubits = (
+            n_qubits if n_qubits is not None else _circuit_size_by_gates(gates)
+        )
 
     @property
     def gates(self):

--- a/src/python/zquantum/core/wip/circuit/_circuit.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit.py
@@ -24,9 +24,9 @@ class Circuit:
     """Orquestra representation of a quantum circuit."""
 
     def __init__(self, gates: Iterable[Gate], n_qubits: Optional[int] = None):
-        self._gates = gates
+        self._gates = list(gates)
         self._n_qubits = (
-            n_qubits if n_qubits is not None else _circuit_size_by_gates(gates)
+            n_qubits if n_qubits is not None else _circuit_size_by_gates(self._gates)
         )
 
     @property

--- a/src/python/zquantum/core/wip/circuit/_circuit.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit.py
@@ -38,7 +38,7 @@ class Circuit:
     @property
     def symbolic_params(self):
         """Set of all the sympy symbols used as params of gates in the circuit."""
-        return reduce(set.union, (set(gate.symbolic_params) for gate in self._gates))
+        return reduce(set.union, (set(gate.symbolic_params) for gate in self._gates), set())
 
     def __eq__(self, other: "Circuit"):
         if not isinstance(other, type(self)):
@@ -58,7 +58,7 @@ class Circuit:
         new_circuit.gates = self.gates + other_circuit.gates
         return new_circuit
 
-    def evaluate(self, symbols_map: Dict):
+    def evaluate(self, symbols_map: Dict["sympy.Symbol", Any]):
         """Create a copy of the current Circuit with the parameters of each gate evaluated to the values
         provided in the input symbols map
 

--- a/src/python/zquantum/core/wip/circuit/_circuit.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit.py
@@ -2,6 +2,8 @@ import json
 from typing import Dict, Union, TextIO, Iterable, Optional, Any
 from functools import reduce, singledispatch
 
+import sympy
+
 from .gates import Gate
 from ...utils import SCHEMA_VERSION
 
@@ -55,11 +57,10 @@ class Circuit:
 
         return True
 
-
     def __add__(self, other: Union["Circuit"]):
         return _append_to_circuit(other, self)
 
-    def evaluate(self, symbols_map: Dict["sympy.Symbol", Any]):
+    def evaluate(self, symbols_map: Dict[sympy.Symbol, Any]):
         """Create a copy of the current Circuit with the parameters of each gate evaluated to the values
         provided in the input symbols map
 
@@ -89,7 +90,7 @@ class Circuit:
                 str(param) for param in self.symbolic_params
             ],
             "gates": [
-                gate.to_dict(serializable=True) for gate in self.gates
+                gate.to_dict() for gate in self.gates
             ],
         }
 

--- a/src/python/zquantum/core/wip/circuit/_circuit.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit.py
@@ -43,14 +43,13 @@ class Circuit:
         return True
 
     def __add__(self, other_circuit):
-        """Add two circuits.
-        """
+        """Add two circuits."""
         new_circuit = type(self)()
         new_circuit.gates = self.gates + other_circuit.gates
         return new_circuit
 
     def evaluate(self, symbols_map: Dict):
-        """ Create a copy of the current Circuit with the parameters of each gate evaluated to the values 
+        """Create a copy of the current Circuit with the parameters of each gate evaluated to the values
         provided in the input symbols map
 
         Args:
@@ -62,7 +61,7 @@ class Circuit:
         return evaluated_circuit
 
     def to_dict(self, serializable: bool = True):
-        """ Creates a dictionary representing a circuit.
+        """Creates a dictionary representing a circuit.
 
         Args:
             serializable (bool): If true, the returned dictionary is serializable so that it can be stored
@@ -88,7 +87,7 @@ class Circuit:
         return circuit_dict
 
     def save(self, filename: str):
-        """ Save the Circuit object to file in JSON format
+        """Save the Circuit object to file in JSON format
 
         Args:
             filename (str): The path to the file to store the Circuit
@@ -98,7 +97,7 @@ class Circuit:
 
     @classmethod
     def load(cls, data: Union[Dict, TextIO]):
-        """ Load a Circuit object from either a file/file-like object or a dictionary
+        """Load a Circuit object from either a file/file-like object or a dictionary
 
         Args:
             data (Union[Dict, TextIO]): The data to load into the Circuit object

--- a/src/python/zquantum/core/wip/circuit/_circuit.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit.py
@@ -20,7 +20,7 @@ CIRCUIT_SCHEMA = SCHEMA_VERSION + "-circuit"
 
 
 class Circuit:
-    """Orquestra representation of a quantum circuit."""
+    """ZQuantum representation of a quantum circuit."""
 
     def __init__(self, gates: Optional[Iterable[Gate]] = None, n_qubits: Optional[int] = None):
         self._gates = list(gates) if gates is not None else []

--- a/src/python/zquantum/core/wip/circuit/_circuit.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit.py
@@ -23,8 +23,8 @@ CIRCUIT_SCHEMA = SCHEMA_VERSION + "-circuit"
 class Circuit:
     """Orquestra representation of a quantum circuit."""
 
-    def __init__(self, gates: Iterable[Gate], n_qubits: Optional[int] = None):
-        self._gates = list(gates)
+    def __init__(self, gates: Optional[Iterable[Gate]] = None, n_qubits: Optional[int] = None):
+        self._gates = list(gates) if gates is not None else []
         self._n_qubits = (
             n_qubits if n_qubits is not None else _circuit_size_by_gates(self._gates)
         )

--- a/src/python/zquantum/core/wip/circuit/_circuit.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit.py
@@ -70,31 +70,27 @@ class Circuit:
         evaluated_circuit = circuit_class(gates=evaluated_gate_list)
         return evaluated_circuit
 
-    def to_dict(self, serializable: bool = True):
+    def to_dict(self):
         """Creates a dictionary representing a circuit.
+        The dictionary is serializable to JSON.
 
-        Args:
-            serializable (bool): If true, the returned dictionary is serializable so that it can be stored
-                in JSON format
         Returns:
-            Dict: keys are schema, qubits, gates, and symbolic_params
+            A mapping with keys:
+                - "schema"
+                - "n_qubits"
+                - "symbolic_params"
+                - "gates"
         """
-        circuit_dict = {"schema": SCHEMA_VERSION + "-circuit"}
-        if serializable:
-            circuit_dict["qubits"] = list(self.qubits)
-            circuit_dict["gates"] = [
-                gate.to_dict(serializable=True) for gate in self.gates
-            ]
-            circuit_dict["symbolic_params"] = [
+        return {
+            "schema": CIRCUIT_SCHEMA,
+            "n_qubits": self.n_qubits,
+            "symbolic_params": [
                 str(param) for param in self.symbolic_params
-            ]
-        else:
-            circuit_dict["qubits"] = self.qubits
-            circuit_dict["gates"] = [
-                gate.to_dict(serializable=False) for gate in self.gates
-            ]
-            circuit_dict["symbolic_params"] = self.symbolic_params
-        return circuit_dict
+            ],
+            "gates": [
+                gate.to_dict(serializable=True) for gate in self.gates
+            ],
+        }
 
     def save(self, filename: str):
         """Save the Circuit object to file in JSON format
@@ -103,7 +99,7 @@ class Circuit:
             filename (str): The path to the file to store the Circuit
         """
         with open(filename, "w") as f:
-            f.write(json.dumps(self.to_dict(serializable=True), indent=2))
+            f.write(json.dumps(self.to_dict(), indent=2))
 
     @classmethod
     def load(cls, data: Union[Dict, TextIO]):

--- a/src/python/zquantum/core/wip/circuit/_circuit.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from typing import Dict, Union, TextIO, Iterable, Optional, Any
 from functools import reduce, singledispatch
 
@@ -104,7 +105,7 @@ class Circuit:
             f.write(json.dumps(self.to_dict(), indent=2))
 
     @classmethod
-    def load(cls, data: Union[Dict, TextIO]):
+    def load(cls, data: Union[Dict, TextIO, str, Path]):
         """Load a Circuit object from either a file/file-like object or a dictionary
 
         Args:

--- a/src/python/zquantum/core/wip/circuit/_circuit_test.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import numpy.random
 import pytest
 import json
 import os
@@ -142,6 +143,10 @@ RandomGateList = [
     CustomParameterizedGate,
 ]
 
+
+RNG = np.random.default_rng(42)
+
+
 CIRCUITS = [
     Circuit(gates=[]),
     Circuit(gates=[X(0)]),
@@ -166,13 +171,14 @@ CIRCUITS = [
         ]
     ),
     Circuit(gates=[I(0) for _ in range(100)]),
-    Circuit(gates=[random.choice(RandomGateList) for _ in range(100)]),
-    Circuit(gates=[random.choice(RandomGateList) for _ in range(1000)]),
-    Circuit(gates=[random.choice(RandomGateList) for _ in range(10000)]),
+    Circuit(gates=list(RNG.choice(RandomGateList, size=100, replace=True))),
+    Circuit(gates=list(RNG.choice(RandomGateList, size=1000, replace=True))),
 ]
 
 
 #### __init__ ####
+
+
 @pytest.mark.parametrize(
     "gates",
     [

--- a/src/python/zquantum/core/wip/circuit/_circuit_test.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit_test.py
@@ -213,29 +213,25 @@ def test_appending_to_circuit_works():
 
 
 #### qubits ####
+
+
 @pytest.mark.parametrize(
-    "gates, qubits",
+    "gates, n_qubits",
     [
-        ([], tuple()),
-        ([X(0)], (0,)),
-        ([X(1)], (1,)),
-        (
-            [X(0), X(1)],
-            (
-                0,
-                1,
-            ),
-        ),
-        ([CNOT(0, 1)], (0, 1)),
-        ([X(0), X(0), CNOT(0, 1), X(0)], (0, 1)),
+        ([], 0),
+        ([X(0)], 1),
+        ([X(1)], 2),
+        ([X(0), X(1)], 2),
+        ([CNOT(0, 1)], 2),
+        ([X(0), X(0), CNOT(0, 1), X(0)], 2),
     ],
 )
-def test_creating_circuit_has_correct_qubits(gates, qubits):
+def test_creating_circuit_has_correct_number_of_qubits(gates, n_qubits):
     """The Circuit class should have the correct qubits based on the gates that are passed in"""
     # When
     circuit = Circuit(gates=gates)
     # Then
-    assert circuit.qubits == qubits
+    assert circuit.n_qubits == n_qubits
 
 
 def test_creating_circuit_has_correct_qubits_with_gaps():
@@ -695,11 +691,11 @@ def test_gate_is_successfully_converted_to_serializable_dict_form(circuit):
     """The Circuit class should be able to be converted to a serializable dict with the underlying gates
     also converted to serializable dictionaries"""
     # When
-    circuit_dict = circuit.to_dict(serializable=True)
+    circuit_dict = circuit.to_dict()
 
     # Then
     assert circuit_dict["schema"] == SCHEMA_VERSION + "-circuit"
-    assert circuit_dict["qubits"] == list(circuit.qubits)
+    assert circuit_dict["n_qubits"] == circuit.n_qubits
     assert circuit_dict["symbolic_params"] == [
         str(param) for param in circuit.symbolic_params
     ]
@@ -718,7 +714,7 @@ def test_circuit_is_successfully_saved_to_a_file(circuit):
 
     # Then
     assert saved_data["schema"] == SCHEMA_VERSION + "-circuit"
-    assert saved_data["qubits"] == list(circuit.qubits)
+    assert saved_data["n_qubits"] == circuit.n_qubits
     assert saved_data["gates"] == [
         gate.to_dict(serializable=True) for gate in circuit.gates
     ]
@@ -745,10 +741,9 @@ def test_circuit_is_successfully_loaded_from_a_file(circuit):
 
 
 @pytest.mark.parametrize("circuit", CIRCUITS)
-@pytest.mark.parametrize("serializable", [True, False])
-def test_circuit_is_successfully_loaded_from_a_dict(circuit, serializable):
+def test_circuit_is_successfully_loaded_from_a_dict(circuit):
     # Given
-    circuit_dict = circuit.to_dict(serializable=serializable)
+    circuit_dict = circuit.to_dict()
 
     # When
     new_circuit = Circuit.load(circuit_dict)

--- a/src/python/zquantum/core/wip/circuit/_circuit_test.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit_test.py
@@ -148,7 +148,7 @@ RNG = np.random.default_rng(42)
 
 
 CIRCUITS = [
-    Circuit(gates=[]),
+    Circuit(),
     Circuit(gates=[X(0)]),
     Circuit(gates=[X(1)]),
     Circuit(gates=[X(0), X(1)]),
@@ -204,7 +204,7 @@ def test_appending_to_circuit_works():
     # Given
     expected_circuit = Circuit(gates=[H(0), CNOT(0, 1)])
     # When
-    circuit = Circuit(gates=[])
+    circuit = Circuit()
     circuit += H(0)
     circuit += CNOT(0, 1)
     # Then
@@ -354,8 +354,8 @@ def test_symbolic_params_are_correct_for_multiple_gates_with_overlapping_paramet
     "circuit1, circuit2",
     [
         [
-            Circuit(gates=[]),
-            Circuit(gates=[]),
+            Circuit(),
+            Circuit(),
         ],
         [
             Circuit(gates=[X(0), H(0), CNOT(0, 1)]),
@@ -393,12 +393,12 @@ def test_circuit_eq_same_gates(circuit1, circuit2):
     "circuit1, circuit2",
     [
         [
-            Circuit(gates=[]),
+            Circuit(),
             Circuit(gates=[H(0)]),
         ],
         [
             Circuit(gates=[H(0)]),
-            Circuit(gates=[]),
+            Circuit(),
         ],
         [
             Circuit(
@@ -494,18 +494,18 @@ def test_gate_eq_not_same_gates(circuit1, circuit2):
     "circuit1, circuit2, expected_circuit",
     [
         [
-            Circuit(gates=[]),
+            Circuit(),
             Circuit(gates=[H(0)]),
             Circuit(gates=[H(0)]),
         ],
         [
-            Circuit(gates=[]),
-            Circuit(gates=[]),
-            Circuit(gates=[]),
+            Circuit(),
+            Circuit(),
+            Circuit(),
         ],
         [
             Circuit(gates=[H(0)]),
-            Circuit(gates=[]),
+            Circuit(),
             Circuit(gates=[H(0)]),
         ],
         [

--- a/src/python/zquantum/core/wip/circuit/_circuit_test.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit_test.py
@@ -584,10 +584,14 @@ def test_circuit_evaluated_with_all_params_has_no_free_params():
 @pytest.mark.xfail
 def test_circuit_evaluate_with_too_many_params_specified():
     # Given
-    symbols_map = {"theta_0": 0.5, "theta_1": 0.6, "theta_2": 0.7}
+    symbols_map = {
+        sympy.Symbol("theta_0"): 0.5,
+        sympy.Symbol("theta_1"): 0.6,
+        sympy.Symbol("theta_2"): 0.7
+    }
     RYGateQubit0 = RY(0).evaluate(symbols_map)
     RZGateQubit0 = RZ(0).evaluate(symbols_map)
-    RZGateQubit0DifferentAngle = RZ(0).evaluate({"theta_1": 0.4})
+    RZGateQubit0DifferentAngle = RZ(0).evaluate({sympy.Symbol("theta_1"): 0.4})
     circuit = Circuit(
         gates=[
             RX(0),
@@ -613,10 +617,10 @@ def test_circuit_evaluate_with_too_many_params_specified():
 
 def test_circuit_evaluate_with_some_params_specified():
     # Given
-    symbols_map = {"theta_0": 0.5}
+    symbols_map = {sympy.Symbol("theta_0"): 0.5}
     RYGateQubit0 = RY(0).evaluate(symbols_map)
     RZGateQubit0 = RZ(0).evaluate(symbols_map)
-    RZGateQubit0DifferentAngle = RZ(0).evaluate({"theta_1": 0.4})
+    RZGateQubit0DifferentAngle = RZ(0).evaluate({sympy.Symbol("theta_1"): 0.4})
     circuit = Circuit(
         gates=[
             RX(0),
@@ -643,8 +647,8 @@ def test_circuit_evaluate_with_some_params_specified():
 
 def test_circuit_evaluate_with_wrong_params():
     # Given
-    symbols_map = {"theta_2": 0.7}
-    RZGateQubit0DifferentAngle = RZ(0).evaluate({"theta_1": 0.4})
+    symbols_map = {sympy.Symbol("theta_2"): 0.7}
+    RZGateQubit0DifferentAngle = RZ(0).evaluate({sympy.Symbol("theta_1"): 0.4})
     circuit = Circuit(
         gates=[
             RX(0),

--- a/src/python/zquantum/core/wip/circuit/_circuit_test.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import numpy.random
 import pytest
 import json
 import os

--- a/src/python/zquantum/core/wip/circuit/_circuit_test.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit_test.py
@@ -171,8 +171,8 @@ CIRCUITS = [
         ]
     ),
     Circuit(gates=[I(0) for _ in range(100)]),
-    Circuit(gates=list(RNG.choice(RandomGateList, size=100, replace=True))),
-    Circuit(gates=list(RNG.choice(RandomGateList, size=1000, replace=True))),
+    Circuit(gates=RNG.choice(RandomGateList, size=100, replace=True)),
+    Circuit(gates=RNG.choice(RandomGateList, size=1000, replace=True)),
 ]
 
 

--- a/src/python/zquantum/core/wip/circuit/_circuit_test.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit_test.py
@@ -586,7 +586,7 @@ def test_circuit_evaluate_with_too_many_params_specified():
     symbols_map = {
         sympy.Symbol("theta_0"): 0.5,
         sympy.Symbol("theta_1"): 0.6,
-        sympy.Symbol("theta_2"): 0.7
+        sympy.Symbol("theta_2"): 0.7,
     }
     RYGateQubit0 = RY(0).evaluate(symbols_map)
     RZGateQubit0 = RZ(0).evaluate(symbols_map)
@@ -704,9 +704,7 @@ def test_circuit_is_successfully_saved_to_a_file(circuit):
     # Then
     assert saved_data["schema"] == SCHEMA_VERSION + "-circuit"
     assert saved_data["n_qubits"] == circuit.n_qubits
-    assert saved_data["gates"] == [
-        gate.to_dict() for gate in circuit.gates
-    ]
+    assert saved_data["gates"] == [gate.to_dict() for gate in circuit.gates]
     assert saved_data["symbolic_params"] == [
         str(param) for param in circuit.symbolic_params
     ]

--- a/src/python/zquantum/core/wip/circuit/_circuit_test.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit_test.py
@@ -673,7 +673,7 @@ def test_circuit_evaluate_with_wrong_params():
 
 
 @pytest.mark.parametrize("circuit", CIRCUITS)
-def test_gate_is_successfully_converted_to_serializable_dict_form(circuit):
+def test_gate_is_successfully_converted_to_dict_form(circuit):
     """The Circuit class should be able to be converted to a serializable dict with the underlying gates
     also converted to serializable dictionaries"""
     # When
@@ -687,7 +687,7 @@ def test_gate_is_successfully_converted_to_serializable_dict_form(circuit):
     ]
     assert isinstance(circuit_dict["gates"], list)
     for gate_dict, gate in zip(circuit_dict["gates"], circuit.gates):
-        assert gate_dict == gate.to_dict(serializable=True)
+        assert gate_dict == gate.to_dict()
 
 
 #### save ####
@@ -702,7 +702,7 @@ def test_circuit_is_successfully_saved_to_a_file(circuit):
     assert saved_data["schema"] == SCHEMA_VERSION + "-circuit"
     assert saved_data["n_qubits"] == circuit.n_qubits
     assert saved_data["gates"] == [
-        gate.to_dict(serializable=True) for gate in circuit.gates
+        gate.to_dict() for gate in circuit.gates
     ]
     assert saved_data["symbolic_params"] == [
         str(param) for param in circuit.symbolic_params

--- a/src/python/zquantum/core/wip/circuit/_circuit_test.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit_test.py
@@ -205,11 +205,11 @@ def test_appending_to_circuit_works():
     expected_circuit = Circuit(gates=[H(0), CNOT(0, 1)])
     # When
     circuit = Circuit(gates=[])
-    circuit.gates.append(H(0))
-    circuit.gates.append(CNOT(0, 1))
+    circuit += H(0)
+    circuit += CNOT(0, 1)
     # Then
     assert circuit.gates == expected_circuit.gates
-    assert circuit.qubits == expected_circuit.qubits
+    assert circuit.n_qubits == expected_circuit.n_qubits
 
 
 #### qubits ####
@@ -240,7 +240,7 @@ def test_creating_circuit_has_correct_qubits_with_gaps():
     circuit = Circuit(gates=[X(0), CNOT(0, 1), CNOT(0, 9)])
 
     # Then
-    assert circuit.qubits == (0, 1, 9)
+    assert circuit.n_qubits == 10
 
 
 #### symbolic_params ####
@@ -670,20 +670,6 @@ def test_circuit_evaluate_with_wrong_params():
 
 
 #### to_dict ####
-@pytest.mark.parametrize("circuit", CIRCUITS)
-def test_circuit_is_successfully_converted_to_dict_form(circuit):
-    """The Circuit class should be able to be converted to a dict with the underlying gates
-    also converted to dictionaries"""
-    # When
-    circuit_dict = circuit.to_dict(serializable=False)
-
-    # Then
-    assert circuit_dict["schema"] == SCHEMA_VERSION + "-circuit"
-    assert circuit_dict["qubits"] == circuit.qubits
-    assert circuit_dict["symbolic_params"] == circuit.symbolic_params
-    assert isinstance(circuit_dict["gates"], list)
-    for gate_dict, gate in zip(circuit_dict["gates"], circuit.gates):
-        assert gate_dict == gate.to_dict(serializable=False)
 
 
 @pytest.mark.parametrize("circuit", CIRCUITS)

--- a/src/python/zquantum/core/wip/circuit/conversions/cirq_conversions.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/cirq_conversions.py
@@ -146,7 +146,7 @@ def convert_to_cirq(obj):
 
 
 @convert_to_cirq.register
-def convert_orquestra_gate_to_cirq(gate: Gate) -> cirq.GateOperation:
+def convert_zquantum_gate_to_cirq(gate: Gate) -> cirq.GateOperation:
     """Convert native Orquestra get to its Cirq counterpart."""
     try:
         cirq_gate = ZQUANTUM_TO_CIRQ_MAPPING[type(gate)]
@@ -172,8 +172,8 @@ def convert_from_cirq(obj):
 
 
 @singledispatch
-def orquestra_gate_factory_from_cirq_gate(gate: cirq.Gate) -> Callable[..., Gate]:
-    """Create a function that constructs orquestra Gate based on Cirq Gate.
+def zquantum_gate_factory_from_cirq_gate(gate: cirq.Gate) -> Callable[..., Gate]:
+    """Create a function that constructs zquantum Gate based on Cirq Gate.
 
     Args:
           gate: Cirq gate to base the factory on.
@@ -184,13 +184,13 @@ def orquestra_gate_factory_from_cirq_gate(gate: cirq.Gate) -> Callable[..., Gate
     raise NotImplementedError(f"Don't know Orquestra factory for gate: {gate}.")
 
 
-@orquestra_gate_factory_from_cirq_gate.register
+@zquantum_gate_factory_from_cirq_gate.register
 def identity_gate_factory_from_cirq_identity(_gate: cirq.IdentityGate) -> Type[I]:
     return I
 
 
-@orquestra_gate_factory_from_cirq_gate.register
-def orquestra_gate_factory_from_eigengate(gate: cirq.EigenGate) -> Callable[..., Gate]:
+@zquantum_gate_factory_from_cirq_gate.register
+def zquantum_gate_factory_from_eigengate(gate: cirq.EigenGate) -> Callable[..., Gate]:
     key = (type(gate), gate.global_shift, gate.exponent)
     if key in EIGENGATE_SPECIAL_CASES:
         return EIGENGATE_SPECIAL_CASES[key]
@@ -205,7 +205,7 @@ def orquestra_gate_factory_from_eigengate(gate: cirq.EigenGate) -> Callable[...,
 
 
 @convert_from_cirq.register
-def convert_cirq_gate_operation_to_orquestra_gate(
+def convert_cirq_gate_operation_to_zquantum_gate(
     operation: cirq.GateOperation,
 ) -> Gate:
     """Convert Cirq GateOperation to native Orquestra Gate.
@@ -229,7 +229,7 @@ def convert_cirq_gate_operation_to_orquestra_gate(
             "gate operations with LineQubits."
         )
 
-    orquestra_gate_factory = orquestra_gate_factory_from_cirq_gate(operation.gate)
-    orquestra_qubits = [qubit.x for qubit in operation.qubits]
+    zquantum_gate_factory = zquantum_gate_factory_from_cirq_gate(operation.gate)
+    zquantum_qubits = [qubit.x for qubit in operation.qubits]
 
-    return orquestra_gate_factory(*orquestra_qubits)
+    return zquantum_gate_factory(*zquantum_qubits)

--- a/src/python/zquantum/core/wip/circuit/conversions/cirq_conversions.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/cirq_conversions.py
@@ -59,7 +59,7 @@ def make_rotation_factory(
 
 # Mapping between Orquestra gate classes and Cirq gates.
 # Note that not all gates are included, those require special treatment.
-ORQUESTRA_TO_CIRQ_MAPPING = {
+ZQUANTUM_TO_CIRQ_MAPPING = {
     X: cirq.X,
     Y: cirq.Y,
     Z: cirq.Z,
@@ -149,7 +149,7 @@ def convert_to_cirq(obj):
 def convert_orquestra_gate_to_cirq(gate: Gate) -> cirq.GateOperation:
     """Convert native Orquestra get to its Cirq counterpart."""
     try:
-        cirq_gate = ORQUESTRA_TO_CIRQ_MAPPING[type(gate)]
+        cirq_gate = ZQUANTUM_TO_CIRQ_MAPPING[type(gate)]
         if gate.params:
             cirq_gate = cirq_gate(*gate.params)
         return cirq_gate(*(cirq.LineQubit(qubit) for qubit in gate.qubits))

--- a/src/python/zquantum/core/wip/circuit/conversions/cirq_conversions.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/cirq_conversions.py
@@ -57,7 +57,7 @@ def make_rotation_factory(
     return _rotation
 
 
-# Mapping between Orquestra gate classes and Cirq gates.
+# Mapping between ZQuantum gate classes and Cirq gates.
 # Note that not all gates are included, those require special treatment.
 ZQUANTUM_TO_CIRQ_MAPPING = {
     X: cirq.X,
@@ -138,7 +138,7 @@ def angle_to_exponent(angle: Param) -> Param:
 
 @singledispatch
 def convert_to_cirq(obj):
-    """Convert native Orquestra object to its closest Cirq counterpart.
+    """Convert native ZQuantum object to its closest Cirq counterpart.
 
     TODO: add longer description once all conversions are done.
     """
@@ -147,7 +147,7 @@ def convert_to_cirq(obj):
 
 @convert_to_cirq.register
 def convert_zquantum_gate_to_cirq(gate: Gate) -> cirq.GateOperation:
-    """Convert native Orquestra get to its Cirq counterpart."""
+    """Convert native ZQuantum get to its Cirq counterpart."""
     try:
         cirq_gate = ZQUANTUM_TO_CIRQ_MAPPING[type(gate)]
         if gate.params:
@@ -155,19 +155,19 @@ def convert_zquantum_gate_to_cirq(gate: Gate) -> cirq.GateOperation:
         return cirq_gate(*(cirq.LineQubit(qubit) for qubit in gate.qubits))
     except KeyError:
         raise NotImplementedError(
-            f"Cannot convert Orquestra gate {gate} to cirq. This is probably a bug, "
-            "please reach out to the Orquestra support."
+            f"Cannot convert ZQuantum gate {gate} to cirq. This is probably a bug, "
+            "please reach out to the ZQuantum support."
         )
 
 
 @singledispatch
 def convert_from_cirq(obj):
-    """Convert Cirq object to its closes Orquestra counterpart.
+    """Convert Cirq object to its closes ZQuantum counterpart.
 
     TODO: add longer description once all conversions are done.
     """
     raise NotImplementedError(
-        f"Conversion from cirq to Orquestra not supported for {obj}."
+        f"Conversion from cirq to ZQuantum not supported for {obj}."
     )
 
 
@@ -181,7 +181,7 @@ def zquantum_gate_factory_from_cirq_gate(gate: cirq.Gate) -> Callable[..., Gate]
           function of the form f(*qubits) -> Gate. For most variants of this
           function those will be just respective classes initializers.
     """
-    raise NotImplementedError(f"Don't know Orquestra factory for gate: {gate}.")
+    raise NotImplementedError(f"Don't know ZQuantum factory for gate: {gate}.")
 
 
 @zquantum_gate_factory_from_cirq_gate.register
@@ -208,24 +208,24 @@ def zquantum_gate_factory_from_eigengate(gate: cirq.EigenGate) -> Callable[..., 
 def convert_cirq_gate_operation_to_zquantum_gate(
     operation: cirq.GateOperation,
 ) -> Gate:
-    """Convert Cirq GateOperation to native Orquestra Gate.
+    """Convert Cirq GateOperation to native ZQuantum Gate.
 
     Note that Cirq distinguishes concept of GateOperation and Gate. The correspondence
     between terminology in Cirq is as follows:
 
-    Cirq Gate <-> Orquestra Gate subclass
-    Cirq GateOperation <-> A concrete instance of some Orquestra Gate,
+    Cirq Gate <-> ZQuantum Gate subclass
+    Cirq GateOperation <-> A concrete instance of some ZQuantum Gate,
 
     which is why this function accepts GateOperation instead of Gate.
 
     Args:
         operation: operation to be converted.
     Returns:
-        Native Orquestra Gate.
+        Native ZQuantum Gate.
     """
     if not all(isinstance(qubit, cirq.LineQubit) for qubit in operation.qubits):
         raise NotImplementedError(
-            "Currently conversions from cirq to Orquestra is supported only for "
+            "Currently conversions from cirq to ZQuantum is supported only for "
             "gate operations with LineQubits."
         )
 

--- a/src/python/zquantum/core/wip/circuit/conversions/cirq_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/cirq_conversions_test.py
@@ -70,7 +70,7 @@ TWO_QUBIT_ROTATION_GATE_FACTORIES = [
 
 
 # Here we combine multiple testcases of the form
-# (Orquestra gate, Cirq operation)
+# (ZQuantum gate, Cirq operation)
 # We do this for easier parametrization in tests that follow.
 TEST_CASES_WITHOUT_SYMBOLIC_PARAMS = (
     [

--- a/src/python/zquantum/core/wip/circuit/conversions/cirq_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/cirq_conversions_test.py
@@ -118,39 +118,39 @@ TEST_CASES_WITH_SYMBOLIC_PARAMS = [
 
 
 @pytest.mark.parametrize(
-    "orquestra_gate, cirq_operation", TEST_CASES_WITHOUT_SYMBOLIC_PARAMS
+    "zquantum_gate, cirq_operation", TEST_CASES_WITHOUT_SYMBOLIC_PARAMS
 )
 class TestGateConversionWithoutSymbolicParameters:
-    def test_converting_orquestra_gate_to_cirq_gives_expected_operation(
-        self, orquestra_gate, cirq_operation
+    def test_converting_zquantum_gate_to_cirq_gives_expected_operation(
+        self, zquantum_gate, cirq_operation
     ):
-        assert convert_to_cirq(orquestra_gate) == cirq_operation
+        assert convert_to_cirq(zquantum_gate) == cirq_operation
 
-    def test_converting_cirq_operation_to_orquestra_gives_expected_gate(
-        self, orquestra_gate, cirq_operation
+    def test_converting_cirq_operation_to_zquantum_gives_expected_gate(
+        self, zquantum_gate, cirq_operation
     ):
-        assert convert_from_cirq(cirq_operation) == orquestra_gate
+        assert convert_from_cirq(cirq_operation) == zquantum_gate
 
-    def test_orquestra_gate_and_cirq_gate_have_the_same_matrix(
-        self, orquestra_gate, cirq_operation
+    def test_zquantum_gate_and_cirq_gate_have_the_same_matrix(
+        self, zquantum_gate, cirq_operation
     ):
         # This is to ensure that we are indeed converting the same gate.
         assert np.allclose(
-            np.array(orquestra_gate.matrix).astype(np.complex128),
+            np.array(zquantum_gate.matrix).astype(np.complex128),
             cirq.unitary(cirq_operation.gate),
         )
 
 
 @pytest.mark.parametrize(
-    "orquestra_gate, cirq_operation", TEST_CASES_WITH_SYMBOLIC_PARAMS
+    "zquantum_gate, cirq_operation", TEST_CASES_WITH_SYMBOLIC_PARAMS
 )
 class TestGateConversionWithSymbolicParameters:
-    def test_converting_orquestra_gate_to_cirq_gives_expected_operation(
-        self, orquestra_gate, cirq_operation
+    def test_converting_zquantum_gate_to_cirq_gives_expected_operation(
+        self, zquantum_gate, cirq_operation
     ):
-        assert convert_to_cirq(orquestra_gate) == cirq_operation
+        assert convert_to_cirq(zquantum_gate) == cirq_operation
 
-    def test_converting_cirq_operation_to_orquestra_gives_expected_gate(
-        self, orquestra_gate, cirq_operation
+    def test_converting_cirq_operation_to_zquantum_gives_expected_gate(
+        self, zquantum_gate, cirq_operation
     ):
-        assert convert_from_cirq(cirq_operation) == orquestra_gate
+        assert convert_from_cirq(cirq_operation) == zquantum_gate

--- a/src/python/zquantum/core/wip/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/pyquil_conversions.py
@@ -16,7 +16,7 @@ from .symbolic.pyquil_expressions import QUIL_DIALECT, expression_from_pyquil
 from .symbolic.sympy_expressions import SYMPY_DIALECT
 
 
-ORQUESTRA_CLS_TO_PYQUIL_FUNCTION = {
+ZQUANTUM_CLS_TO_PYQUIL_FUNCTION = {
     circuit.X: pyquil.gates.X,
     circuit.Y: pyquil.gates.Y,
     circuit.Z: pyquil.gates.Z,
@@ -36,7 +36,7 @@ ORQUESTRA_CLS_TO_PYQUIL_FUNCTION = {
 
 
 # A Mapping from PyQuil gate names to the Orquestra classes.
-PYQUIL_NAME_TO_ORQUESTRA_CLS = {
+PYQUIL_NAME_TO_ZQUANTUM_CLS = {
     "X": circuit.X,
     "Y": circuit.Y,
     "Z": circuit.Z,
@@ -92,7 +92,7 @@ def convert_gate_to_pyquil(
 def _convert_ordinary_gate_to_pyquil(
     gate: circuit.Gate, _program: Optional[pyquil.Program] = None
 ) -> pyquil.gates.Gate:
-    pyquil_function = ORQUESTRA_CLS_TO_PYQUIL_FUNCTION[type(gate)]
+    pyquil_function = ZQUANTUM_CLS_TO_PYQUIL_FUNCTION[type(gate)]
     translated_params = [
         translate_expression(expression_from_sympy(param), QUIL_DIALECT)
         for param in gate.params
@@ -237,7 +237,7 @@ def convert_gate_from_pyquil(gate: pyquil.quil.Gate, custom_gates=None) -> circu
         for param in gate.params
     )
 
-    pyquil_name_to_orquestra_cls = copy(PYQUIL_NAME_TO_ORQUESTRA_CLS)
+    pyquil_name_to_orquestra_cls = copy(PYQUIL_NAME_TO_ZQUANTUM_CLS)
 
     if custom_gates is not None:
         pyquil_name_to_orquestra_cls.update(custom_gates)

--- a/src/python/zquantum/core/wip/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/pyquil_conversions.py
@@ -183,7 +183,7 @@ def convert_from_pyquil(
     obj: Union[pyquil.Program, pyquil.quil.Gate], custom_gates=None
 ):
     raise NotImplementedError(
-        f"Conversion from pyquil to orquestra not implemented for {obj}"
+        f"Conversion from pyquil to zquantum not implemented for {obj}"
     )
 
 
@@ -210,16 +210,16 @@ def custom_gate_factory_from_pyquil_defgate(gate: pyquil.quil.DefGate):
 
     def _factory(*args):
         qubits = args[:num_qubits]
-        orquestra_gate = circuit.CustomGate(
+        zquantum_gate = circuit.CustomGate(
             sympy_matrix, qubits=tuple(qubits), name=gate.name
         )
         if len(args) != num_qubits:
             parameters = args[num_qubits:]
 
-            orquestra_gate = orquestra_gate.evaluate(
+            zquantum_gate = zquantum_gate.evaluate(
                 {symbol: value for symbol, value in zip(symbols, parameters)}
             )
-        return orquestra_gate
+        return zquantum_gate
 
     return _factory
 
@@ -232,19 +232,19 @@ def convert_gate_from_pyquil(gate: pyquil.quil.Gate, custom_gates=None) -> circu
     control_qubits = all_qubits[:number_of_control_modifiers]
     target_qubits = all_qubits[number_of_control_modifiers:]
 
-    orquestra_params = tuple(
+    zquantum_params = tuple(
         translate_expression(expression_from_pyquil(param), SYMPY_DIALECT)
         for param in gate.params
     )
 
-    pyquil_name_to_orquestra_cls = copy(PYQUIL_NAME_TO_ZQUANTUM_CLS)
+    pyquil_name_to_zquantum_cls = copy(PYQUIL_NAME_TO_ZQUANTUM_CLS)
 
     if custom_gates is not None:
-        pyquil_name_to_orquestra_cls.update(custom_gates)
+        pyquil_name_to_zquantum_cls.update(custom_gates)
 
     try:
-        gate_cls = pyquil_name_to_orquestra_cls[gate.name]
-        result = gate_cls(*target_qubits, *orquestra_params)
+        gate_cls = pyquil_name_to_zquantum_cls[gate.name]
+        result = gate_cls(*target_qubits, *zquantum_params)
 
         # Control qubits need to be applied in reverse because in PyQuil they
         # are prepended to the list when applying control modifier.
@@ -272,7 +272,7 @@ def convert_gate_from_pyquil(gate: pyquil.quil.Gate, custom_gates=None) -> circu
 
 
 @convert_from_pyquil.register
-def convert_pyquil_program_to_orquestra(program: pyquil.Program, custom_gates=None):
+def convert_pyquil_program_to_zquantum(program: pyquil.Program, custom_gates=None):
     custom_gates = {
         definition.name: custom_gate_factory_from_pyquil_defgate(definition)
         for definition in program.defined_gates

--- a/src/python/zquantum/core/wip/circuit/conversions/pyquil_conversions.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/pyquil_conversions.py
@@ -35,7 +35,7 @@ ZQUANTUM_CLS_TO_PYQUIL_FUNCTION = {
 }
 
 
-# A Mapping from PyQuil gate names to the Orquestra classes.
+# A Mapping from PyQuil gate names to the ZQuantum classes.
 PYQUIL_NAME_TO_ZQUANTUM_CLS = {
     "X": circuit.X,
     "Y": circuit.Y,
@@ -261,11 +261,11 @@ def convert_gate_from_pyquil(gate: pyquil.quil.Gate, custom_gates=None) -> circu
     except TypeError:
         raise ValueError(
             f"Cannot convert {gate}. Please check that you haven't reimplemented "
-            "predefined gate. If this is not the case, contact Orquestra support."
+            "predefined gate. If this is not the case, contact ZQuantum support."
         )
     except KeyError:
         raise ValueError(
-            f"Conversion to Orquestra is not supported for {gate.name} gate. "
+            f"Conversion to ZQuantum is not supported for {gate.name} gate. "
             "If this is a custom gate, make sure to convert it together with "
             "a corresponding PyQuil program."
         )

--- a/src/python/zquantum/core/wip/circuit/conversions/pyquil_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/pyquil_conversions_test.py
@@ -683,7 +683,7 @@ def test_converting_circuit_to_pyquil_gives_program_with_the_same_gates(
 
 
 def test_pyquil_circuit_obtained_from_empty_circuit_is_also_empty():
-    circuit = Circuit()
+    circuit = Circuit(gates=[])
 
     pyquil_circuit = convert_to_pyquil(circuit)
 

--- a/src/python/zquantum/core/wip/circuit/conversions/pyquil_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/pyquil_conversions_test.py
@@ -683,7 +683,7 @@ def test_converting_circuit_to_pyquil_gives_program_with_the_same_gates(
 
 
 def test_pyquil_circuit_obtained_from_empty_circuit_is_also_empty():
-    circuit = Circuit(gates=[])
+    circuit = Circuit()
 
     pyquil_circuit = convert_to_pyquil(circuit)
 

--- a/src/python/zquantum/core/wip/circuit/conversions/pyquil_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/pyquil_conversions_test.py
@@ -74,8 +74,8 @@ def pyquil_gate_matrix(gate: pyquil.gates.Gate) -> np.ndarray:
 
 
 @pytest.fixture
-def example_orquestra_circuit():
-    """Constructs an example_orquestra_circuit.
+def example_zquantum_circuit():
+    """Constructs an example_zquantum_circuit.
 
     This circuit should be equivalent to the the one constructed by
     the example_pyquil_circuit. This equivalence is used in
@@ -152,7 +152,7 @@ def example_pyquil_program():
 
 @pytest.mark.parametrize("qubit_index", [0, 1, 5, 13])
 @pytest.mark.parametrize(
-    "orquestra_gate_cls, pyquil_gate_func",
+    "zquantum_gate_cls, pyquil_gate_func",
     [
         (X, pyquil.gates.X),
         (Y, pyquil.gates.Y),
@@ -163,17 +163,17 @@ def example_pyquil_program():
     ],
 )
 class TestSingleQubitNonParametricGatesConversion:
-    def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
-        self, qubit_index, orquestra_gate_cls, pyquil_gate_func
+    def test_conversion_from_zquantum_to_pyquil_gives_correct_gate(
+        self, qubit_index, zquantum_gate_cls, pyquil_gate_func
     ):
-        assert convert_to_pyquil(orquestra_gate_cls(qubit_index)) == pyquil_gate_func(
+        assert convert_to_pyquil(zquantum_gate_cls(qubit_index)) == pyquil_gate_func(
             qubit_index
         )
 
-    def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
-        self, qubit_index, orquestra_gate_cls, pyquil_gate_func
+    def test_conversion_from_pyquil_to_zquantum_gives_correct_gate(
+        self, qubit_index, zquantum_gate_cls, pyquil_gate_func
     ):
-        assert convert_from_pyquil(pyquil_gate_func(qubit_index)) == orquestra_gate_cls(
+        assert convert_from_pyquil(pyquil_gate_func(qubit_index)) == zquantum_gate_cls(
             qubit_index
         )
 
@@ -181,7 +181,7 @@ class TestSingleQubitNonParametricGatesConversion:
 @pytest.mark.parametrize("qubit_index", [0, 4, 10, 11])
 @pytest.mark.parametrize("angle", [np.pi, np.pi / 2, 0.4])
 @pytest.mark.parametrize(
-    "orquestra_gate_cls, pyquil_gate_func",
+    "zquantum_gate_cls, pyquil_gate_func",
     [
         (RX, pyquil.gates.RX),
         (RY, pyquil.gates.RY),
@@ -190,25 +190,25 @@ class TestSingleQubitNonParametricGatesConversion:
     ],
 )
 class TestSingleQubitRotationGatesConversion:
-    def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
-        self, qubit_index, angle, orquestra_gate_cls, pyquil_gate_func
+    def test_conversion_from_zquantum_to_pyquil_gives_correct_gate(
+        self, qubit_index, angle, zquantum_gate_cls, pyquil_gate_func
     ):
         assert pyquil_gate_func(angle, qubit_index) == convert_to_pyquil(
-            orquestra_gate_cls(qubit_index, angle)
+            zquantum_gate_cls(qubit_index, angle)
         )
 
-    def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
-        self, qubit_index, angle, orquestra_gate_cls, pyquil_gate_func
+    def test_conversion_from_pyquil_to_zquantum_gives_correct_gate(
+        self, qubit_index, angle, zquantum_gate_cls, pyquil_gate_func
     ):
-        assert orquestra_gate_cls(qubit_index, angle) == convert_from_pyquil(
+        assert zquantum_gate_cls(qubit_index, angle) == convert_from_pyquil(
             pyquil_gate_func(angle, qubit_index)
         )
 
 
 @pytest.mark.parametrize("qubit_index", [0, 4, 10, 11])
-@pytest.mark.parametrize("orquestra_angle, pyquil_angle", EXAMPLE_PARAMETRIZED_ANGLES)
+@pytest.mark.parametrize("zquantum_angle, pyquil_angle", EXAMPLE_PARAMETRIZED_ANGLES)
 @pytest.mark.parametrize(
-    "orquestra_gate_cls, pyquil_gate_func",
+    "zquantum_gate_cls, pyquil_gate_func",
     [
         (RX, pyquil.gates.RX),
         (RY, pyquil.gates.RY),
@@ -217,46 +217,46 @@ class TestSingleQubitRotationGatesConversion:
     ],
 )
 class TestSingleQubitRotationGatesWithSymbolicParamsConversion:
-    def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
+    def test_conversion_from_zquantum_to_pyquil_gives_correct_gate(
         self,
         qubit_index,
-        orquestra_angle,
+        zquantum_angle,
         pyquil_angle,
-        orquestra_gate_cls,
+        zquantum_gate_cls,
         pyquil_gate_func,
     ):
         program = pyquil.Program()
 
         assert pyquil_gate_func(pyquil_angle, qubit_index) == convert_to_pyquil(
-            orquestra_gate_cls(qubit_index, orquestra_angle), program
+            zquantum_gate_cls(qubit_index, zquantum_angle), program
         )
 
-    def test_translated_angle_expression_from_orquestra_gate_is_added_to_program(
+    def test_translated_angle_expression_from_zquantum_gate_is_added_to_program(
         self,
         qubit_index,
-        orquestra_angle,
+        zquantum_angle,
         pyquil_angle,
-        orquestra_gate_cls,
+        zquantum_gate_cls,
         pyquil_gate_func,
     ):
         program = pyquil.Program()
-        orquestra_gate = orquestra_gate_cls(qubit_index, orquestra_angle)
-        convert_to_pyquil(orquestra_gate, program)
+        zquantum_gate = zquantum_gate_cls(qubit_index, zquantum_angle)
+        convert_to_pyquil(zquantum_gate, program)
 
         assert program.instructions == [
             pyquil.quil.Declare(str(param), "REAL")
-            for param in orquestra_gate.symbolic_params
+            for param in zquantum_gate.symbolic_params
         ]
 
-    def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
+    def test_conversion_from_pyquil_to_zquantum_gives_correct_gate(
         self,
         qubit_index,
-        orquestra_angle,
+        zquantum_angle,
         pyquil_angle,
-        orquestra_gate_cls,
+        zquantum_gate_cls,
         pyquil_gate_func,
     ):
-        assert orquestra_gate_cls(qubit_index, orquestra_angle) == convert_from_pyquil(
+        assert zquantum_gate_cls(qubit_index, zquantum_angle) == convert_from_pyquil(
             pyquil_gate_func(pyquil_angle, qubit_index)
         )
 
@@ -264,14 +264,14 @@ class TestSingleQubitRotationGatesWithSymbolicParamsConversion:
 @pytest.mark.parametrize("qubit_indices", [[0, 1], [2, 10], [4, 7]])
 @pytest.mark.parametrize("angle", [0, np.pi / 4, np.pi / 2, np.pi, 2 * np.pi])
 class TestCPHASEGateConversion:
-    def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
+    def test_conversion_from_zquantum_to_pyquil_gives_correct_gate(
         self, qubit_indices, angle
     ):
         assert pyquil.gates.CPHASE(angle, *qubit_indices) == convert_to_pyquil(
             CPHASE(*qubit_indices, angle)
         )
 
-    def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
+    def test_conversion_from_pyquil_to_zquantum_gives_correct_gate(
         self, qubit_indices, angle
     ):
         assert CPHASE(*qubit_indices, angle) == convert_from_pyquil(
@@ -280,46 +280,46 @@ class TestCPHASEGateConversion:
 
 
 @pytest.mark.parametrize("qubit_indices", [[0, 1], [2, 10], [4, 7]])
-@pytest.mark.parametrize("orquestra_angle, pyquil_angle", EXAMPLE_PARAMETRIZED_ANGLES)
+@pytest.mark.parametrize("zquantum_angle, pyquil_angle", EXAMPLE_PARAMETRIZED_ANGLES)
 class TestCPHASEGateWithSymbolicParamsConversion:
-    def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
-        self, qubit_indices, orquestra_angle, pyquil_angle
+    def test_conversion_from_zquantum_to_pyquil_gives_correct_gate(
+        self, qubit_indices, zquantum_angle, pyquil_angle
     ):
         program = pyquil.Program()
         assert pyquil.gates.CPHASE(pyquil_angle, *qubit_indices) == convert_to_pyquil(
-            CPHASE(*qubit_indices, orquestra_angle), program
+            CPHASE(*qubit_indices, zquantum_angle), program
         )
 
-    def test_translated_angle_from_orquestra_gate_is_added_to_program(
-        self, qubit_indices, orquestra_angle, pyquil_angle
+    def test_translated_angle_from_zquantum_gate_is_added_to_program(
+        self, qubit_indices, zquantum_angle, pyquil_angle
     ):
         program = pyquil.Program()
-        orquestra_gate = CPHASE(*qubit_indices, orquestra_angle)
-        convert_to_pyquil(orquestra_gate, program)
+        zquantum_gate = CPHASE(*qubit_indices, zquantum_angle)
+        convert_to_pyquil(zquantum_gate, program)
 
         assert program.instructions == [
             pyquil.quil.Declare(str(param), "REAL")
-            for param in orquestra_gate.symbolic_params
+            for param in zquantum_gate.symbolic_params
         ]
 
-    def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
-        self, qubit_indices, orquestra_angle, pyquil_angle
+    def test_conversion_from_pyquil_to_zquantum_gives_correct_gate(
+        self, qubit_indices, zquantum_angle, pyquil_angle
     ):
-        assert CPHASE(*qubit_indices, orquestra_angle) == convert_from_pyquil(
+        assert CPHASE(*qubit_indices, zquantum_angle) == convert_from_pyquil(
             pyquil.gates.CPHASE(pyquil_angle, *qubit_indices)
         )
 
 
 @pytest.mark.parametrize("qubit_indices", [[0, 1], [2, 10], [4, 7]])
 class TestSWAPGateConversion:
-    def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
+    def test_conversion_from_pyquil_to_zquantum_gives_correct_gate(
         self, qubit_indices
     ):
         assert pyquil.gates.SWAP(*qubit_indices) == convert_to_pyquil(
             SWAP(*qubit_indices)
         )
 
-    def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
+    def test_conversion_from_zquantum_to_pyquil_gives_correct_gate(
         self, qubit_indices
     ):
         assert SWAP(*qubit_indices) == convert_from_pyquil(
@@ -329,21 +329,21 @@ class TestSWAPGateConversion:
 
 @pytest.mark.parametrize("control, target", [(0, 1), (2, 3), (0, 10)])
 @pytest.mark.parametrize(
-    "orquestra_gate_cls, pyquil_gate_func",
+    "zquantum_gate_cls, pyquil_gate_func",
     [(CZ, pyquil.gates.CZ), (CNOT, pyquil.gates.CNOT)],
 )
 class TestTwoQubitPredefinedControlledGatesConversion:
-    def test_conversion_from_orquestra_to_pyquil_gives_correct_gate(
-        self, control, target, orquestra_gate_cls, pyquil_gate_func
+    def test_conversion_from_zquantum_to_pyquil_gives_correct_gate(
+        self, control, target, zquantum_gate_cls, pyquil_gate_func
     ):
         assert pyquil_gate_func(control, target) == convert_to_pyquil(
-            orquestra_gate_cls(control, target)
+            zquantum_gate_cls(control, target)
         )
 
-    def test_conversion_from_pyquil_to_orquestra_gives_correct_gate(
-        self, control, target, orquestra_gate_cls, pyquil_gate_func
+    def test_conversion_from_pyquil_to_zquantum_gives_correct_gate(
+        self, control, target, zquantum_gate_cls, pyquil_gate_func
     ):
-        assert orquestra_gate_cls(control, target) == convert_from_pyquil(
+        assert zquantum_gate_cls(control, target) == convert_from_pyquil(
             pyquil_gate_func(control, target)
         )
 
@@ -369,7 +369,7 @@ class TestCorrectnessOfGateTypeAndMatrix:
             XY(0, 1, np.pi / 5)
         ],
     )
-    def test_conversion_from_orquestra_to_pyquil_preserves_gate_type_and_matrix(
+    def test_conversion_from_zquantum_to_pyquil_preserves_gate_type_and_matrix(
         self, gate
     ):
         pyquil_gate = convert_to_pyquil(gate)
@@ -400,15 +400,15 @@ class TestCorrectnessOfGateTypeAndMatrix:
             pyquil.gates.XY(np.pi / 5, 0, 1)
         ],
     )
-    def test_conversion_from_pyquil_to_orquestra_preserves_gate_type_and_matrix(
+    def test_conversion_from_pyquil_to_zquantum_preserves_gate_type_and_matrix(
         self, pyquil_gate
     ):
-        orquestra_gate = convert_from_pyquil(pyquil_gate)
+        zquantum_gate = convert_from_pyquil(pyquil_gate)
 
-        assert pyquil_gate.name == ZQUANTUM_GATE_TYPE_TO_PYQUIL_NAME[type(orquestra_gate)]
+        assert pyquil_gate.name == ZQUANTUM_GATE_TYPE_TO_PYQUIL_NAME[type(zquantum_gate)]
         assert np.allclose(
             pyquil_gate_matrix(pyquil_gate),
-            np.array(orquestra_gate.matrix.tolist(), dtype=complex),
+            np.array(zquantum_gate.matrix.tolist(), dtype=complex),
         )
 
 
@@ -418,7 +418,7 @@ class TestCorrectnessOfGateTypeAndMatrix:
 # This is to test whether pyquil CONTROLLED modifier gets applied correct
 # of times.
 @pytest.mark.parametrize(
-    "orquestra_gate, pyquil_gate, control_qubits",
+    "zquantum_gate, pyquil_gate, control_qubits",
     [
         (X(2), pyquil.gates.X(2), (1,)),
         (Y(1), pyquil.gates.Y(1), (0,)),
@@ -428,9 +428,9 @@ class TestCorrectnessOfGateTypeAndMatrix:
     scope="function",
 )
 class TestControlledGateConversion:
-    def make_orquestra_controlled_gate(self, gate, control_qubits):
+    def make_zquantum_controlled_gate(self, gate, control_qubits):
         if control_qubits:
-            return self.make_orquestra_controlled_gate(
+            return self.make_zquantum_controlled_gate(
                 ControlledGate(gate, control_qubits[0]), control_qubits[1:]
             )
         return gate
@@ -447,19 +447,19 @@ class TestControlledGateConversion:
         return gate
 
     def test_converting_nested_controlled_gate_gives_pyquil_gate_with_applied_controlled_modifiers(
-        self, orquestra_gate, pyquil_gate, control_qubits
+        self, zquantum_gate, pyquil_gate, control_qubits
     ):
         assert self.make_pyquil_controlled_gate(
             pyquil_gate, control_qubits
         ) == convert_to_pyquil(
-            self.make_orquestra_controlled_gate(orquestra_gate, control_qubits)
+            self.make_zquantum_controlled_gate(zquantum_gate, control_qubits)
         )
 
     def test_converting_pyquil_gate_with_controlled_modifiers_gives_nested_controlled_gate(
-        self, orquestra_gate, pyquil_gate, control_qubits
+        self, zquantum_gate, pyquil_gate, control_qubits
     ):
-        assert self.make_orquestra_controlled_gate(
-            orquestra_gate, control_qubits
+        assert self.make_zquantum_controlled_gate(
+            zquantum_gate, control_qubits
         ) == convert_from_pyquil(
             self.make_pyquil_controlled_gate(pyquil_gate, control_qubits)
         )
@@ -477,7 +477,7 @@ class TestGatesWithDaggerConversion:
             pyquil.gates.RX(0.5, 1).controlled(3),
         ],
     )
-    def test_dagger_of_orquestra_gate_is_taken_when_converting_gate_with_dagger_modifier(
+    def test_dagger_of_zquantum_gate_is_taken_when_converting_gate_with_dagger_modifier(
         self, pyquil_gate
     ):
         pyquil_dagger = deepcopy(pyquil_gate).dagger()
@@ -535,7 +535,7 @@ class TestCustomGateFactoryFromPyquilDefgate:
 
         gate_factory = custom_gate_factory_from_pyquil_defgate(gate_definition)
 
-        expected_orquestra_matrix = sympy.Matrix(
+        expected_zquantum_matrix = sympy.Matrix(
             [
                 [1.0, 0, 0, 0],
                 [0, sympy.Symbol("theta"), 0, 0],
@@ -544,7 +544,7 @@ class TestCustomGateFactoryFromPyquilDefgate:
             ]
         )
 
-        expected_orquestra_gate = CustomGate(expected_orquestra_matrix, (0, 3), "U")
+        expected_zquantum_gate = CustomGate(expected_zquantum_matrix, (0, 3), "U")
 
         assert gate_factory(
             0,
@@ -553,7 +553,7 @@ class TestCustomGateFactoryFromPyquilDefgate:
             sympy.Symbol("theta"),
             sympy.Symbol('x') + sympy.Symbol("y"),
             sympy.cos(sympy.Symbol("theta"))
-        ) == expected_orquestra_gate
+        ) == expected_zquantum_gate
 
     def test_passing_custom_gate_dict_allows_for_converting_custom_pyquil_gates(self):
         gate_matrix = [[1, 0], [0, -1]]
@@ -567,15 +567,15 @@ class TestCustomGateFactoryFromPyquilDefgate:
         with pytest.raises(ValueError):
             convert_from_pyquil(pyquil_gate)
 
-        expected_orquestra_gate = CustomGate(
+        expected_zquantum_gate = CustomGate(
             sympy.Matrix(gate_matrix),
             (2,),
             "U"
         )
 
-        orquestra_gate = convert_from_pyquil(pyquil_gate, custom_gates_mapping)
+        zquantum_gate = convert_from_pyquil(pyquil_gate, custom_gates_mapping)
 
-        assert orquestra_gate == expected_orquestra_gate
+        assert zquantum_gate == expected_zquantum_gate
 
 
 @pytest.mark.parametrize(
@@ -675,9 +675,9 @@ def test_passing_manually_constructed_gate_with_mismatching_properties_raises_va
 
 
 def test_converting_circuit_to_pyquil_gives_program_with_the_same_gates(
-    example_orquestra_circuit, example_pyquil_program
+    example_zquantum_circuit, example_pyquil_program
 ):
-    converted_program = convert_to_pyquil(example_orquestra_circuit)
+    converted_program = convert_to_pyquil(example_zquantum_circuit)
 
     assert converted_program == example_pyquil_program
 
@@ -691,14 +691,14 @@ def test_pyquil_circuit_obtained_from_empty_circuit_is_also_empty():
 
 
 def test_converting_pyquil_program_gives_circuit_with_the_same_gates(
-    example_orquestra_circuit, example_pyquil_program
+    example_zquantum_circuit, example_pyquil_program
 ):
     converted_circuit = convert_from_pyquil(example_pyquil_program)
 
-    assert converted_circuit == example_orquestra_circuit
+    assert converted_circuit == example_zquantum_circuit
 
 
-def test_orquestra_circuit_obtained_from_empty_program_is_also_empty():
+def test_zquantum_circuit_obtained_from_empty_program_is_also_empty():
     program = pyquil.Program()
 
     assert not convert_from_pyquil(program).gates

--- a/src/python/zquantum/core/wip/circuit/conversions/pyquil_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/pyquil_conversions_test.py
@@ -33,7 +33,7 @@ import numpy as np
 import pytest
 
 
-ORQUESTRA_GATE_TYPE_TO_PYQUIL_NAME = {
+ZQUANTUM_GATE_TYPE_TO_PYQUIL_NAME = {
     X: "X",
     Y: "Y",
     Z: "Z",
@@ -374,7 +374,7 @@ class TestCorrectnessOfGateTypeAndMatrix:
     ):
         pyquil_gate = convert_to_pyquil(gate)
 
-        assert pyquil_gate.name == ORQUESTRA_GATE_TYPE_TO_PYQUIL_NAME[type(gate)]
+        assert pyquil_gate.name == ZQUANTUM_GATE_TYPE_TO_PYQUIL_NAME[type(gate)]
         assert np.allclose(
             pyquil_gate_matrix(pyquil_gate),
             np.array(gate.matrix.tolist(), dtype=complex),
@@ -405,7 +405,7 @@ class TestCorrectnessOfGateTypeAndMatrix:
     ):
         orquestra_gate = convert_from_pyquil(pyquil_gate)
 
-        assert pyquil_gate.name == ORQUESTRA_GATE_TYPE_TO_PYQUIL_NAME[type(orquestra_gate)]
+        assert pyquil_gate.name == ZQUANTUM_GATE_TYPE_TO_PYQUIL_NAME[type(orquestra_gate)]
         assert np.allclose(
             pyquil_gate_matrix(pyquil_gate),
             np.array(orquestra_gate.matrix.tolist(), dtype=complex),

--- a/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions.py
@@ -117,13 +117,13 @@ def convert_from_qiskit(
 def _convert_operation_from_qiskit(operation: QiskitOperation) -> Gate:
     try:
         qiskit_op, qiskit_qubits, _ = operation
-        orquestra_gate_cls = QISKIT_TO_ZQUANTUM_MAPPING[type(qiskit_op)]
-        orquestra_params = [
+        zquantum_gate_cls = QISKIT_TO_ZQUANTUM_MAPPING[type(qiskit_op)]
+        zquantum_params = [
             translate_expression(intermediate_expr, SYMPY_DIALECT)
             for intermediate_expr in map(expression_from_qiskit, qiskit_op.params)
         ]
-        return orquestra_gate_cls(
-            *(qubit.index for qubit in qiskit_qubits), *orquestra_params
+        return zquantum_gate_cls(
+            *(qubit.index for qubit in qiskit_qubits), *zquantum_params
         )
     except KeyError:
         raise NotImplementedError(
@@ -154,7 +154,7 @@ def convert_to_qiskit(obj, num_qubits_in_circuit: int) -> QiskitOperation:
 
 
 @convert_to_qiskit.register
-def _convert_orquestra_gate_to_qiskit(
+def _convert_zquantum_gate_to_qiskit(
     gate: Gate, num_qubits_in_circuit: int
 ) -> QiskitOperation:
     try:
@@ -184,7 +184,7 @@ def _convert_controlled_gate_to_qiskit(
 
 
 @convert_to_qiskit.register
-def _convert_orquestra_circuit_to_qiskit(orq_circuit: Circuit):
+def _convert_zquantum_circuit_to_qiskit(orq_circuit: Circuit):
     qiskit_circuit = qiskit.QuantumCircuit(orq_circuit.n_qubits)
     qiskit_triplets = [
         convert_to_qiskit(orq_gate, orq_circuit.n_qubits)

--- a/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions.py
@@ -71,6 +71,11 @@ QISKIT_TO_ORQUESTRA_MAPPING = {
         value: key for key, value in ORQUESTRA_TO_QISKIT_MAPPING.items()
     },
     qiskit.extensions.CRXGate: _make_controlled_gate_factory(RX),
+    qiskit.extensions.CRYGate: _make_controlled_gate_factory(RY),
+    qiskit.extensions.CRZGate: _make_controlled_gate_factory(RZ),
+    qiskit.extensions.CSwapGate: _make_controlled_gate_factory(SWAP),
+    # TODO: search through Qiskit gates, find all specialized subclasses for
+    # controlled gates and add them here
 }
 
 
@@ -93,8 +98,12 @@ def convert_from_qiskit(
     """
     if isinstance(obj, tuple):
         return _convert_operation_from_qiskit(obj)
+    elif isinstance(obj, qiskit.QuantumCircuit):
+        return _convert_circuit_from_qiskit(obj)
     else:
-        raise NotImplementedError()
+        raise NotImplementedError(
+            f"Cannot convert {obj} to Orquestra"
+        )
 
 
 def _convert_operation_from_qiskit(operation: QiskitOperation) -> Gate:
@@ -112,6 +121,11 @@ def _convert_operation_from_qiskit(operation: QiskitOperation) -> Gate:
         raise NotImplementedError(
             f"Cannot convert {operation} to Orquestra, unknown operation."
         )
+
+
+def _convert_circuit_from_qiskit(circuit: qiskit.QuantumCircuit) -> Circuit:
+    orq_gates = [convert_from_qiskit(triplet) for triplet in circuit.data]
+    return Circuit(gates=orq_gates, n_qubits=circuit.num_qubits)
 
 
 @singledispatch

--- a/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions.py
@@ -137,15 +137,13 @@ def _convert_orquestra_gate_to_qiskit(
         raise NotImplementedError(f"Conversion of {gate} to Qiskit is not supported.")
 
 
-
-
 @convert_to_qiskit.register
-def _convert_orquestra_circuit_to_qiskit(
-    orq_circuit: Circuit
-):
+def _convert_orquestra_circuit_to_qiskit(orq_circuit: Circuit):
     qiskit_circuit = qiskit.QuantumCircuit(orq_circuit.n_qubits)
-    for qiskit_gate, qiskit_qubits, qiskit_clbits in [convert_to_qiskit(orq_gate, orq_circuit.n_qubits)
-                                                      for orq_gate in orq_circuit.gates]:
+    for qiskit_gate, qiskit_qubits, qiskit_clbits in [
+        convert_to_qiskit(orq_gate, orq_circuit.n_qubits)
+        for orq_gate in orq_circuit.gates
+    ]:
         qiskit_circuit.append(qiskit_gate, qiskit_qubits, qiskit_clbits)
 
     return qiskit_circuit

--- a/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions.py
@@ -94,7 +94,7 @@ def _convert_operation_from_qiskit(operation: QiskitOperation) -> Gate:
             for intermediate_expr in map(expression_from_qiskit, qiskit_op.params)
         ]
         return orquestra_gate_cls(
-            *(qubit.index for qubit in reversed(qiskit_qubits)), *orquestra_params
+            *(qubit.index for qubit in qiskit_qubits), *orquestra_params
         )
     except KeyError:
         raise NotImplementedError(
@@ -125,7 +125,7 @@ def _convert_orquestra_gate_to_qiskit(
     try:
         qiskit_qubits = [
             qiskit_qubit(qubit, num_qubits_in_circuit)
-            for qubit in reversed(gate.qubits)
+            for qubit in gate.qubits
         ]
         qiskit_gate_cls = ORQUESTRA_TO_QISKIT_MAPPING[type(gate)]
         qiskit_params = [
@@ -140,10 +140,11 @@ def _convert_orquestra_gate_to_qiskit(
 @convert_to_qiskit.register
 def _convert_orquestra_circuit_to_qiskit(orq_circuit: Circuit):
     qiskit_circuit = qiskit.QuantumCircuit(orq_circuit.n_qubits)
-    for qiskit_gate, qiskit_qubits, qiskit_clbits in [
+    qiskit_triplets = [
         convert_to_qiskit(orq_gate, orq_circuit.n_qubits)
         for orq_gate in orq_circuit.gates
-    ]:
+    ]
+    for qiskit_gate, qiskit_qubits, qiskit_clbits in qiskit_triplets:
         qiskit_circuit.append(qiskit_gate, qiskit_qubits, qiskit_clbits)
 
     return qiskit_circuit

--- a/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions.py
@@ -66,6 +66,16 @@ def _make_controlled_gate_factory(gate_cls):
     return _factory
 
 
+# NOTE:
+# Qiskit implements a special subclasses for some of the controlled gate variants:
+# https://github.com/Qiskit/qiskit-terra/blob/0.16.4/qiskit/circuit/add_control.py#L72
+# We'll support most of them eventually. The development plan is:
+# 1. Add mapping for some most common cases (done).
+# 2. Support most of the Qiskit controlled gates via our CustomGate when it's reworked.
+# 3. Add specialized gate subclasses on our side if there's a need for handling special
+#     cases explicitly.
+
+
 QISKIT_TO_ORQUESTRA_MAPPING = {
     **{
         value: key for key, value in ORQUESTRA_TO_QISKIT_MAPPING.items()
@@ -74,8 +84,6 @@ QISKIT_TO_ORQUESTRA_MAPPING = {
     qiskit.extensions.CRYGate: _make_controlled_gate_factory(RY),
     qiskit.extensions.CRZGate: _make_controlled_gate_factory(RZ),
     qiskit.extensions.CSwapGate: _make_controlled_gate_factory(SWAP),
-    # TODO: search through Qiskit gates, find all specialized subclasses for
-    # controlled gates and add them here
 }
 
 

--- a/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions.py
@@ -36,7 +36,7 @@ QiskitOperation = Tuple[
 ]
 
 
-ORQUESTRA_TO_QISKIT_MAPPING = {
+ZQUANTUM_TO_QISKIT_MAPPING = {
     X: qiskit.extensions.XGate,
     Y: qiskit.extensions.YGate,
     Z: qiskit.extensions.ZGate,
@@ -76,9 +76,9 @@ def _make_controlled_gate_factory(gate_cls):
 #     cases explicitly.
 
 
-QISKIT_TO_ORQUESTRA_MAPPING = {
+QISKIT_TO_ZQUANTUM_MAPPING = {
     **{
-        value: key for key, value in ORQUESTRA_TO_QISKIT_MAPPING.items()
+        value: key for key, value in ZQUANTUM_TO_QISKIT_MAPPING.items()
     },
     qiskit.extensions.CRXGate: _make_controlled_gate_factory(RX),
     qiskit.extensions.CRYGate: _make_controlled_gate_factory(RY),
@@ -117,7 +117,7 @@ def convert_from_qiskit(
 def _convert_operation_from_qiskit(operation: QiskitOperation) -> Gate:
     try:
         qiskit_op, qiskit_qubits, _ = operation
-        orquestra_gate_cls = QISKIT_TO_ORQUESTRA_MAPPING[type(qiskit_op)]
+        orquestra_gate_cls = QISKIT_TO_ZQUANTUM_MAPPING[type(qiskit_op)]
         orquestra_params = [
             translate_expression(intermediate_expr, SYMPY_DIALECT)
             for intermediate_expr in map(expression_from_qiskit, qiskit_op.params)
@@ -162,7 +162,7 @@ def _convert_orquestra_gate_to_qiskit(
             qiskit_qubit(qubit, num_qubits_in_circuit)
             for qubit in gate.qubits
         ]
-        qiskit_gate_cls = ORQUESTRA_TO_QISKIT_MAPPING[type(gate)]
+        qiskit_gate_cls = ZQUANTUM_TO_QISKIT_MAPPING[type(gate)]
         qiskit_params = [
             translate_expression(intermediate_expr, QISKIT_DIALECT)
             for intermediate_expr in map(expression_from_sympy, gate.params)

--- a/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions.py
@@ -137,17 +137,14 @@ def _convert_orquestra_gate_to_qiskit(
         raise NotImplementedError(f"Conversion of {gate} to Qiskit is not supported.")
 
 
-def _orq_circuit_size(circuit: Circuit):
-    return max(circuit.qubits) + 1
 
 
 @convert_to_qiskit.register
 def _convert_orquestra_circuit_to_qiskit(
     orq_circuit: Circuit
 ):
-    n_qubits = _orq_circuit_size(orq_circuit)
-    qiskit_circuit = qiskit.QuantumCircuit(n_qubits)
-    for qiskit_gate, qiskit_qubits, qiskit_clbits in [convert_to_qiskit(orq_gate, n_qubits)
+    qiskit_circuit = qiskit.QuantumCircuit(orq_circuit.n_qubits)
+    for qiskit_gate, qiskit_qubits, qiskit_clbits in [convert_to_qiskit(orq_gate, orq_circuit.n_qubits)
                                                       for orq_gate in orq_circuit.gates]:
         qiskit_circuit.append(qiskit_gate, qiskit_qubits, qiskit_clbits)
 

--- a/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions.py
@@ -1,4 +1,4 @@
-"""Conversions between Qiskit and Orquestra objects."""
+"""Conversions between Qiskit and ZQuantum objects."""
 from functools import singledispatch
 from typing import Tuple, List, Union
 
@@ -96,13 +96,13 @@ def qiskit_qubit(index: int, num_qubits_in_circuit: int) -> qiskit.circuit.Qubit
 def convert_from_qiskit(
     obj: Union[QiskitOperation, qiskit.QuantumCircuit]
 ) -> Union[Gate, Circuit]:
-    """Convert Qiskit object to a corresponding one in Orquestra.
+    """Convert Qiskit object to a corresponding one in ZQuantum.
 
     Args:
         obj: Qiskit object to convert. Currently, only gate operations are supported.
 
     Returns:
-        Orquestra object converted from the `obj`.
+        ZQuantum object converted from the `obj`.
     """
     if isinstance(obj, tuple):
         return _convert_operation_from_qiskit(obj)
@@ -110,7 +110,7 @@ def convert_from_qiskit(
         return _convert_circuit_from_qiskit(obj)
     else:
         raise NotImplementedError(
-            f"Cannot convert {obj} to Orquestra"
+            f"Cannot convert {obj} to ZQuantum"
         )
 
 
@@ -127,7 +127,7 @@ def _convert_operation_from_qiskit(operation: QiskitOperation) -> Gate:
         )
     except KeyError:
         raise NotImplementedError(
-            f"Cannot convert {operation} to Orquestra, unknown operation."
+            f"Cannot convert {operation} to ZQuantum, unknown operation."
         )
 
 
@@ -138,12 +138,12 @@ def _convert_circuit_from_qiskit(circuit: qiskit.QuantumCircuit) -> Circuit:
 
 @singledispatch
 def convert_to_qiskit(obj, num_qubits_in_circuit: int) -> QiskitOperation:
-    """Convert Orquestra object to a corresponding one in Qiskit.
+    """Convert ZQuantum object to a corresponding one in Qiskit.
 
     Args:
         obj: Object to convert. Currenly, only gates are supported.
         num_qubits_in_circuit: Number of qubits in target Qiskit circuit. It's
-            needed because Orquestra gates don't contain information about
+            needed because ZQuantum gates don't contain information about
             number of qubits in circuit, but Qiskit operations do.
 
     Returns:
@@ -177,7 +177,7 @@ def _convert_controlled_gate_to_qiskit(
     gate: ControlledGate, num_qubits_in_circuit: int
 ) -> QiskitOperation:
     target_gate, _, _ = convert_to_qiskit(gate.target_gate, num_qubits_in_circuit)
-    # NOTE: We're assuming that Orquestra only supports singly-controlled gates.
+    # NOTE: We're assuming that ZQuantum only supports singly-controlled gates.
     controlled_gate = target_gate.control(1)
     qiskit_qubits = [qiskit_qubit(qubit, num_qubits_in_circuit) for qubit in gate.qubits]
     return controlled_gate, qiskit_qubits, []

--- a/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions_test.py
@@ -90,15 +90,15 @@ TEST_CASES_WITHOUT_SYMBOLIC_PARAMS = [
     ],
     *[
         (
-            orquestra_gate(*qubits),
+            orquestra_gate(*qubit_pair),
             (
                 qiskit_gate(),
-                [qiskit_qubit(qubit, max(qubits) + 1) for qubit in reversed(qubits)],
+                [qiskit_qubit(qubit, max(qubit_pair) + 1) for qubit in qubit_pair],
                 [],
             ),
         )
         for orquestra_gate, qiskit_gate in EQUIVALENT_NONPARAMETRIC_TWO_QUBIT_GATES
-        for qubits in [(0, 1), (3, 4), (10, 1)]
+        for qubit_pair in [(0, 1), (3, 4), (10, 1)]
     ],
     *[
         (
@@ -111,15 +111,15 @@ TEST_CASES_WITHOUT_SYMBOLIC_PARAMS = [
     ],
     *[
         (
-            orquestra_gate(*qubits, angle),
+            orquestra_gate(*qubit_pair, angle),
             (
                 qiskit_gate(angle),
-                [qiskit_qubit(qubit, max(qubits) + 1) for qubit in reversed(qubits)],
+                [qiskit_qubit(qubit, max(qubit_pair) + 1) for qubit in qubit_pair],
                 [],
             ),
         )
         for orquestra_gate, qiskit_gate in EQUIVALENT_TWO_QUBIT_ROTATION_GATES
-        for qubits in [(0, 1), (3, 4), (10, 1)]
+        for qubit_pair in [(0, 1), (3, 4), (10, 1)]
         for angle in [0, np.pi, np.pi / 2, 0.4, np.pi / 5]
     ],
 ]
@@ -137,36 +137,44 @@ TEST_CASES_WITH_SYMBOLIC_PARAMS = [
     ],
     *[
         (
-            orquestra_gate(*qubits, orquestra_angle),
+            orquestra_gate(*qubit_pair, orquestra_angle),
             (
                 qiskit_gate(qiskit_angle),
-                [qiskit_qubit(qubit, max(qubits) + 1) for qubit in reversed(qubits)],
+                [qiskit_qubit(qubit, max(qubit_pair) + 1) for qubit in qubit_pair],
                 [],
             ),
         )
         for orquestra_gate, qiskit_gate in EQUIVALENT_TWO_QUBIT_ROTATION_GATES
-        for qubits in [(0, 1), (3, 4), (10, 1)]
+        for qubit_pair in [(0, 1), (3, 4), (10, 1)]
         for orquestra_angle, qiskit_angle in EXAMPLE_SYMBOLIC_ANGLES
     ],
 ]
 
 
+# NOTE: In Qiskit, 0 is the most significant qubit,
+# whereas in Orquestra, 0 is the least significant qubit.
+# This is we need to flip the indices.
+#
+# See more at
+# https://qiskit.org/documentation/tutorials/circuits/1_getting_started_with_qiskit.html#Visualize-Circuit
+
+
 def _single_qubit_qiskit_circuit():
     qc = qiskit.QuantumCircuit(6)
     qc.x(0)
-    qc.z(3)
+    qc.z(2)
     return qc
 
 
 def _two_qubit_qiskit_circuit():
     qc = qiskit.QuantumCircuit(4)
-    qc.cnot(1, 3)
+    qc.cnot(0, 1)
     return qc
 
 
 def _parametric_qiskit_circuit():
     qc = qiskit.QuantumCircuit(4)
-    qc.rx(np.pi, 2)
+    qc.rx(np.pi, 0)
     return qc
 
 
@@ -175,7 +183,7 @@ EQUIVALENT_CIRCUITS = [
         Circuit(
             [
                 X(0),
-                Z(3),
+                Z(2),
             ],
             6,
         ),
@@ -184,7 +192,7 @@ EQUIVALENT_CIRCUITS = [
     (
         Circuit(
             [
-                CNOT(1, 3),
+                CNOT(0, 1),
             ],
             4,
         ),
@@ -193,7 +201,7 @@ EQUIVALENT_CIRCUITS = [
     (
         Circuit(
             [
-                RX(2, np.pi),
+                RX(0, np.pi),
             ],
             4,
         ),
@@ -291,6 +299,6 @@ class TestCircuitConversion:
     ):
         converted = convert_to_qiskit(orquestra_circuit)
         assert converted == qiskit_circuit, (
-            f"Converted circuit:\n{_draw_qiskit_circuit(converted)}\n isn't equal"
+            f"Converted circuit:\n{_draw_qiskit_circuit(converted)}\n isn't equal "
             f"to {_draw_qiskit_circuit(qiskit_circuit)}"
         )

--- a/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions_test.py
@@ -271,9 +271,16 @@ class TestGateConversionWithSymbolicParameters:
     ):
         assert convert_from_qiskit(qiskit_operation) == orquestra_gate
 
+
+def _draw_qiskit_circuit(circuit):
+    return qiskit.visualization.circuit_drawer(circuit, output='text')
+
+
 @pytest.mark.parametrize(
     "orquestra_circuit, qiskit_circuit", EQUIVALENT_CIRCUITS
 )
 class TestCircuitConversion:
-    def test_foo(self, orquestra_circuit, qiskit_circuit):
-        assert False
+    def test_converting_orquestra_circuit_to_qiskit_gives_expected_circuit(self, orquestra_circuit, qiskit_circuit):
+        converted = convert_to_qiskit(orquestra_circuit)
+        assert converted == qiskit_circuit, \
+            f"Converted circuit:\n{_draw_qiskit_circuit(converted)}\n isn't equal to {_draw_qiskit_circuit(qiskit_circuit)}"

--- a/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions_test.py
@@ -362,5 +362,5 @@ class TestCircuitConversion:
         converted = convert_to_qiskit(orquestra_circuit)
         assert converted == qiskit_circuit, (
             f"Converted circuit:\n{_draw_qiskit_circuit(converted)}\n isn't equal "
-            f"to {_draw_qiskit_circuit(qiskit_circuit)}"
+            f"to\n{_draw_qiskit_circuit(qiskit_circuit)}"
         )

--- a/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions_test.py
@@ -181,7 +181,7 @@ TEST_CASES_FOR_CONTROLLED_GATES = [
 
 
 # NOTE: In Qiskit, 0 is the most significant qubit,
-# whereas in Orquestra, 0 is the least significant qubit.
+# whereas in ZQuantum, 0 is the least significant qubit.
 # This is we need to flip the indices.
 #
 # See more at

--- a/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions_test.py
@@ -87,41 +87,41 @@ TWO_QUBIT_SWAP_MATRIX = np.array(
 
 TEST_CASES_WITHOUT_SYMBOLIC_PARAMS = [
     *[
-        (orquestra_gate(qubit), (qiskit_gate(), [qiskit_qubit(qubit, qubit + 1)], []))
-        for orquestra_gate, qiskit_gate in EQUIVALENT_NONPARAMETRIC_SINGLE_QUBIT_GATES
+        (zquantum_gate(qubit), (qiskit_gate(), [qiskit_qubit(qubit, qubit + 1)], []))
+        for zquantum_gate, qiskit_gate in EQUIVALENT_NONPARAMETRIC_SINGLE_QUBIT_GATES
         for qubit in [0, 1, 4, 10]
     ],
     *[
         (
-            orquestra_gate(*qubit_pair),
+            zquantum_gate(*qubit_pair),
             (
                 qiskit_gate(),
                 [qiskit_qubit(qubit, max(qubit_pair) + 1) for qubit in qubit_pair],
                 [],
             ),
         )
-        for orquestra_gate, qiskit_gate in EQUIVALENT_NONPARAMETRIC_TWO_QUBIT_GATES
+        for zquantum_gate, qiskit_gate in EQUIVALENT_NONPARAMETRIC_TWO_QUBIT_GATES
         for qubit_pair in [(0, 1), (3, 4), (10, 1)]
     ],
     *[
         (
-            orquestra_gate(qubit, angle),
+            zquantum_gate(qubit, angle),
             (qiskit_gate(angle), [qiskit_qubit(qubit, qubit + 1)], []),
         )
-        for orquestra_gate, qiskit_gate in EQUIVALENT_SINGLE_QUBIT_ROTATION_GATES
+        for zquantum_gate, qiskit_gate in EQUIVALENT_SINGLE_QUBIT_ROTATION_GATES
         for qubit in [0, 1, 4, 10]
         for angle in [0, np.pi, np.pi / 2, 0.4, np.pi / 5]
     ],
     *[
         (
-            orquestra_gate(*qubit_pair, angle),
+            zquantum_gate(*qubit_pair, angle),
             (
                 qiskit_gate(angle),
                 [qiskit_qubit(qubit, max(qubit_pair) + 1) for qubit in qubit_pair],
                 [],
             ),
         )
-        for orquestra_gate, qiskit_gate in EQUIVALENT_TWO_QUBIT_ROTATION_GATES
+        for zquantum_gate, qiskit_gate in EQUIVALENT_TWO_QUBIT_ROTATION_GATES
         for qubit_pair in [(0, 1), (3, 4), (10, 1)]
         for angle in [0, np.pi, np.pi / 2, 0.4, np.pi / 5]
     ],
@@ -131,25 +131,25 @@ TEST_CASES_WITHOUT_SYMBOLIC_PARAMS = [
 TEST_CASES_WITH_SYMBOLIC_PARAMS = [
     *[
         (
-            orquestra_gate(qubit, orquestra_angle),
+            zquantum_gate(qubit, zquantum_angle),
             (qiskit_gate(qiskit_angle), [qiskit_qubit(qubit, qubit + 1)], []),
         )
-        for orquestra_gate, qiskit_gate in EQUIVALENT_SINGLE_QUBIT_ROTATION_GATES
+        for zquantum_gate, qiskit_gate in EQUIVALENT_SINGLE_QUBIT_ROTATION_GATES
         for qubit in [0, 1, 4, 10]
-        for orquestra_angle, qiskit_angle in EXAMPLE_SYMBOLIC_ANGLES
+        for zquantum_angle, qiskit_angle in EXAMPLE_SYMBOLIC_ANGLES
     ],
     *[
         (
-            orquestra_gate(*qubit_pair, orquestra_angle),
+            zquantum_gate(*qubit_pair, zquantum_angle),
             (
                 qiskit_gate(qiskit_angle),
                 [qiskit_qubit(qubit, max(qubit_pair) + 1) for qubit in qubit_pair],
                 [],
             ),
         )
-        for orquestra_gate, qiskit_gate in EQUIVALENT_TWO_QUBIT_ROTATION_GATES
+        for zquantum_gate, qiskit_gate in EQUIVALENT_TWO_QUBIT_ROTATION_GATES
         for qubit_pair in [(0, 1), (3, 4), (10, 1)]
-        for orquestra_angle, qiskit_angle in EXAMPLE_SYMBOLIC_ANGLES
+        for zquantum_angle, qiskit_angle in EXAMPLE_SYMBOLIC_ANGLES
     ],
 ]
 
@@ -277,31 +277,31 @@ def _are_qiskit_operations_equal(operation_1, operation_2):
 
 
 @pytest.mark.parametrize(
-    "orquestra_gate, qiskit_operation", TEST_CASES_WITHOUT_SYMBOLIC_PARAMS
+    "zquantum_gate, qiskit_operation", TEST_CASES_WITHOUT_SYMBOLIC_PARAMS
 )
 class TestGateConversionWithoutSymbolicParameters:
-    def test_converting_orquestra_gate_to_qiskit_gives_expected_operation(
-        self, orquestra_gate, qiskit_operation
+    def test_converting_zquantum_gate_to_qiskit_gives_expected_operation(
+        self, zquantum_gate, qiskit_operation
     ):
         assert (
-            convert_to_qiskit(orquestra_gate, max(orquestra_gate.qubits) + 1)
+            convert_to_qiskit(zquantum_gate, max(zquantum_gate.qubits) + 1)
             == qiskit_operation
         )
 
-    def test_converting_qiskit_operation_to_orquestra_gives_expected_gate(
-        self, orquestra_gate, qiskit_operation
+    def test_converting_qiskit_operation_to_zquantum_gives_expected_gate(
+        self, zquantum_gate, qiskit_operation
     ):
-        assert convert_from_qiskit(qiskit_operation) == orquestra_gate
+        assert convert_from_qiskit(qiskit_operation) == zquantum_gate
 
-    def test_orquestra_gate_and_qiskit_gate_have_the_same_matrix(
-        self, orquestra_gate, qiskit_operation
+    def test_zquantum_gate_and_qiskit_gate_have_the_same_matrix(
+        self, zquantum_gate, qiskit_operation
     ):
-        orquestra_matrix = np.array(orquestra_gate.matrix).astype(np.complex128)
-        if len(orquestra_gate.qubits) == 2:
-            orquestra_matrix = (
-                TWO_QUBIT_SWAP_MATRIX @ orquestra_matrix @ TWO_QUBIT_SWAP_MATRIX
+        zquantum_matrix = np.array(zquantum_gate.matrix).astype(np.complex128)
+        if len(zquantum_gate.qubits) == 2:
+            zquantum_matrix = (
+                TWO_QUBIT_SWAP_MATRIX @ zquantum_matrix @ TWO_QUBIT_SWAP_MATRIX
             )
-        np.testing.assert_allclose(orquestra_matrix, qiskit_operation[0].to_matrix())
+        np.testing.assert_allclose(zquantum_matrix, qiskit_operation[0].to_matrix())
 
 
 class TestQiskitQubit:
@@ -315,58 +315,58 @@ class TestQiskitQubit:
 
 
 @pytest.mark.parametrize(
-    "orquestra_gate, qiskit_operation", TEST_CASES_WITH_SYMBOLIC_PARAMS
+    "zquantum_gate, qiskit_operation", TEST_CASES_WITH_SYMBOLIC_PARAMS
 )
 class TestGateConversionWithSymbolicParameters:
-    def test_converting_orquestra_gate_to_qiskit_gives_expected_operation(
-        self, orquestra_gate, qiskit_operation
+    def test_converting_zquantum_gate_to_qiskit_gives_expected_operation(
+        self, zquantum_gate, qiskit_operation
     ):
         assert _are_qiskit_operations_equal(
-            convert_to_qiskit(orquestra_gate, max(orquestra_gate.qubits) + 1),
+            convert_to_qiskit(zquantum_gate, max(zquantum_gate.qubits) + 1),
             qiskit_operation,
         )
 
-    def test_converting_qiskit_operation_to_orquestra_gives_expected_gate(
-        self, orquestra_gate, qiskit_operation
+    def test_converting_qiskit_operation_to_zquantum_gives_expected_gate(
+        self, zquantum_gate, qiskit_operation
     ):
-        assert convert_from_qiskit(qiskit_operation) == orquestra_gate
+        assert convert_from_qiskit(qiskit_operation) == zquantum_gate
 
 
 @pytest.mark.parametrize(
-    "orquestra_gate, qiskit_operation", TEST_CASES_FOR_CONTROLLED_GATES
+    "zquantum_gate, qiskit_operation", TEST_CASES_FOR_CONTROLLED_GATES
 )
 class TestGateConversionForControlledGates:
-    def test_converting_orquestra_gate_to_qiskit_gives_expected_operation(
-        self, orquestra_gate, qiskit_operation
+    def test_converting_zquantum_gate_to_qiskit_gives_expected_operation(
+        self, zquantum_gate, qiskit_operation
     ):
         assert _are_qiskit_operations_equal(
-            convert_to_qiskit(orquestra_gate, max(orquestra_gate.qubits) + 1),
+            convert_to_qiskit(zquantum_gate, max(zquantum_gate.qubits) + 1),
             qiskit_operation,
         )
 
-    def test_converting_qiskit_operation_to_orquestra_gives_expected_gate(
-        self, orquestra_gate, qiskit_operation
+    def test_converting_qiskit_operation_to_zquantum_gives_expected_gate(
+        self, zquantum_gate, qiskit_operation
     ):
-        assert convert_from_qiskit(qiskit_operation) == orquestra_gate
+        assert convert_from_qiskit(qiskit_operation) == zquantum_gate
 
 
 def _draw_qiskit_circuit(circuit):
     return qiskit.visualization.circuit_drawer(circuit, output="text")
 
 
-@pytest.mark.parametrize("orquestra_circuit, qiskit_circuit", EQUIVALENT_CIRCUITS)
+@pytest.mark.parametrize("zquantum_circuit, qiskit_circuit", EQUIVALENT_CIRCUITS)
 class TestCircuitConversion:
-    def test_converting_orquestra_circuit_to_qiskit_gives_expected_circuit(
-        self, orquestra_circuit, qiskit_circuit
+    def test_converting_zquantum_circuit_to_qiskit_gives_expected_circuit(
+        self, zquantum_circuit, qiskit_circuit
     ):
-        converted = convert_to_qiskit(orquestra_circuit)
+        converted = convert_to_qiskit(zquantum_circuit)
         assert converted == qiskit_circuit, (
             f"Converted circuit:\n{_draw_qiskit_circuit(converted)}\n isn't equal "
             f"to\n{_draw_qiskit_circuit(qiskit_circuit)}"
         )
 
-    def test_converting_qiskit_circuit_to_orquestra_gives_expected_circuit(
-        self, orquestra_circuit, qiskit_circuit
+    def test_converting_qiskit_circuit_to_zquantum_gives_expected_circuit(
+        self, zquantum_circuit, qiskit_circuit
     ):
         converted = convert_from_qiskit(qiskit_circuit)
-        assert converted == orquestra_circuit
+        assert converted == zquantum_circuit

--- a/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions_test.py
@@ -3,7 +3,6 @@ import numpy as np
 import sympy
 import pytest
 
-from ..gates import ControlledGate, CustomGate
 from .. import (
     X,
     Y,
@@ -173,22 +172,31 @@ def _parametric_qiskit_circuit():
 
 EQUIVALENT_CIRCUITS = [
     (
-        Circuit([
-            X(0),
-            Z(3),
-        ], 6),
+        Circuit(
+            [
+                X(0),
+                Z(3),
+            ],
+            6,
+        ),
         _single_qubit_qiskit_circuit(),
     ),
     (
-        Circuit([
-            CNOT(1, 3),
-        ], 4),
+        Circuit(
+            [
+                CNOT(1, 3),
+            ],
+            4,
+        ),
         _two_qubit_qiskit_circuit(),
     ),
     (
-        Circuit([
-            RX(2, np.pi),
-        ], 4),
+        Circuit(
+            [
+                RX(2, np.pi),
+            ],
+            4,
+        ),
         _parametric_qiskit_circuit(),
     ),
 ]
@@ -273,14 +281,16 @@ class TestGateConversionWithSymbolicParameters:
 
 
 def _draw_qiskit_circuit(circuit):
-    return qiskit.visualization.circuit_drawer(circuit, output='text')
+    return qiskit.visualization.circuit_drawer(circuit, output="text")
 
 
-@pytest.mark.parametrize(
-    "orquestra_circuit, qiskit_circuit", EQUIVALENT_CIRCUITS
-)
+@pytest.mark.parametrize("orquestra_circuit, qiskit_circuit", EQUIVALENT_CIRCUITS)
 class TestCircuitConversion:
-    def test_converting_orquestra_circuit_to_qiskit_gives_expected_circuit(self, orquestra_circuit, qiskit_circuit):
+    def test_converting_orquestra_circuit_to_qiskit_gives_expected_circuit(
+        self, orquestra_circuit, qiskit_circuit
+    ):
         converted = convert_to_qiskit(orquestra_circuit)
-        assert converted == qiskit_circuit, \
-            f"Converted circuit:\n{_draw_qiskit_circuit(converted)}\n isn't equal to {_draw_qiskit_circuit(qiskit_circuit)}"
+        assert converted == qiskit_circuit, (
+            f"Converted circuit:\n{_draw_qiskit_circuit(converted)}\n isn't equal"
+            f"to {_draw_qiskit_circuit(qiskit_circuit)}"
+        )

--- a/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions_test.py
@@ -364,3 +364,9 @@ class TestCircuitConversion:
             f"Converted circuit:\n{_draw_qiskit_circuit(converted)}\n isn't equal "
             f"to\n{_draw_qiskit_circuit(qiskit_circuit)}"
         )
+
+    def test_converting_qiskit_circuit_to_orquestra_gives_expected_circuit(
+        self, orquestra_circuit, qiskit_circuit
+    ):
+        converted = convert_from_qiskit(qiskit_circuit)
+        assert converted == orquestra_circuit

--- a/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions_test.py
@@ -153,7 +153,7 @@ TEST_CASES_WITH_SYMBOLIC_PARAMS = [
 
 
 def _single_qubit_qiskit_circuit():
-    qc = qiskit.QuantumCircuit(4)
+    qc = qiskit.QuantumCircuit(6)
     qc.x(0)
     qc.z(3)
     return qc
@@ -176,19 +176,19 @@ EQUIVALENT_CIRCUITS = [
         Circuit([
             X(0),
             Z(3),
-        ]),
+        ], 6),
         _single_qubit_qiskit_circuit(),
     ),
     (
         Circuit([
             CNOT(1, 3),
-        ]),
+        ], 4),
         _two_qubit_qiskit_circuit(),
     ),
     (
         Circuit([
             RX(2, np.pi),
-        ]),
+        ], 4),
         _parametric_qiskit_circuit(),
     ),
 ]

--- a/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions/qiskit_conversions_test.py
@@ -208,7 +208,7 @@ def _parametric_qiskit_circuit():
 
 
 def _qiskit_circuit_with_controlled_gate():
-    qc = qiskit.QuantumCircuit(4)
+    qc = qiskit.QuantumCircuit(5)
     qc.append(qiskit.extensions.SwapGate().control(1), [1, 0, 2])
     return qc
 
@@ -249,7 +249,7 @@ EQUIVALENT_CIRCUITS = [
             ],
             5,
         ),
-        _parametric_qiskit_circuit(),
+        _qiskit_circuit_with_controlled_gate(),
     ),
 ]
 

--- a/src/python/zquantum/core/wip/circuit/gates/_gate.py
+++ b/src/python/zquantum/core/wip/circuit/gates/_gate.py
@@ -361,6 +361,9 @@ class ControlledGate(SpecializedGate):
         target_matrix = self.target_gate.matrix
         return sympy.Matrix.diag(sympy.eye(target_matrix.shape[0]), target_matrix)
 
+    def __repr__(self):
+        return f"{type(self).__name__}(target_gate={self.target_gate}, control={self.control})"
+
 
 class Dagger(SpecializedGate):
     def __init__(self, gate: Gate):

--- a/src/python/zquantum/core/wip/circuit/gates/_gate.py
+++ b/src/python/zquantum/core/wip/circuit/gates/_gate.py
@@ -25,7 +25,7 @@ GATE_SCHEMA = SCHEMA_VERSION + "-gate"
 MATRIX_SCHEMA = SCHEMA_VERSION + "-matrix"
 
 
-def _matrix_to_dict(matrix: sympy.Matrix):
+def matrix_to_dict(matrix: sympy.Matrix):
     return {
         "schema": MATRIX_SCHEMA,
         "rows": [
@@ -182,7 +182,7 @@ class Gate(ABC):
         return {
             "schema": GATE_SCHEMA,
             "qubits": list(self.qubits),
-            "matrix": _matrix_to_dict(self.matrix),
+            "matrix": matrix_to_dict(self.matrix),
             "symbolic_params": [str(param) for param in self.symbolic_params],
         }
 

--- a/src/python/zquantum/core/wip/circuit/gates/_gate_test.py
+++ b/src/python/zquantum/core/wip/circuit/gates/_gate_test.py
@@ -462,19 +462,19 @@ class TestGateSerialization:
     ):
         gate = CustomGate(matrix, qubits)
 
-        gate_dict = gate.to_dict(serializable=False)
+        gate_dict = gate.to_dict()
 
         assert gate_dict["schema"] == SCHEMA_VERSION + "-gate"
-        assert gate_dict["qubits"] == qubits
-        assert gate_dict["matrix"] == matrix
-        assert gate_dict["symbolic_params"] == gate.symbolic_params
+        assert gate_dict["qubits"] == list(qubits)
+        # matrix is another object serialized on its own, so it's not easy to compare
+        assert gate_dict["symbolic_params"] == list(map(str, gate.symbolic_params))
 
-    def test_gates_matrix_is_expanded_if_serializable_is_set_to_true(
+    def test_gates_matrix_is_expanded(
         self, matrix, qubits
     ):
         gate = CustomGate(matrix, qubits)
 
-        gate_dict = gate.to_dict(serializable=True)
+        gate_dict = gate.to_dict()
 
         assert gate_dict["schema"] == SCHEMA_VERSION + "-gate"
         assert gate_dict["qubits"] == list(qubits)
@@ -483,7 +483,7 @@ class TestGateSerialization:
             symbol: sympy.Symbol(symbol) for symbol in gate_dict["symbolic_params"]
         }
 
-        for row_index, row in enumerate(gate_dict["matrix"]):
+        for row_index, row in enumerate(gate_dict["matrix"]["rows"]):
             for col_index, element in enumerate(row["elements"]):
                 assert (
                     sympy.sympify(element, locals=symbols)
@@ -493,7 +493,7 @@ class TestGateSerialization:
             str(param) for param in gate.symbolic_params
         ]
 
-    def test_saving_gate_to_a_file_outputs_the_same_dictionary_as_to_dict_with_serializable_set_to_true(
+    def test_saving_gate_to_a_file_outputs_the_same_dictionary_as_to_dict(
         self, matrix, qubits
     ):
         gate = CustomGate(matrix, qubits)
@@ -503,7 +503,7 @@ class TestGateSerialization:
         with open("gate.json", "r") as f:
             saved_data = json.load(f)
 
-        assert saved_data == gate.to_dict(serializable=True)
+        assert saved_data == gate.to_dict()
 
         os.remove("gate.json")
 
@@ -518,12 +518,11 @@ class TestGateSerialization:
         os.remove("gate.json")
 
     def test_loading_gate_from_dict_gives_the_same_gate(self, matrix, qubits):
-        for serializable in [True, False]:
-            gate = CustomGate(matrix, qubits)
+        gate = CustomGate(matrix, qubits)
 
-            gate_dict = gate.to_dict(serializable=serializable)
+        gate_dict = gate.to_dict()
 
-            assert gate == Gate.load(gate_dict)
+        assert gate == Gate.load(gate_dict)
 
 
 @pytest.mark.parametrize(

--- a/src/python/zquantum/core/wip/circuit/gates/_gate_test.py
+++ b/src/python/zquantum/core/wip/circuit/gates/_gate_test.py
@@ -4,7 +4,7 @@ import json
 import os
 import sympy
 from ....utils import SCHEMA_VERSION
-from ._gate import Gate, CustomGate, ControlledGate, _matrix_to_dict
+from ._gate import Gate, CustomGate, matrix_to_dict
 
 THETA = sympy.Symbol("theta")
 
@@ -466,13 +466,8 @@ class TestGateSerialization:
 
         assert gate_dict["schema"] == SCHEMA_VERSION + "-gate"
         assert gate_dict["qubits"] == list(qubits)
+        assert gate_dict["matrix"] == matrix_to_dict(matrix.evalf())
         # matrix is another object serialized on its own, so it's not easy to compare
-        expected_matrix_dict = _matrix_to_dict(matrix)
-        assert all(
-            Gate.are_elements_equal(first, second)
-            for row1, row2 in zip(gate_dict["matrix"]["rows"], expected_matrix_dict["rows"])
-            for first, second in zip(row1["elements"], row2["elements"])
-        )
         assert gate_dict["symbolic_params"] == list(map(str, gate.symbolic_params))
 
     def test_gates_matrix_is_expanded(

--- a/src/python/zquantum/core/wip/circuit/gates/_gate_test.py
+++ b/src/python/zquantum/core/wip/circuit/gates/_gate_test.py
@@ -4,7 +4,7 @@ import json
 import os
 import sympy
 from ....utils import SCHEMA_VERSION
-from ._gate import Gate, CustomGate, ControlledGate
+from ._gate import Gate, CustomGate, ControlledGate, _matrix_to_dict
 
 THETA = sympy.Symbol("theta")
 
@@ -467,6 +467,12 @@ class TestGateSerialization:
         assert gate_dict["schema"] == SCHEMA_VERSION + "-gate"
         assert gate_dict["qubits"] == list(qubits)
         # matrix is another object serialized on its own, so it's not easy to compare
+        expected_matrix_dict = _matrix_to_dict(matrix)
+        assert all(
+            Gate.are_elements_equal(first, second)
+            for row1, row2 in zip(gate_dict["matrix"]["rows"], expected_matrix_dict["rows"])
+            for first, second in zip(row1["elements"], row2["elements"])
+        )
         assert gate_dict["symbolic_params"] == list(map(str, gate.symbolic_params))
 
     def test_gates_matrix_is_expanded(

--- a/src/python/zquantum/core/wip/circuit/gates/_two_qubit_gates.py
+++ b/src/python/zquantum/core/wip/circuit/gates/_two_qubit_gates.py
@@ -25,12 +25,18 @@ class CNOT(HermitianMixin, ControlledGate):
     def __init__(self, control: int, target: int):
         super().__init__(X(target), control)
 
+    __repr__ = SpecializedGate.__repr__
+    __str__ = SpecializedGate.__str__
+
 
 class CZ(HermitianMixin, ControlledGate):
     """"Controlled Z gate."""
 
     def __init__(self, control: int, target: int):
         super().__init__(Z(target), control)
+
+    __repr__ = SpecializedGate.__repr__
+    __str__ = SpecializedGate.__str__
 
 
 class CPHASE(ControlledGate):
@@ -44,6 +50,9 @@ class CPHASE(ControlledGate):
     ):
         super().__init__(PHASE(target, angle), control)
         self.angle = angle
+
+    __repr__ = SpecializedGate.__repr__
+    __str__ = SpecializedGate.__str__
 
 
 class SWAP(HermitianMixin, SpecializedGate):


### PR DESCRIPTION
Adds support for translating whole circuits between Orquestra and Qiskit. Builds upon changes from #197 where only gate-level translation was supported. Developed in pair with @dexter2206.

Additionally, the PR contains a subtle refactor of the Circuit class:
- adds `n_qubits` property to allow representing circuits with unused qubits. Qiskit allows it already, so it was necessary for converting between the two frameworks.
- removes the `qubits` property, as I couldn't think of use cases for it and it provided no additional information over the afromentioned `n_qubits`. 
- removes support for passing `serializable=False` flag to `to_dict()` method. Like above, I couldn't think of a use-case for generating non-serializable dictionaries. 
- reimplements the `__add__` operator, so it supports concatenating two circuits together horizontally + to allow defining the circuit with gates in a similar way to PyQuil, while keeping the objects immutable, like:
```
circuit = Circuit()
circuit += X(0)
circuit += RX(0, 0)
```

Considering the code removals – I believe we should go for a codebase that's as small as possible, with **just right** feature  set size. Smaller code usually means easier software design and less maintenance + there's no point in having a feature if nobody uses it.

If you find a use-case that I didn't, please let me know! I'm open to re-thinking how to address that need.