### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,6 @@ setuptools.setup(
         "cirq>=0.9.1",
         "qiskit==0.23.2",
         "overrides>=3.1.0",
+        "ruamel.yaml"
     ],
 )


### PR DESCRIPTION
ruamel.yaml is necessary for inputs to succeed (imported over the pyquil dependencies)
problem might only occur when customImage is hosted