### PR TITLE
Removing __init__.py from zquantum

### DIFF
--- a/src/python/zquantum/core/bitstring_distribution/_bitstring_distribution_test.py
+++ b/src/python/zquantum/core/bitstring_distribution/_bitstring_distribution_test.py
@@ -22,6 +22,7 @@ from ._bitstring_distribution import (
     evaluate_distribution_distance,
     BitstringDistribution,
 )
+
 from ..utils import SCHEMA_VERSION
 
 
@@ -172,7 +173,7 @@ def test_passed_measure_is_used_for_evaluating_distribution_distance():
 def mock_open():
     mock_open = mock.mock_open()
     with mock.patch(
-        "zquantum.core.bitstring_distribution._bitstring_distribution.open", mock_open
+        "core.bitstring_distribution._bitstring_distribution.open", mock_open
     ):
         yield mock_open
 


### PR DESCRIPTION
Having an `__init__.py` in `src/python/zquantum` prevents the importing of other packages in the `zquantum` namespace such as `z-quantum-inference`.