### PR TITLE
Fix error when printing circuit in a repl

### DIFF
--- a/src/python/zquantum/core/wip/circuits/_circuit.py
+++ b/src/python/zquantum/core/wip/circuits/_circuit.py
@@ -115,8 +115,7 @@ class Circuit:
         return (
             f"{type(self).__name__}"
             f"(operations=[{', '.join(map(str, self.operations))}], "
-            f"n_qubits={self.n_qubits}, "
-            f"custom_gate_definitions={self.custom_gate_definitions})"
+            f"n_qubits={self.n_qubits})"
         )
 
 

--- a/src/python/zquantum/core/wip/circuits/_circuit_test.py
+++ b/src/python/zquantum/core/wip/circuits/_circuit_test.py
@@ -62,7 +62,7 @@ def test_creating_circuit_has_correct_operations():
     Circuit([H(0)]),
     Circuit([H(0)], 5),
 ])
-def test_printing_circuit_doesnt_raise(circuit):
+def test_printing_circuit_doesnt_raise_exception(circuit):
     str(circuit)
     repr(circuit)
 

--- a/src/python/zquantum/core/wip/circuits/_circuit_test.py
+++ b/src/python/zquantum/core/wip/circuits/_circuit_test.py
@@ -1,5 +1,6 @@
 import numpy as np
 import sympy
+import pytest
 
 from ._builtin_gates import (
     X,
@@ -53,6 +54,17 @@ EXAMPLE_OPERATIONS = tuple(
 def test_creating_circuit_has_correct_operations():
     circuit = Circuit(operations=EXAMPLE_OPERATIONS)
     assert circuit.operations == list(EXAMPLE_OPERATIONS)
+
+
+@pytest.mark.parametrize("circuit", [
+    Circuit(),
+    Circuit([]),
+    Circuit([H(0)]),
+    Circuit([H(0)], 5),
+])
+def test_printing_circuit_doesnt_raise(circuit):
+    str(circuit)
+    repr(circuit)
 
 
 class TestConcatenation:


### PR DESCRIPTION
I stumbled opon it when I prepared the usage doc. It's a leftover from previous implementation when `Circuit` had `custom_gate_definitions` field, now it's computed dynamically (introduced in #233).