### PR TITLE
Fix running tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setuptools.setup(
         "pyquil~=2.25",
         "cirq>=0.9.1",
         "qiskit~=0.25",
-        "overrides>=3.1.0",
+        "overrides~=3.1",
     ],
     extras_require=extras_require,
 )


### PR DESCRIPTION
Addresses issue found by @dexter2206. `overrides` package in version 4 changed behavior in a way we don't support at the moment. When a parent class defines a method with `**kwargs`, the new package version requires the overridden method to contain the `**kwargs` as well. We don't do that for the estimators, hence the following error:

```
tests/zquantum/core/interfaces/executable_estimator_test.py:None (tests/zquantum/core/interfaces/executable_estimator_test.py)
interfaces\executable_estimator_test.py:12: in <module>
    from zquantum.core.estimator import (
..\..\..\src\python\zquantum\core\estimator.py:147: in <module>
    class BasicEstimator(Estimator):
C:\Users\dexte\.conda\envs\zapata-main\lib\site-packages\overrides\enforce.py:155: in __new__
    ensure_signature_is_compatible(base_class_method, value)
C:\Users\dexte\.conda\envs\zapata-main\lib\site-packages\overrides\enforce.py:34: in ensure_signature_is_compatible
    ensure_all_args_defined_in_sub(super_sig, sub_sig)
C:\Users\dexte\.conda\envs\zapata-main\lib\site-packages\overrides\enforce.py:47: in ensure_all_args_defined_in_sub
    raise TypeError(f"`{name}` is not present.")
E   TypeError: `estimator_kwargs` is not present.
```