### PR TITLE
Fix handling inactive qubits past last active qubit

### DIFF
--- a/src/python/zquantum/core/wip/circuits/_compatibility.py
+++ b/src/python/zquantum/core/wip/circuits/_compatibility.py
@@ -9,4 +9,9 @@ AnyCircuit = Union[OldCircuit, NewCircuit]
 
 
 def new_circuit_from_old_circuit(old: OldCircuit) -> NewCircuit:
-    return import_from_cirq(old.to_cirq())
+    if not old.qubits:
+        return NewCircuit([])
+
+    pre_new_circuit = import_from_cirq(old.to_cirq())
+    n_qubits = max([qubit.index for qubit in old.qubits]) + 1
+    return NewCircuit(pre_new_circuit.operations, n_qubits=n_qubits)


### PR DESCRIPTION
Currently, converting old circuit to new (wip) circuit discards inactive qubits past the last active qubit. This is because we used old -> Cirq -> new conversion strategy, and already old -> Cirq part loses those inactive qubits.

This PR fixes this by checking the old circuit for the qubit with the largest index and then explicitly setting `n_qubits` in the new circuit.