### PR TITLE
Fix numpy API error message

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
     install_requires=[
         "pytest>=5.3.5",
         "networkx==2.4",
-        "numpy>=1.18.1",
+        "numpy>=1.20",
         "scipy>=1.4.1",
         "sympy>=1.7",
         "openfermion>=1.0.0",

--- a/steps/transforms.py
+++ b/steps/transforms.py
@@ -21,21 +21,20 @@ def transform_interaction_operator(
         transformation (str): The transformation to use. Either "Jordan-Wigner" or "Bravyi-Kitaev"
         input_operator (Union[str, SymbolicOperator]): The interaction operator to transform
     """
-    print("This is my code")
-    # if isinstance(input_operator, str):
-    #    input_operator = load_interaction_operator(input_operator)
+    if isinstance(input_operator, str):
+        input_operator = load_interaction_operator(input_operator)
 
-    # if transformation == "Jordan-Wigner":
-    #    transformation = jordan_wigner
-    # elif transformation == "Bravyi-Kitaev":
-    #    input_operator = get_fermion_operator(input_operator)
-    #    transformation = bravyi_kitaev
-    # else:
-    #    raise RuntimeError("Unrecognized transformation ", transformation)
+    if transformation == "Jordan-Wigner":
+        transformation = jordan_wigner
+    elif transformation == "Bravyi-Kitaev":
+        input_operator = get_fermion_operator(input_operator)
+        transformation = bravyi_kitaev
+    else:
+        raise RuntimeError("Unrecognized transformation ", transformation)
 
-    # start_time = time.time()
-    # transformed_operator = transformation(input_operator)
-    # walltime = time.time() - start_time
+    start_time = time.time()
+    transformed_operator = transformation(input_operator)
+    walltime = time.time() - start_time
 
-    # save_qubit_operator(transformed_operator, "transformed-operator.json")
-    # save_timing(walltime, "timing.json")
+    save_qubit_operator(transformed_operator, "transformed-operator.json")
+    save_timing(walltime, "timing.json")

--- a/steps/transforms.py
+++ b/steps/transforms.py
@@ -21,20 +21,21 @@ def transform_interaction_operator(
         transformation (str): The transformation to use. Either "Jordan-Wigner" or "Bravyi-Kitaev"
         input_operator (Union[str, SymbolicOperator]): The interaction operator to transform
     """
-    if isinstance(input_operator, str):
-        input_operator = load_interaction_operator(input_operator)
+    print("This is my code")
+    # if isinstance(input_operator, str):
+    #    input_operator = load_interaction_operator(input_operator)
 
-    if transformation == "Jordan-Wigner":
-        transformation = jordan_wigner
-    elif transformation == "Bravyi-Kitaev":
-        input_operator = get_fermion_operator(input_operator)
-        transformation = bravyi_kitaev
-    else:
-        raise RuntimeError("Unrecognized transformation ", transformation)
+    # if transformation == "Jordan-Wigner":
+    #    transformation = jordan_wigner
+    # elif transformation == "Bravyi-Kitaev":
+    #    input_operator = get_fermion_operator(input_operator)
+    #    transformation = bravyi_kitaev
+    # else:
+    #    raise RuntimeError("Unrecognized transformation ", transformation)
 
-    start_time = time.time()
-    transformed_operator = transformation(input_operator)
-    walltime = time.time() - start_time
+    # start_time = time.time()
+    # transformed_operator = transformation(input_operator)
+    # walltime = time.time() - start_time
 
-    save_qubit_operator(transformed_operator, "transformed-operator.json")
-    save_timing(walltime, "timing.json")
+    # save_qubit_operator(transformed_operator, "transformed-operator.json")
+    # save_timing(walltime, "timing.json")


### PR DESCRIPTION
Fixes issue where `RuntimeError: module compiled against API version 0xe but this version of numpy is 0xd` would be printed when importing some modules from `z-quantum-core`. Example scenario:
```
docker run --rm -it zapatacomputing/z-quantum-default:latest /bin/bash
pip3 install git+https://github.com/zapatacomputing/z-quantum-core
python3 -c "import zquantum.core.openfermion"
```

Looks like the log is [printed](https://github.com/numpy/numpy/blob/623bc1fae1d47df24e7f1e29321d0c0ba2771ce0/numpy/core/code_generators/generate_numpy_api.py#L73) by numpy itself when its internal checks fail. My hypothesis is that we use some libraries distributed as prebuilt wheels that linked a newer numpy version than the one we've been using so far, hence C API mismatch between link and run time. Bumping numpy to at least v1.20 works this around, the error isn't printed anymore.