### PR TITLE
Make zquantum-core testable on Win10

### DIFF
--- a/src/python/zquantum/core/circuit/_circuit.py
+++ b/src/python/zquantum/core/circuit/_circuit.py
@@ -564,16 +564,19 @@ class Circuit(object):
         self.qubits = _qubits
 
 
-def save_circuit(circuit, filename):
+def save_circuit(circuit, file_or_path):
     """Saves a circuit object to a file.
 
     Args:
-        circuit (core.Circuit): the circuit to be saved
-        filename (str): the name of the file
+        circuit: the circuit to be saved
+        file_or_path: the name of the file
     """
-
-    with open(filename, "w") as f:
-        f.write(json.dumps(circuit.to_dict(serialize_gate_params=True)))
+    payload = circuit.to_dict(serialize_gate_params=True)
+    try:
+        json.dump(payload, file_or_path)
+    except AttributeError:
+        with open(file_or_path, "w") as f:
+            json.dump(payload, f)
 
 
 def load_circuit(file):

--- a/tests/zquantum/core/openfermion/_io_test.py
+++ b/tests/zquantum/core/openfermion/_io_test.py
@@ -178,6 +178,18 @@ class TestQubitOperator(unittest.TestCase):
         # Then
         # TODO
 
+        files_to_remove = ("parameter-grid-evaluation.json", "optimal-parameters.json")
+        failed_to_remove = []
+
+        for path in files_to_remove:
+            try:
+                os.remove(path)
+            except OSError:
+                failed_to_remove.append(path)
+
+        if failed_to_remove:
+            raise RuntimeError(f"Failed to remove files: {failed_to_remove}")
+
     def test_interaction_rdm_io(self):
         # Given
 
@@ -211,8 +223,3 @@ class TestQubitOperator(unittest.TestCase):
         converted_interaction_rdm = convert_dict_to_interaction_rdm(rdm_dict)
 
         self.assertEqual(self.interaction_rdm, converted_interaction_rdm)
-
-    def tearDown(self):
-        subprocess.run(
-            ["rm", "parameter-grid-evaluation.json", "optimal-parameters.json"]
-        )

--- a/tests/zquantum/core/wip/circuits/_serde_test.py
+++ b/tests/zquantum/core/wip/circuits/_serde_test.py
@@ -10,8 +10,6 @@ from zquantum.core.wip.circuits._serde import (
     to_dict,
 )
 from zquantum.core import circuit as old_circuit
-import tempfile
-import json
 
 ALPHA = sympy.Symbol("alpha")
 GAMMA = sympy.Symbol("gamma")
@@ -139,12 +137,6 @@ def test_loading_old_circuit_dict_raises_error(serialize_gate_params):
 @pytest.mark.parametrize("serialize_gate_params", [False, True])
 def test_loading_old_circuit_string_raises_error(serialize_gate_params):
     old_circ = _make_example_old_circuit()
-
-    with tempfile.NamedTemporaryFile() as tmp_file:
-        old_circuit.save_circuit(old_circ, tmp_file.name)
-        with open(tmp_file.name) as f:
-            circ_dict = json.load(f)
-
     circ_dict = old_circ.to_dict(serialize_gate_params)
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
This adds several fixes that seem to be needed to run our unit tests on Windows 10. The introduced changes should be backwards compatible, and should not break existing compatibility with other OSes.