### PR TITLE
Raise error when trying to load new circuit from old circuit dict

### DIFF
--- a/src/python/zquantum/core/wip/circuits/_serde.py
+++ b/src/python/zquantum/core/wip/circuits/_serde.py
@@ -6,7 +6,7 @@ import sympy
 from ...utils import SCHEMA_VERSION
 from . import _builtin_gates, _circuit, _gates
 
-CIRCUIT_SCHEMA = SCHEMA_VERSION + "-circuit"
+CIRCUIT_SCHEMA = SCHEMA_VERSION + "-circuit-v2"
 
 
 def serialize_expr(expr: sympy.Expr):
@@ -139,6 +139,10 @@ def _dagger_gate_to_dict(gate: _gates.Dagger):
 
 
 def circuit_from_dict(dict_):
+    schema = dict_.get("schema")
+    if schema != CIRCUIT_SCHEMA:
+        raise ValueError(f"Invalid circuit schema: {schema}")
+
     defs = [
         custom_gate_def_from_dict(def_dict)
         for def_dict in dict_.get("custom_gate_definitions", [])


### PR DESCRIPTION
Explicitly checks schema when loading new circuits. This allows writing compatibility code that supports loading both old and new serialized circuits. Needed to migrate steps in #277.
(paired with @dexter2206)