### PR TITLE
Import+export for custom gates in Qiskit

### DIFF
--- a/src/python/zquantum/core/wip/circuit/_gates.py
+++ b/src/python/zquantum/core/wip/circuit/_gates.py
@@ -359,11 +359,11 @@ class CustomGateDefinition:
         n_qubits = _n_qubits(self.matrix)
         object.__setattr__(self, "_n_qubits", n_qubits)
 
-    def __call__(self, *params):
+    def __call__(self, *gate_params):
         return MatrixFactoryGate(
             self.gate_name,
             FixedMatrixFactory(self.matrix, self.params_ordering),
-            params,
+            gate_params,
             self._n_qubits,
         )
 

--- a/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions.py
+++ b/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions.py
@@ -94,7 +94,7 @@ def export_to_qiskit(circuit: _gates.Circuit) -> qiskit.QuantumCircuit:
             gate_op.gate,
             applied_qubit_indices=gate_op.qubit_indices,
             n_qubits_in_circuit=circuit.n_qubits,
-            custom_names=custom_names
+            custom_names=custom_names,
         )
         for gate_op in circuit.operations
     ]
@@ -104,23 +104,26 @@ def export_to_qiskit(circuit: _gates.Circuit) -> qiskit.QuantumCircuit:
 
 
 def _export_gate_to_qiskit(
-        gate,
-        applied_qubit_indices,
-        n_qubits_in_circuit,
-        custom_names
+    gate, applied_qubit_indices, n_qubits_in_circuit, custom_names
 ):
     try:
-        return _export_gate_via_mapping(gate, applied_qubit_indices, n_qubits_in_circuit, custom_names)
+        return _export_gate_via_mapping(
+            gate, applied_qubit_indices, n_qubits_in_circuit, custom_names
+        )
     except ValueError:
         pass
 
     try:
-        return _export_controlled_gate(gate, applied_qubit_indices, n_qubits_in_circuit, custom_names)
+        return _export_controlled_gate(
+            gate, applied_qubit_indices, n_qubits_in_circuit, custom_names
+        )
     except ValueError:
         pass
 
     try:
-        return _export_custom_gate(gate, applied_qubit_indices, n_qubits_in_circuit, custom_names)
+        return _export_custom_gate(
+            gate, applied_qubit_indices, n_qubits_in_circuit, custom_names
+        )
     except ValueError:
         pass
 
@@ -128,10 +131,7 @@ def _export_gate_to_qiskit(
 
 
 def _export_gate_via_mapping(
-        gate,
-        applied_qubit_indices,
-        n_qubits_in_circuit,
-        custom_names
+    gate, applied_qubit_indices, n_qubits_in_circuit, custom_names
 ):
     try:
         qiskit_cls = ZQUANTUM_QISKIT_GATE_MAP[bg.builtin_gate_by_name(gate.name)]
@@ -162,7 +162,7 @@ def _export_controlled_gate(
         gate.wrapped_gate,
         applied_qubit_indices=target_indices,
         n_qubits_in_circuit=n_qubits_in_circuit,
-        custom_names=custom_names
+        custom_names=custom_names,
     )
     controlled_gate = target_gate.control(gate.num_control_qubits)
     qiskit_qubits = [
@@ -172,16 +172,17 @@ def _export_controlled_gate(
 
 
 def _export_custom_gate(
-    gate: g.MatrixFactoryGate,
-    applied_qubit_indices,
-    n_qubits_in_circuit,
-    custom_names
+    gate: g.MatrixFactoryGate, applied_qubit_indices, n_qubits_in_circuit, custom_names
 ):
     if gate.name not in custom_names:
-        raise ValueError(f"Can't export gate {gate} as a custom gate, the circuit is missing its definition")
+        raise ValueError(
+            f"Can't export gate {gate} as a custom gate, the circuit is missing its definition"
+        )
 
     if gate.params:
-        raise ValueError(f"Can't export parametrized gate {gate}, Qiskit doesn't support parametrized custom gates")
+        raise ValueError(
+            f"Can't export parametrized gate {gate}, Qiskit doesn't support parametrized custom gates"
+        )
     # At that time of writing it, Qiskit doesn't support parametrized gates defined with a symbolic matrix
     # See https://github.com/Qiskit/qiskit-terra/issues/4751 for more info.
 
@@ -189,7 +190,11 @@ def _export_custom_gate(
         qiskit_qubit(qubit_i, n_qubits_in_circuit) for qubit_i in applied_qubit_indices
     ]
     qiskit_matrix = np.array(gate.matrix)
-    return qiskit.extensions.UnitaryGate(qiskit_matrix, label=gate.name), qiskit_qubits, []
+    return (
+        qiskit.extensions.UnitaryGate(qiskit_matrix, label=gate.name),
+        qiskit_qubits,
+        [],
+    )
 
 
 def import_from_qiskit(circuit: qiskit.QuantumCircuit) -> _gates.Circuit:

--- a/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions.py
+++ b/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions.py
@@ -135,7 +135,7 @@ def _export_gate_via_mapping(
     gate, applied_qubit_indices, n_qubits_in_circuit, custom_names
 ):
     try:
-        qiskit_cls = ZQUANTUM_QISKIT_GATE_MAP[bg.builtin_gate_by_name(gate.name)]
+        qiskit_cls = ZQUANTUM_QISKIT_GATE_MAP[_builtin_gates.builtin_gate_by_name(gate.name)]
     except KeyError:
         raise ValueError(f"Can't export gate {gate} to Qiskit via mapping")
 
@@ -153,7 +153,7 @@ def _export_controlled_gate(
     n_qubits_in_circuit,
     custom_names
 ):
-    if not isinstance(gate, g.ControlledGate):
+    if not isinstance(gate, _gates.ControlledGate):
         # Raising an exception here is redundant to the type hint, but it allows us
         # to handle exporting all gates in the same way, regardless of type
         raise ValueError(f"Can't export gate {gate} as a controlled gate")
@@ -173,7 +173,7 @@ def _export_controlled_gate(
 
 
 def _export_custom_gate(
-    gate: g.MatrixFactoryGate, applied_qubit_indices, n_qubits_in_circuit, custom_names
+    gate: _gates.MatrixFactoryGate, applied_qubit_indices, n_qubits_in_circuit, custom_names
 ):
     if gate.name not in custom_names:
         raise ValueError(
@@ -204,7 +204,7 @@ class AnonGateOperation(NamedTuple):
     qubit_indices: Tuple[int, ...]
 
 
-ImportedOperation = Union[g.GateOperation, AnonGateOperation]
+ImportedOperation = Union[_gates.GateOperation, AnonGateOperation]
 
 
 def _apply_custom_gate(

--- a/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions.py
+++ b/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions.py
@@ -135,7 +135,9 @@ def _export_gate_via_mapping(
     gate, applied_qubit_indices, n_qubits_in_circuit, custom_names
 ):
     try:
-        qiskit_cls = ZQUANTUM_QISKIT_GATE_MAP[_builtin_gates.builtin_gate_by_name(gate.name)]
+        qiskit_cls = ZQUANTUM_QISKIT_GATE_MAP[
+            _builtin_gates.builtin_gate_by_name(gate.name)
+        ]
     except KeyError:
         raise ValueError(f"Can't export gate {gate} to Qiskit via mapping")
 
@@ -151,7 +153,7 @@ def _export_controlled_gate(
     gate: _gates.ControlledGate,
     applied_qubit_indices,
     n_qubits_in_circuit,
-    custom_names
+    custom_names,
 ):
     if not isinstance(gate, _gates.ControlledGate):
         # Raising an exception here is redundant to the type hint, but it allows us
@@ -173,7 +175,10 @@ def _export_controlled_gate(
 
 
 def _export_custom_gate(
-    gate: _gates.MatrixFactoryGate, applied_qubit_indices, n_qubits_in_circuit, custom_names
+    gate: _gates.MatrixFactoryGate,
+    applied_qubit_indices,
+    n_qubits_in_circuit,
+    custom_names,
 ):
     if gate.name not in custom_names:
         raise ValueError(
@@ -273,9 +278,7 @@ def _import_qiskit_op_via_mapping(
     try:
         gate_ref = QISKIT_ZQUANTUM_GATE_MAP[type(qiskit_gate)]
     except KeyError:
-        raise ValueError(
-            f"Conversion of {qiskit_gate} from Qiskit is unsupported."
-        )
+        raise ValueError(f"Conversion of {qiskit_gate} from Qiskit is unsupported.")
 
     # values to consider:
     # - gate matrix parameters (only parametric gates)

--- a/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions.py
+++ b/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions.py
@@ -146,7 +146,6 @@ def _export_gate_via_mapping(
     return qiskit_cls(*qiskit_params), qiskit_qubits, []
 
 
-# @_export_gate_to_qiskit.register
 def _export_controlled_gate(
     gate: _gates.ControlledGate,
     applied_qubit_indices,
@@ -178,8 +177,13 @@ def _export_custom_gate(
     n_qubits_in_circuit,
     custom_names
 ):
-    if gate.name not in custom_names or gate.params:
+    if gate.name not in custom_names:
         raise ValueError(f"Can't export gate {gate} as a custom gate, the circuit is missing its definition")
+
+    if gate.params:
+        raise ValueError(f"Can't export parametrized gate {gate}, Qiskit doesn't support parametrized custom gates")
+    # At that time of writing it, Qiskit doesn't support parametrized gates defined with a symbolic matrix
+    # See https://github.com/Qiskit/qiskit-terra/issues/4751 for more info.
 
     qiskit_qubits = [
         qiskit_qubit(qubit_i, n_qubits_in_circuit) for qubit_i in applied_qubit_indices

--- a/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions.py
+++ b/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions.py
@@ -185,7 +185,7 @@ def _export_custom_gate(
         qiskit_qubit(qubit_i, n_qubits_in_circuit) for qubit_i in applied_qubit_indices
     ]
     qiskit_matrix = np.array(gate.matrix)
-    return qiskit.extensions.UnitaryGate(qiskit_matrix), qiskit_qubits, []
+    return qiskit.extensions.UnitaryGate(qiskit_matrix, label=gate.name), qiskit_qubits, []
 
 
 def import_from_qiskit(circuit: qiskit.QuantumCircuit) -> _gates.Circuit:

--- a/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions_test.py
@@ -231,23 +231,45 @@ FOREIGN_QISKIT_CIRCUITS = [
 ]
 
 
-CUSTOM_GATE_DEF = g.CustomGateDefinition("custom.A", sympy.Matrix([[0, 1], [1, 0]]), [])
+A1_GATE_DEF = g.CustomGateDefinition(
+    "unitary.33c11b461fe67e717e37ac34a568cd1c27a89013703bf5b84194f0732a33a26d",
+    sympy.Matrix([[0, 1], [1, 0]]),
+    tuple(),
+)
+A2_GATE_DEF = g.CustomGateDefinition(
+    "custom.A2.33c11b461fe67e717e37ac34a568cd1c27a89013703bf5b84194f0732a33a26d",
+    sympy.Matrix([[0, 1], [1, 0]]),
+    tuple(),
+)
 
 
 EQUIVALENT_CUSTOM_GATE_CIRCUITS = [
     (
         g.Circuit(
-            operations=[CUSTOM_GATE_DEF()(1)],
+            operations=[A1_GATE_DEF()(1)],
             n_qubits=4,
-            custom_gate_definitions=[CUSTOM_GATE_DEF],
+            custom_gate_definitions=[A1_GATE_DEF],
         ),
         _make_qiskit_circuit(
             4,
             [
-                ("unitary", (np.array([[0, 1], [1, 0]]), 1, "custom.A")),
+                ("unitary", (np.array([[0, 1], [1, 0]]), 1)),
             ],
         ),
-    )
+    ),
+    (
+        g.Circuit(
+            operations=[A2_GATE_DEF()(3)],
+            n_qubits=5,
+            custom_gate_definitions=[A2_GATE_DEF],
+        ),
+        _make_qiskit_circuit(
+            5,
+            [
+                ("unitary", (np.array([[0, 1], [1, 0]]), 3, "custom.A2")),
+            ],
+        ),
+    ),
 ]
 
 
@@ -347,9 +369,9 @@ class TestExportingToQiskit:
     def test_exporting_circuit_with_custom_gates_gives_equivalent_circuit(
         self, zquantum_circuit, qiskit_circuit
     ):
-        converted = export_to_qiskit(zquantum_circuit)
-        assert converted == qiskit_circuit, (
-            f"Converted circuit:\n{_draw_qiskit_circuit(converted)}\n isn't equal "
+        exported = export_to_qiskit(zquantum_circuit)
+        assert exported == qiskit_circuit, (
+            f"Exported circuit:\n{_draw_qiskit_circuit(exported)}\n isn't equal "
             f"to\n{_draw_qiskit_circuit(qiskit_circuit)}"
         )
 
@@ -421,7 +443,11 @@ class TestImportingFromQiskit:
         )
         assert bound_imported == ref_bound
 
-    @pytest.mark.parametrize("qiskit_circuit", FOREIGN_QISKIT_CIRCUITS)
-    def test_importing_circuit_with_unsupported_gates_raises(self, qiskit_circuit):
-        with pytest.raises(NotImplementedError):
-            import_from_qiskit(qiskit_circuit)
+    @pytest.mark.parametrize(
+        "zquantum_circuit, qiskit_circuit", EQUIVALENT_CUSTOM_GATE_CIRCUITS
+    )
+    def test_importing_circuit_with_custom_gates_gives_equivalent_circuit(
+        self, zquantum_circuit, qiskit_circuit
+    ):
+        imported = import_from_qiskit(qiskit_circuit)
+        assert imported == zquantum_circuit

--- a/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions_test.py
@@ -237,7 +237,7 @@ CUSTOM_GATE_DEF = g.CustomGateDefinition("A", sympy.Matrix([[0, 1], [1, 0]]), []
 EQUIVALENT_CUSTOM_GATE_CIRCUITS = [
     (
         g.Circuit(
-            operations=[CUSTOM_GATE_DEF()(0)],
+            operations=[CUSTOM_GATE_DEF()(1)],
             n_qubits=4,
             custom_gate_definitions=[CUSTOM_GATE_DEF],
         ),
@@ -341,6 +341,17 @@ class TestExportingToQiskit:
         with pytest.raises(NotImplementedError):
             export_to_qiskit(zquantum_circuit)
 
+    @pytest.mark.parametrize(
+        "zquantum_circuit, qiskit_circuit", EQUIVALENT_CUSTOM_GATE_CIRCUITS
+    )
+    def test_exporting_circuit_with_custom_gates_gives_equivalent_circuit(
+        self, zquantum_circuit, qiskit_circuit
+    ):
+        converted = export_to_qiskit(zquantum_circuit)
+        assert converted == qiskit_circuit, (
+            f"Converted circuit:\n{_draw_qiskit_circuit(converted)}\n isn't equal "
+            f"to\n{_draw_qiskit_circuit(qiskit_circuit)}"
+        )
 
 class TestImportingFromQiskit:
     @pytest.mark.parametrize(

--- a/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions_test.py
@@ -370,9 +370,11 @@ class TestExportingToQiskit:
         self, zquantum_circuit, qiskit_circuit
     ):
         exported = export_to_qiskit(zquantum_circuit)
-        assert exported == qiskit_circuit, (
-            f"Exported circuit:\n{_draw_qiskit_circuit(exported)}\n isn't equal "
-            f"to\n{_draw_qiskit_circuit(qiskit_circuit)}"
+        # We can't compare the circuits directly, because the gate names can differ.
+        # Qiskit allows multiple gate operations with the same label. ZQuantum doesn't
+        # allow that, so we append a matrix hash to the name.
+        assert qiskit.quantum_info.Operator(exported) == qiskit.quantum_info.Operator(
+            qiskit_circuit
         )
 
 

--- a/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions_test.py
@@ -120,7 +120,7 @@ EXAMPLE_PARAM_VALUES = {
 
 EQUIVALENT_NON_PARAMETRIZED_CIRCUITS = [
     (
-        g.Circuit([], 3),
+        _gates.Circuit([], 3),
         _make_qiskit_circuit(3, []),
     ),
     (
@@ -231,12 +231,12 @@ FOREIGN_QISKIT_CIRCUITS = [
 ]
 
 
-UNITARY_GATE_DEF = g.CustomGateDefinition(
+UNITARY_GATE_DEF = _gates.CustomGateDefinition(
     "unitary.33c11b461fe67e717e37ac34a568cd1c27a89013703bf5b84194f0732a33a26d",
     sympy.Matrix([[0, 1], [1, 0]]),
     tuple(),
 )
-CUSTOM_A2_GATE_DEF = g.CustomGateDefinition(
+CUSTOM_A2_GATE_DEF = _gates.CustomGateDefinition(
     "custom.A2.33c11b461fe67e717e37ac34a568cd1c27a89013703bf5b84194f0732a33a26d",
     sympy.Matrix([[0, 1], [1, 0]]),
     tuple(),
@@ -245,7 +245,7 @@ CUSTOM_A2_GATE_DEF = g.CustomGateDefinition(
 
 EQUIVALENT_CUSTOM_GATE_CIRCUITS = [
     (
-        g.Circuit(
+        _gates.Circuit(
             operations=[UNITARY_GATE_DEF()(1)],
             n_qubits=4,
             custom_gate_definitions=[UNITARY_GATE_DEF],
@@ -258,7 +258,7 @@ EQUIVALENT_CUSTOM_GATE_CIRCUITS = [
         ),
     ),
     (
-        g.Circuit(
+        _gates.Circuit(
             operations=[CUSTOM_A2_GATE_DEF()(3)],
             n_qubits=5,
             custom_gate_definitions=[CUSTOM_A2_GATE_DEF],
@@ -271,7 +271,7 @@ EQUIVALENT_CUSTOM_GATE_CIRCUITS = [
         ),
     ),
     (
-        g.Circuit(
+        _gates.Circuit(
             operations=[UNITARY_GATE_DEF()(1), UNITARY_GATE_DEF()(1)],
             n_qubits=4,
             custom_gate_definitions=[UNITARY_GATE_DEF],
@@ -285,7 +285,7 @@ EQUIVALENT_CUSTOM_GATE_CIRCUITS = [
         ),
     ),
     (
-        g.Circuit(
+        _gates.Circuit(
             operations=[
                 UNITARY_GATE_DEF()(1),
                 CUSTOM_A2_GATE_DEF()(1),

--- a/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions_test.py
@@ -353,6 +353,7 @@ class TestExportingToQiskit:
             f"to\n{_draw_qiskit_circuit(qiskit_circuit)}"
         )
 
+
 class TestImportingFromQiskit:
     @pytest.mark.parametrize(
         "zquantum_circuit, qiskit_circuit", EQUIVALENT_NON_PARAMETRIZED_CIRCUITS
@@ -412,10 +413,12 @@ class TestImportingFromQiskit:
         bound_imported = import_from_qiskit(bound)
 
         # 3. Bind the ref
-        ref_bound = zquantum_circuit.bind({
-            symbol: EXAMPLE_PARAM_VALUES[str(symbol)]
-            for symbol in zquantum_circuit.free_symbols
-        })
+        ref_bound = zquantum_circuit.bind(
+            {
+                symbol: EXAMPLE_PARAM_VALUES[str(symbol)]
+                for symbol in zquantum_circuit.free_symbols
+            }
+        )
         assert bound_imported == ref_bound
 
     @pytest.mark.parametrize("qiskit_circuit", FOREIGN_QISKIT_CIRCUITS)

--- a/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions_test.py
@@ -231,12 +231,12 @@ FOREIGN_QISKIT_CIRCUITS = [
 ]
 
 
-A1_GATE_DEF = g.CustomGateDefinition(
+UNITARY_GATE_DEF = g.CustomGateDefinition(
     "unitary.33c11b461fe67e717e37ac34a568cd1c27a89013703bf5b84194f0732a33a26d",
     sympy.Matrix([[0, 1], [1, 0]]),
     tuple(),
 )
-A2_GATE_DEF = g.CustomGateDefinition(
+CUSTOM_A2_GATE_DEF = g.CustomGateDefinition(
     "custom.A2.33c11b461fe67e717e37ac34a568cd1c27a89013703bf5b84194f0732a33a26d",
     sympy.Matrix([[0, 1], [1, 0]]),
     tuple(),
@@ -246,9 +246,9 @@ A2_GATE_DEF = g.CustomGateDefinition(
 EQUIVALENT_CUSTOM_GATE_CIRCUITS = [
     (
         g.Circuit(
-            operations=[A1_GATE_DEF()(1)],
+            operations=[UNITARY_GATE_DEF()(1)],
             n_qubits=4,
-            custom_gate_definitions=[A1_GATE_DEF],
+            custom_gate_definitions=[UNITARY_GATE_DEF],
         ),
         _make_qiskit_circuit(
             4,
@@ -259,14 +259,47 @@ EQUIVALENT_CUSTOM_GATE_CIRCUITS = [
     ),
     (
         g.Circuit(
-            operations=[A2_GATE_DEF()(3)],
+            operations=[CUSTOM_A2_GATE_DEF()(3)],
             n_qubits=5,
-            custom_gate_definitions=[A2_GATE_DEF],
+            custom_gate_definitions=[CUSTOM_A2_GATE_DEF],
         ),
         _make_qiskit_circuit(
             5,
             [
                 ("unitary", (np.array([[0, 1], [1, 0]]), 3, "custom.A2")),
+            ],
+        ),
+    ),
+    (
+        g.Circuit(
+            operations=[UNITARY_GATE_DEF()(1), UNITARY_GATE_DEF()(1)],
+            n_qubits=4,
+            custom_gate_definitions=[UNITARY_GATE_DEF],
+        ),
+        _make_qiskit_circuit(
+            4,
+            [
+                ("unitary", (np.array([[0, 1], [1, 0]]), 1)),
+                ("unitary", (np.array([[0, 1], [1, 0]]), 1)),
+            ],
+        ),
+    ),
+    (
+        g.Circuit(
+            operations=[
+                UNITARY_GATE_DEF()(1),
+                CUSTOM_A2_GATE_DEF()(1),
+                UNITARY_GATE_DEF()(0),
+            ],
+            n_qubits=4,
+            custom_gate_definitions=[UNITARY_GATE_DEF, CUSTOM_A2_GATE_DEF],
+        ),
+        _make_qiskit_circuit(
+            4,
+            [
+                ("unitary", (np.array([[0, 1], [1, 0]]), 1)),
+                ("unitary", (np.array([[0, 1], [1, 0]]), 1, "custom.A2")),
+                ("unitary", (np.array([[0, 1], [1, 0]]), 0)),
             ],
         ),
     ),
@@ -366,7 +399,7 @@ class TestExportingToQiskit:
     @pytest.mark.parametrize(
         "zquantum_circuit, qiskit_circuit", EQUIVALENT_CUSTOM_GATE_CIRCUITS
     )
-    def test_exporting_circuit_with_custom_gates_gives_equivalent_circuit(
+    def test_exporting_circuit_with_custom_gates_gives_equivalent_operator(
         self, zquantum_circuit, qiskit_circuit
     ):
         exported = export_to_qiskit(zquantum_circuit)

--- a/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions_test.py
@@ -286,10 +286,14 @@ class TestExportingToQiskit:
     def test_exporting_and_binding_parametrized_circuit_results_in_equivalent_circuit(
         self, zquantum_circuit, qiskit_circuit
     ):
+        # 1. Export
         converted = export_to_qiskit(zquantum_circuit)
+        # 2. Bind params
         converted_bound = converted.bind_parameters(
             {param: EXAMPLE_PARAM_VALUES[str(param)] for param in converted.parameters}
         )
+
+        # 3. Bind the ref
         ref_bound = qiskit_circuit.bind_parameters(
             {
                 param: EXAMPLE_PARAM_VALUES[str(param)]
@@ -307,13 +311,17 @@ class TestExportingToQiskit:
     def test_binding_and_exporting_parametrized_circuit_results_in_equivalent_circuit(
         self, zquantum_circuit, qiskit_circuit
     ):
+        # 1. Bind params
         bound = zquantum_circuit.bind(
             {
                 symbol: EXAMPLE_PARAM_VALUES[str(symbol)]
                 for symbol in zquantum_circuit.free_symbols
             }
         )
+        # 2. Export
         bound_converted = export_to_qiskit(bound)
+
+        # 3. Bind the ref
         ref_bound = qiskit_circuit.bind_parameters(
             {
                 param: EXAMPLE_PARAM_VALUES[str(param)]
@@ -355,6 +363,49 @@ class TestImportingFromQiskit:
         assert sorted(map(str, imported.free_symbols)) == sorted(
             map(str, qiskit_circuit.parameters)
         )
+
+    @pytest.mark.parametrize(
+        "zquantum_circuit, qiskit_circuit", EQUIVALENT_PARAMETRIZED_CIRCUITS
+    )
+    def test_importing_and_binding_parametrized_circuit_results_in_equivalent_circuit(
+        self, zquantum_circuit, qiskit_circuit
+    ):
+        # 1. Import
+        imported = import_from_qiskit(qiskit_circuit)
+        symbols_map = {
+            symbol: EXAMPLE_PARAM_VALUES[str(symbol)]
+            for symbol in imported.free_symbols
+        }
+        # 2. Bind params
+        imported_bound = imported.bind(symbols_map)
+
+        # 3. Bind the ref
+        ref_bound = zquantum_circuit.bind(symbols_map)
+
+        assert imported_bound == ref_bound
+
+    @pytest.mark.parametrize(
+        "zquantum_circuit, qiskit_circuit", EQUIVALENT_PARAMETRIZED_CIRCUITS
+    )
+    def test_binding_and_importing_parametrized_circuit_results_in_equivalent_circuit(
+        self, zquantum_circuit, qiskit_circuit
+    ):
+        # 1. Bind params
+        bound = qiskit_circuit.bind_parameters(
+            {
+                param: EXAMPLE_PARAM_VALUES[str(param)]
+                for param in qiskit_circuit.parameters
+            }
+        )
+        # 2. Import
+        bound_imported = import_from_qiskit(bound)
+
+        # 3. Bind the ref
+        ref_bound = zquantum_circuit.bind({
+            symbol: EXAMPLE_PARAM_VALUES[str(symbol)]
+            for symbol in zquantum_circuit.free_symbols
+        })
+        assert bound_imported == ref_bound
 
     @pytest.mark.parametrize("qiskit_circuit", FOREIGN_QISKIT_CIRCUITS)
     def test_importing_circuit_with_unsupported_gates_raises(self, qiskit_circuit):

--- a/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions_test.py
@@ -231,7 +231,7 @@ FOREIGN_QISKIT_CIRCUITS = [
 ]
 
 
-CUSTOM_GATE_DEF = g.CustomGateDefinition("A", sympy.Matrix([[0, 1], [1, 0]]), [])
+CUSTOM_GATE_DEF = g.CustomGateDefinition("custom.A", sympy.Matrix([[0, 1], [1, 0]]), [])
 
 
 EQUIVALENT_CUSTOM_GATE_CIRCUITS = [
@@ -244,7 +244,7 @@ EQUIVALENT_CUSTOM_GATE_CIRCUITS = [
         _make_qiskit_circuit(
             4,
             [
-                ("unitary", (np.array([[0, 1], [1, 0]]), 1)),
+                ("unitary", (np.array([[0, 1], [1, 0]]), 1, "custom.A")),
             ],
         ),
     )

--- a/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions_test.py
+++ b/src/python/zquantum/core/wip/circuit/conversions2/qiskit_conversions_test.py
@@ -81,7 +81,7 @@ class TestGateConversion:
         np.testing.assert_allclose(zquantum_matrix, qiskit_matrix)
 
 
-# circuits ---------
+# --------- circuits ---------
 
 # NOTE: In Qiskit, 0 is the most significant qubit,
 # whereas in ZQuantum, 0 is the least significant qubit.
@@ -91,41 +91,18 @@ class TestGateConversion:
 # https://qiskit.org/documentation/tutorials/circuits/1_getting_started_with_qiskit.html#Visualize-Circuit
 
 
-def _single_qubit_qiskit_circuit():
-    qc = qiskit.QuantumCircuit(6)
-    qc.x(0)
-    qc.z(2)
-    return qc
-
-
-def _two_qubit_qiskit_circuit():
-    qc = qiskit.QuantumCircuit(4)
-    qc.cnot(0, 1)
-    return qc
-
-
-def _parametric_qiskit_circuit(angle):
-    qc = qiskit.QuantumCircuit(4)
-    qc.rx(angle, 1)
-    return qc
-
-
-def _qiskit_circuit_with_controlled_gate():
-    qc = qiskit.QuantumCircuit(5)
-    qc.append(qiskit.circuit.library.SwapGate().control(1), [2, 0, 3])
-    return qc
-
-
-def _qiskit_circuit_with_multicontrolled_gate():
-    qc = qiskit.QuantumCircuit(6)
-    qc.append(qiskit.circuit.library.YGate().control(2), [4, 5, 2])
-    return qc
-
-
 def _qiskit_circuit_with_u1_gates():
     qc = qiskit.QuantumCircuit(7)
     qc.u1(0.42, 2)
     qc.u1(QISKIT_THETA, 1)
+    return qc
+
+
+def _make_qiskit_circuit(n_qubits, commands):
+    qc = qiskit.QuantumCircuit(n_qubits)
+    for method_name, method_args in commands:
+        method = getattr(qc, method_name)
+        method(*method_args)
     return qc
 
 
@@ -150,7 +127,10 @@ EQUIVALENT_CIRCUITS = [
             ],
             6,
         ),
-        _single_qubit_qiskit_circuit(),
+        _make_qiskit_circuit(6, [
+            ('x', (0,)),
+            ('z', (2,)),
+        ]),
     ),
     (
         _gates.Circuit(
@@ -159,7 +139,9 @@ EQUIVALENT_CIRCUITS = [
             ],
             4,
         ),
-        _two_qubit_qiskit_circuit(),
+        _make_qiskit_circuit(4, [
+            ('cnot', (0, 1)),
+        ]),
     ),
     (
         _gates.Circuit(
@@ -168,21 +150,27 @@ EQUIVALENT_CIRCUITS = [
             ],
             4,
         ),
-        _parametric_qiskit_circuit(np.pi),
+        _make_qiskit_circuit(4, [
+            ('rx', (np.pi, 1)),
+        ]),
     ),
     (
         _gates.Circuit(
             [_builtin_gates.SWAP.controlled(1)(2, 0, 3)],
             5,
         ),
-        _qiskit_circuit_with_controlled_gate(),
+        _make_qiskit_circuit(5, [
+            ('append', (qiskit.circuit.library.SwapGate().control(1), [2, 0, 3])),
+        ]),
     ),
     (
         _gates.Circuit(
             [_builtin_gates.Y.controlled(2)(4, 5, 2)],
             6,
         ),
-        _qiskit_circuit_with_multicontrolled_gate(),
+        _make_qiskit_circuit(6, [
+            ('append', (qiskit.circuit.library.YGate().control(2), [4, 5, 2])),
+        ]),
     ),
 ]
 
@@ -195,7 +183,9 @@ EQUIVALENT_PARAMETRIZED_CIRCUITS = [
             ],
             4,
         ),
-        _parametric_qiskit_circuit(QISKIT_THETA),
+        _make_qiskit_circuit(4, [
+            ('rx', (QISKIT_THETA, 1)),
+        ]),
     ),
     (
         _gates.Circuit(
@@ -204,7 +194,9 @@ EQUIVALENT_PARAMETRIZED_CIRCUITS = [
             ],
             4,
         ),
-        _parametric_qiskit_circuit(QISKIT_THETA * QISKIT_GAMMA),
+        _make_qiskit_circuit(4, [
+            ('rx', (QISKIT_THETA * QISKIT_GAMMA, 1)),
+        ]),
     ),
 ]
 


### PR DESCRIPTION
Improvement over #225 that adds conversion for non-parametrized custom gates:
- ZQuantum's custom gate defined via a `CustomGateDefinition` is exported as [Qiskit's Unitary gate](https://qiskit.org/documentation/stubs/qiskit.extensions.UnitaryGate.html)
- Any Qiskit gate we don't have a mapping for is translated to a custom gate


We don't support converting custom parametrized gates, because:
- in case of an export – I couldn't find a way to create a parametrized custom gate in Qiskit. There's a chance it will be added to Qiskit in the future, though (see [the issue](https://github.com/Qiskit/qiskit-terra/issues/4751)).
- in case of an import – when we import a gate without an explicit mapping we rely on getting the gate matrix from Qiskit. [`to_matrix()`](https://qiskit.org/documentation/stubs/qiskit.circuit.Gate.html#qiskit.circuit.Gate.to_matrix) raises an exception when invoked on a parametrized gate, so we can't use it, and I haven't come up with a viable workaround.