### PR TITLE
177435351 circuit compatibility layer

### DIFF
--- a/src/python/zquantum/core/wip/compatibility_tools.py
+++ b/src/python/zquantum/core/wip/compatibility_tools.py
@@ -1,0 +1,107 @@
+"""Tools for building compatibility layers."""
+import warnings
+from typing import Optional, Callable
+
+
+class TranslationFailed(Exception):
+    """Exception raised if translation failed.
+
+    Note that this class is needed so that we can distinguish between exceptions
+    occurring because of translation failure (that should be intercepted) and others
+    (which should be propagated).
+    """
+
+    pass
+
+
+def _translate_if_needed(
+    obj, old_type, translate_old_to_wip, deprecation_msg=None, considered_iterables=None
+):
+    considered_iterables = [] if not considered_iterables else considered_iterables
+    if isinstance(obj, old_type):
+        try:
+            if deprecation_msg:
+                warnings.warn(deprecation_msg, DeprecationWarning)
+            return translate_old_to_wip(obj)
+        except Exception:
+            raise TranslationFailed(
+                f"Translation of {obj} failed. Please report this as a bug and provide "
+                f"minimal example that triggers this error."
+            )
+    elif type(obj) in considered_iterables:
+        # Note that here we use exact type comparison. This makes for a simpler implementation,
+        # and it is rather unexpected to see subclasses of list or tuple.
+        return type(obj)(
+            _translate_if_needed(
+                o, old_type, translate_old_to_wip, deprecation_msg, considered_iterables
+            )
+            for o in obj
+        )
+    return obj
+
+
+def compatible_with_old_type(
+    old_type,
+    translate_old_to_wip,
+    deprecation_msg: Optional[str] = None,
+    fallback_function=None,
+    consider_iterable_types=None,
+):
+    """Create a decorator marking function as compatible as some "old" type.
+
+    Args:
+        old_type: type that the function is compatible with (e.g. old style Circuit)
+        translate_old_to_wip: callable mapping old style object to new one.
+            It should take a single argument and return a single value.
+        deprecation_msg: if and old style object is encountered, a deprecation warning
+            is issued with this message. If not provided, not DeprecationWarning is
+            ever produced.
+        fallback_function: function equivalent to the decorated one, that should be
+            used in case of any translation failure. If provided, translation failures
+            trigger warning, otherwise they result in an error.
+        consider_iterable_types: an iterable of iterable types (e.g. list, tuple)
+            that should be also checked for old-style objects. This is supposed to
+            work with built-in sequential types.
+    Returns:
+        A decorator that makes given function using wip objects compatible with old-style
+        objects.
+    Raises:
+        TranslationFailure: if translation failed and no fallback_function is provided.
+    """
+    def _compatible_with_old_type(wrapped: Callable):
+        def _inner(*args, **kwargs):
+            try:
+                new_args = tuple(
+                    _translate_if_needed(
+                        obj,
+                        old_type,
+                        translate_old_to_wip,
+                        deprecation_msg,
+                        consider_iterable_types,
+                    )
+                    for obj in args
+                )
+                new_kwargs = {
+                    key: _translate_if_needed(
+                        obj,
+                        old_type,
+                        translate_old_to_wip,
+                        deprecation_msg,
+                        consider_iterable_types,
+                    )
+                    for key, obj in kwargs.items()
+                }
+                return wrapped(*new_args, **new_kwargs)
+            except TranslationFailed as err:
+                if fallback_function:
+                    warnings.warn(
+                        f"Translation from {old_type} failed, and fallback function will be used."
+                        "Please report this as a bug and provide minimal example that leads to"
+                        "this error."
+                    )
+                    return fallback_function(*args, **kwargs)
+                raise err
+
+        return _inner
+
+    return _compatible_with_old_type

--- a/tests/zquantum/core/wip/compatibility_tools_test.py
+++ b/tests/zquantum/core/wip/compatibility_tools_test.py
@@ -1,0 +1,198 @@
+from unittest.mock import Mock
+
+import pytest
+
+from zquantum.core.wip.compatibility_tools import compatible_with_old_type
+
+
+class WipType:
+    def __init__(self, x):
+        self.x = x
+
+    def __eq__(self, other):
+        return type(self) == type(other) and self.x == other.x
+
+    def __repr__(self):
+        return f"WipType({self.x})"
+
+
+class OldType:
+    def __init__(self, x):
+        self.x = x
+
+    def __eq__(self, other):
+        return type(self) == type(other) and self.x == other.x
+
+    def __repr__(self):
+        return f"OldType({self.x})"
+
+
+def translate_old_to_wip(old: OldType):
+    return WipType(old.x)
+
+
+class TestUsesWipTypeDecorator:
+    @pytest.mark.parametrize(
+        "args, kwargs",
+        [
+            ((1, "test", [5, 7]), {}),
+            ((WipType(1),), {}),
+            ((WipType(2), 1, "test"), {"x": 10}),
+            ((1, 2), {"x": WipType(3), "y": WipType(4)}),
+        ],
+    )
+    def test_uses_wip_type_uses_original_callable_if_no_arguments_of_old_type_are_passed(
+        self, args, kwargs
+    ):
+        original_func = Mock()
+        decorated_func = compatible_with_old_type(
+            old_type=OldType,
+            translate_old_to_wip=translate_old_to_wip,
+        )(original_func)
+
+        assert decorated_func(*args, **kwargs) == original_func.return_value
+        original_func.assert_called_once_with(*args, **kwargs)
+
+    @pytest.mark.parametrize(
+        "original_args, original_kwargs, translated_args, translated_kwargs",
+        [
+            ((OldType(1),), {}, (WipType(1),), {}),
+            ((OldType(2), 1, "test"), {"x": 10}, (WipType(2), 1, "test"), {"x": 10}),
+            ((1, 2), {"x": OldType(3)}, (1, 2), {"x": WipType(3)}),
+        ],
+    )
+    def test_uses_wip_type_translates_old_type_to_wip_type(
+        self, original_args, original_kwargs, translated_args, translated_kwargs
+    ):
+        original_func = Mock()
+        decorated_func = compatible_with_old_type(
+            old_type=OldType,
+            translate_old_to_wip=translate_old_to_wip,
+        )(original_func)
+
+        assert (
+            decorated_func(*original_args, **original_kwargs)
+            == original_func.return_value
+        )
+        original_func.assert_called_once_with(*translated_args, **translated_kwargs)
+
+    @pytest.mark.parametrize(
+        "args, kwargs",
+        [
+            ((OldType(1),), {}),
+            ((OldType(2), 1, "test"), {"x": 10}),
+            ((1, 2), {"x": OldType(3)}),
+        ],
+    )
+    def test_deprecation_warning_is_raised_if_deprecation_msg_is_not_none_and_old_type_is_passed(
+        self, args, kwargs
+    ):
+        original_func = Mock()
+        deprecation_msg = "OldType will soon be deprecated"
+        decorated_func = compatible_with_old_type(
+            old_type=OldType,
+            translate_old_to_wip=translate_old_to_wip,
+            deprecation_msg=deprecation_msg,
+        )(original_func)
+
+        with pytest.deprecated_call():
+            decorated_func(*args, **kwargs)
+
+    @pytest.mark.parametrize(
+        "args, kwargs",
+        [
+            ((WipType(1),), {}),
+            ((WipType(2), 1, "test"), {"x": 10}),
+            ((1, 2), {"x": WipType(3)}),
+        ],
+    )
+    def test_deprecation_warning_is_not_raised_if_deprecation_msg_is_none(
+        self, args, kwargs
+    ):
+        original_func = Mock()
+        deprecation_msg = "OldType will soon be deprecated"
+        decorated_func = compatible_with_old_type(
+            old_type=OldType,
+            translate_old_to_wip=translate_old_to_wip,
+            deprecation_msg=deprecation_msg,
+        )(original_func)
+
+        with pytest.warns(None) as warnings_record:
+            decorated_func(*args, **kwargs)
+
+        assert not warnings_record
+
+    @pytest.mark.parametrize(
+        "args, kwargs",
+        [
+            ((OldType(1),), {}),
+            ((OldType(2), 1, "test"), {"x": 10}),
+            ((1, 2), {"x": OldType(3)}),
+        ],
+    )
+    def test_fallback_function_is_used_if_translation_fails(self, args, kwargs):
+        original_func = Mock()
+        fallback_func = Mock()
+
+        def _malfunctioning_translation_func(obj):
+            raise ValueError()
+
+        decorated_func = compatible_with_old_type(
+            old_type=OldType,
+            translate_old_to_wip=_malfunctioning_translation_func,
+            fallback_function=fallback_func,
+        )(original_func)
+
+        assert decorated_func(*args, **kwargs) == fallback_func.return_value
+        original_func.assert_not_called()
+        fallback_func.assert_called_once_with(*args, **kwargs)
+
+    @pytest.mark.parametrize(
+        "original_args, original_kwargs, translated_args, translated_kwargs",
+        [
+            (((OldType(1), 2, OldType(2)),), {}, ((WipType(1), 2, WipType(2)),), {}),
+            ((), {"x": [OldType(0), OldType(4)]}, (), {"x": [WipType(0), WipType(4)]}),
+            (
+                ([OldType(1), "test"],),
+                {"x": (OldType(2), 3)},
+                ([WipType(1), "test"],),
+                {"x": (WipType(2), 3)},
+            ),
+        ],
+    )
+    def test_old_type_objects_are_translated_if_they_occur_in_considered_iterables(
+        self, original_args, original_kwargs, translated_args, translated_kwargs
+    ):
+        original_func = Mock()
+        decorated_func = compatible_with_old_type(
+            old_type=OldType,
+            translate_old_to_wip=translate_old_to_wip,
+            consider_iterable_types=(list, tuple),
+        )(original_func)
+
+        assert (
+            decorated_func(*original_args, **original_kwargs)
+            == original_func.return_value
+        )
+        original_func.assert_called_once_with(*translated_args, **translated_kwargs)
+
+    @pytest.mark.parametrize(
+        "args, kwargs, iterable_types",
+        [
+            (((OldType(1), 2, OldType(2)),), {}, [list]),
+            ((), {"x": [OldType(0), OldType(4)]}, [tuple]),
+            (([OldType(1), "test"],), {"x": (OldType(2), 3)}, []),
+        ],
+    )
+    def test_old_type_objects_are_not_translated_if_they_occur_in_not_considered_iterables(
+        self, args, kwargs, iterable_types
+    ):
+        original_func = Mock()
+        decorated_func = compatible_with_old_type(
+            old_type=OldType,
+            translate_old_to_wip=translate_old_to_wip,
+            consider_iterable_types=iterable_types,
+        )(original_func)
+
+        assert decorated_func(*args, **kwargs) == original_func.return_value
+        original_func.assert_called_once_with(*args, **kwargs)


### PR DESCRIPTION
This implements a decorator, that could be further used for making functions compatible with both new and old circuits.

Note that function translating old circuits to new ones will be added in the next PR.

