### PR TITLE
Gate Operations decoupled from gates

### DIFF
--- a/src/python/zquantum/core/wip/circuit/_circuit2_test.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit2_test.py
@@ -1,0 +1,32 @@
+import pytest
+import numpy as np
+import sympy
+
+from ._builtin_gates import X, Y, Z, H, I, RX, RY, RZ, PHASE, T, CNOT, CZ, SWAP, ISWAP, CPHASE, XX, YY, ZZ
+from ._gates import Circuit
+
+
+RNG = np.random.default_rng(42)
+
+EXAMPLE_OPERATIONS = tuple([
+    *[gate(qubit_i)
+      for qubit_i in [0, 1, 4]
+      for gate in [X, Y, Z, H, I, T]],
+    *[gate(angle)(qubit_i)
+      for qubit_i in [0, 1, 4]
+      for gate in [PHASE, RX, RY, RZ]
+      for angle in [0, 0.1, np.pi / 5, np.pi, 2 * np.pi, sympy.Symbol("theta")]],
+    *[gate(qubit1_i, qubit2_i)
+      for qubit1_i, qubit2_i in [(0, 1), (1, 0), (0, 5), (4, 2)]
+      for gate in [CNOT, CZ, SWAP, ISWAP]],
+    *[gate(angle)(qubit1_i, qubit2_i)
+      for qubit1_i, qubit2_i in [(0, 1), (1, 0), (0, 5), (4, 2)]
+      for gate in [CPHASE, XX, YY, ZZ]
+      for angle in [0, 0.1, np.pi / 5, np.pi, 2 * np.pi, sympy.Symbol("theta")]],
+])
+
+
+def test_creating_circuit_has_correct_gates():
+    """The Circuit class should have the correct gates that are passed in"""
+    circuit = Circuit(operations=EXAMPLE_OPERATIONS)
+    assert circuit.operations == list(EXAMPLE_OPERATIONS)

--- a/src/python/zquantum/core/wip/circuit/_circuit2_test.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit2_test.py
@@ -26,7 +26,15 @@ EXAMPLE_OPERATIONS = tuple([
 ])
 
 
-def test_creating_circuit_has_correct_gates():
-    """The Circuit class should have the correct gates that are passed in"""
+def test_creating_circuit_has_correct_operations():
     circuit = Circuit(operations=EXAMPLE_OPERATIONS)
     assert circuit.operations == list(EXAMPLE_OPERATIONS)
+
+
+def test_appending_to_circuit_yields_correct_operations():
+    circuit = Circuit()
+    circuit += H(0)
+    circuit += CNOT(0, 2)
+
+    assert circuit.operations == [H(0), CNOT(0, 2)]
+    assert circuit.n_qubits == 3

--- a/src/python/zquantum/core/wip/circuit/_circuit2_test.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit2_test.py
@@ -2,28 +2,53 @@ import pytest
 import numpy as np
 import sympy
 
-from ._builtin_gates import X, Y, Z, H, I, RX, RY, RZ, PHASE, T, CNOT, CZ, SWAP, ISWAP, CPHASE, XX, YY, ZZ
+from ._builtin_gates import (
+    X,
+    Y,
+    Z,
+    H,
+    I,
+    RX,
+    RY,
+    RZ,
+    PHASE,
+    T,
+    CNOT,
+    CZ,
+    SWAP,
+    ISWAP,
+    CPHASE,
+    XX,
+    YY,
+    ZZ,
+)
 from ._gates import Circuit
 
 
 RNG = np.random.default_rng(42)
 
-EXAMPLE_OPERATIONS = tuple([
-    *[gate(qubit_i)
-      for qubit_i in [0, 1, 4]
-      for gate in [X, Y, Z, H, I, T]],
-    *[gate(angle)(qubit_i)
-      for qubit_i in [0, 1, 4]
-      for gate in [PHASE, RX, RY, RZ]
-      for angle in [0, 0.1, np.pi / 5, np.pi, 2 * np.pi, sympy.Symbol("theta")]],
-    *[gate(qubit1_i, qubit2_i)
-      for qubit1_i, qubit2_i in [(0, 1), (1, 0), (0, 5), (4, 2)]
-      for gate in [CNOT, CZ, SWAP, ISWAP]],
-    *[gate(angle)(qubit1_i, qubit2_i)
-      for qubit1_i, qubit2_i in [(0, 1), (1, 0), (0, 5), (4, 2)]
-      for gate in [CPHASE, XX, YY, ZZ]
-      for angle in [0, 0.1, np.pi / 5, np.pi, 2 * np.pi, sympy.Symbol("theta")]],
-])
+EXAMPLE_OPERATIONS = tuple(
+    [
+        *[gate(qubit_i) for qubit_i in [0, 1, 4] for gate in [X, Y, Z, H, I, T]],
+        *[
+            gate(angle)(qubit_i)
+            for qubit_i in [0, 1, 4]
+            for gate in [PHASE, RX, RY, RZ]
+            for angle in [0, 0.1, np.pi / 5, np.pi, 2 * np.pi, sympy.Symbol("theta")]
+        ],
+        *[
+            gate(qubit1_i, qubit2_i)
+            for qubit1_i, qubit2_i in [(0, 1), (1, 0), (0, 5), (4, 2)]
+            for gate in [CNOT, CZ, SWAP, ISWAP]
+        ],
+        *[
+            gate(angle)(qubit1_i, qubit2_i)
+            for qubit1_i, qubit2_i in [(0, 1), (1, 0), (0, 5), (4, 2)]
+            for gate in [CPHASE, XX, YY, ZZ]
+            for angle in [0, 0.1, np.pi / 5, np.pi, 2 * np.pi, sympy.Symbol("theta")]
+        ],
+    ]
+)
 
 
 def test_creating_circuit_has_correct_operations():
@@ -48,7 +73,12 @@ class TestCircuitConcatenation:
         circuit2 = Circuit([X(2), YY(sympy.Symbol("theta"))(5)])
 
         res_circuit = circuit1 + circuit2
-        assert res_circuit.operations == [H(0), CNOT(0, 2), X(2), YY(sympy.Symbol("theta"))(5)]
+        assert res_circuit.operations == [
+            H(0),
+            CNOT(0, 2),
+            X(2),
+            YY(sympy.Symbol("theta"))(5),
+        ]
         assert res_circuit.n_qubits == 6
 
 
@@ -71,7 +101,7 @@ class TestBindingParams:
                 RX(theta1).bind(symbols_map)(0),
                 RY(theta2).bind(symbols_map)(1),
                 RZ(theta3).bind(symbols_map)(0),
-                RX(theta3).bind(symbols_map)(0)
+                RX(theta3).bind(symbols_map)(0),
             ]
         )
 

--- a/src/python/zquantum/core/wip/circuit/_circuit2_test.py
+++ b/src/python/zquantum/core/wip/circuit/_circuit2_test.py
@@ -38,3 +38,15 @@ def test_appending_to_circuit_yields_correct_operations():
 
     assert circuit.operations == [H(0), CNOT(0, 2)]
     assert circuit.n_qubits == 3
+
+
+def test_circuits_sum_yields_correct_operations():
+    circuit1 = Circuit()
+    circuit1 += H(0)
+    circuit1 += CNOT(0, 2)
+
+    circuit2 = Circuit([X(2), YY(sympy.Symbol("theta"))(5)])
+
+    res_circuit = circuit1 + circuit2
+    assert res_circuit.operations == [H(0), CNOT(0, 2), X(2), YY(sympy.Symbol("theta"))(5)]
+    assert res_circuit.n_qubits == 6

--- a/src/python/zquantum/core/wip/circuit/_gates.py
+++ b/src/python/zquantum/core/wip/circuit/_gates.py
@@ -366,7 +366,9 @@ class Circuit:
     def free_symbols(self):
         """Set of all the sympy symbols used as params of gates in the circuit."""
         return reduce(
-            set.union, (_free_symbols(operation.gate.params) for operation in self._operations), set()
+            set.union,
+            (_free_symbols(operation.gate.params) for operation in self._operations),
+            set(),
         )
 
     def __eq__(self, other: "Circuit"):

--- a/src/python/zquantum/core/wip/circuit/_gates.py
+++ b/src/python/zquantum/core/wip/circuit/_gates.py
@@ -142,6 +142,7 @@ class MatrixFactoryGate:
             name=self.name,
             matrix_factory=self.matrix_factory,
             params=new_symbols,
+            num_qubits=self.num_qubits,
         )
 
     def controlled(self, num_controlled_qubits: int) -> Gate:

--- a/src/python/zquantum/core/wip/circuit/_gates.py
+++ b/src/python/zquantum/core/wip/circuit/_gates.py
@@ -3,7 +3,7 @@ import math
 from dataclasses import dataclass
 from functools import singledispatch
 from numbers import Number
-from typing import Tuple, Union, Callable, Dict
+from typing import Tuple, Union, Callable, Dict, NamedTuple
 
 import sympy
 from typing_extensions import Protocol
@@ -61,6 +61,16 @@ class Gate(Protocol):
     def bind(self, symbols_map: Dict[sympy.Symbol, Parameter]) -> "Gate":
         raise NotImplementedError()
 
+    def __call__(self, *qubit_indices: Tuple[int, ...]) -> "GateOperation":
+        """Apply this gate on qubits in a circuit."""
+        return GateOperation(self, qubit_indices)
+
+
+@dataclass(frozen=True)
+class GateOperation:
+    gate: Gate
+    qubit_indices: Tuple[int, ...]
+
 
 @singledispatch
 def _sub_symbols(parameter, symbols_map: Dict[sympy.Symbol, Parameter]) -> Parameter:
@@ -84,7 +94,7 @@ def _sub_symbols_in_symbol(parameter: sympy.Symbol, symbols_map: Dict[sympy.Symb
 
 @dataclass(frozen=True)
 class MatrixFactoryGate:
-    """Gate with a deferred matrix construction.
+    """`Gate` protocol implementation with a deferred matrix construction.
 
     Most built-in gates are instances of this class.
 
@@ -142,6 +152,8 @@ class MatrixFactoryGate:
             if self.params
             else self.name
         )
+
+    __call__ = Gate.__call__
 
 
 @dataclass(frozen=True)

--- a/src/python/zquantum/core/wip/circuit/_gates.py
+++ b/src/python/zquantum/core/wip/circuit/_gates.py
@@ -380,3 +380,20 @@ class Circuit:
 @singledispatch
 def _append_to_circuit(other, circuit: Circuit):
     raise NotImplementedError()
+
+
+@_append_to_circuit.register
+def _append_operation(other: GateOperation, circuit: Circuit):
+    n_qubits_by_operation = max(other.qubit_indices) + 1
+    return type(circuit)(
+        operations=[*circuit.operations, other],
+        n_qubits=max(circuit.n_qubits, n_qubits_by_operation),
+    )
+
+
+@_append_to_circuit.register
+def _append_circuit(other: Circuit, circuit: Circuit):
+    return type(circuit)(
+        operations=[*circuit.operations, *other.operations],
+        n_qubits=max(circuit.n_qubits, other.n_qubits),
+    )

--- a/src/python/zquantum/core/wip/circuit/_gates.py
+++ b/src/python/zquantum/core/wip/circuit/_gates.py
@@ -78,17 +78,23 @@ def _sub_symbols(parameter, symbols_map: Dict[sympy.Symbol, Parameter]) -> Param
 
 
 @_sub_symbols.register
-def _sub_symbols_in_number(parameter: Number, symbols_map: Dict[sympy.Symbol, Parameter]) -> Number:
+def _sub_symbols_in_number(
+    parameter: Number, symbols_map: Dict[sympy.Symbol, Parameter]
+) -> Number:
     return parameter
 
 
 @_sub_symbols.register
-def _sub_symbols_in_expression(parameter: sympy.Expr, symbols_map: Dict[sympy.Symbol, Parameter]) -> sympy.Expr:
+def _sub_symbols_in_expression(
+    parameter: sympy.Expr, symbols_map: Dict[sympy.Symbol, Parameter]
+) -> sympy.Expr:
     return parameter.subs(symbols_map)
 
 
 @_sub_symbols.register
-def _sub_symbols_in_symbol(parameter: sympy.Symbol, symbols_map: Dict[sympy.Symbol, Parameter]) -> Parameter:
+def _sub_symbols_in_symbol(
+    parameter: sympy.Symbol, symbols_map: Dict[sympy.Symbol, Parameter]
+) -> Parameter:
     return symbols_map.get(parameter, parameter)
 
 
@@ -136,7 +142,6 @@ class MatrixFactoryGate:
             name=self.name,
             matrix_factory=self.matrix_factory,
             params=new_symbols,
-            num_qubits=self.num_qubits
         )
 
     def controlled(self, num_controlled_qubits: int) -> Gate:
@@ -173,7 +178,7 @@ class ControlledGate(Gate):
     def matrix(self):
         return sympy.Matrix.diag(
             sympy.eye(2 ** self.num_qubits - 2 ** self.wrapped_gate.num_qubits),
-            self.wrapped_gate.matrix
+            self.wrapped_gate.matrix,
         )
 
     @property
@@ -183,14 +188,14 @@ class ControlledGate(Gate):
     def controlled(self, num_control_qubits: int) -> "ControlledGate":
         return ControlledGate(
             wrapped_gate=self.wrapped_gate,
-            num_control_qubits=self.num_control_qubits + num_control_qubits
+            num_control_qubits=self.num_control_qubits + num_control_qubits,
         )
 
     @property
     def dagger(self) -> "ControlledGate":
         return ControlledGate(
             wrapped_gate=self.wrapped_gate.dagger,
-            num_control_qubits=self.num_control_qubits
+            num_control_qubits=self.num_control_qubits,
         )
 
     def bind(self, symbols_map) -> "Gate":
@@ -306,16 +311,28 @@ def _circuit_size_by_operations(operations):
     return (
         0
         if not operations
-        else max(qubit_index for operation in operations for qubit_index in operation.qubit_indices) + 1
+        else max(
+            qubit_index
+            for operation in operations
+            for qubit_index in operation.qubit_indices
+        )
+        + 1
     )
 
 
 class Circuit:
     """ZQuantum representation of a quantum circuit."""
-    def __init__(self, operations: Optional[Iterable[GateOperation]] = None, n_qubits: Optional[int] = None):
+
+    def __init__(
+        self,
+        operations: Optional[Iterable[GateOperation]] = None,
+        n_qubits: Optional[int] = None,
+    ):
         self._operations = list(operations) if operations is not None else []
         self._n_qubits = (
-            n_qubits if n_qubits is not None else _circuit_size_by_operations(self._operations)
+            n_qubits
+            if n_qubits is not None
+            else _circuit_size_by_operations(self._operations)
         )
 
     @property
@@ -333,7 +350,9 @@ class Circuit:
     @property
     def symbolic_params(self):
         """Set of all the sympy symbols used as params of gates in the circuit."""
-        return reduce(set.union, (set(gate.symbolic_params) for gate in self._operations), set())
+        return reduce(
+            set.union, (set(gate.symbolic_params) for gate in self._operations), set()
+        )
 
     def __eq__(self, other: "Circuit"):
         if not isinstance(other, type(self)):

--- a/src/python/zquantum/core/wip/circuit/_gates_test.py
+++ b/src/python/zquantum/core/wip/circuit/_gates_test.py
@@ -102,6 +102,15 @@ class TestMatrixFactoryGate:
         gate = MatrixFactoryGate("V", example_one_qubit_matrix_factory, (1, 0), 1)
         assert gate.dagger.dagger is gate
 
+    def test_applying_gate_returns_operation_with_correct_gate_and_indices(self):
+        theta = sympy.Symbol("theta")
+        gamma = sympy.Symbol("gamma")
+        gate = MatrixFactoryGate("A", example_two_qubit_matrix_factory, (theta, gamma, 42), 2)
+        operation = gate(4, 1)
+
+        assert operation.gate == gate
+        assert operation.qubit_indices == (4, 1)
+
 
 @pytest.mark.parametrize(
     "gate",


### PR DESCRIPTION
- Calling a gate returns a `GateOperation` that contains information about the applied gate and what qubit indices the gate is to be applied to.
- The PR also contains a Circuit class without (de)serialization support. I'd like to tackle the serialization in another PR.