### PR TITLE
Fix flake8 errors (vol. 1)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-ignore = E203,E266,F401
+ignore = E203,E266,F401,W503
 max-line-length = 88

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -53,7 +53,7 @@ jobs:
           # Extra options: pycodestyle $(extra-pycodestyle-options) $(python-root-list)
           # extra-pycodestyle-options: # optional, default is 
           # Extra options: flake8 $(extra-flake8-options) $(python-root-list)
-          extra-flake8-options: --ignore=E203,E266,F401 --max-line-length=88
+          extra-flake8-options: --ignore=E203,E266,F401,W503 --max-line-length=88
           # Extra options: black --check $(extra-black-options) $(python-root-list)
           extra-black-options: --check
           # Extra options: mypy $(extra-mypy-options) $(python-root-list)

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -36,27 +36,29 @@ jobs:
         with:
           # A list of all paths to test
           python-root-list: src/
-          # Use Pylint
+
           use-pylint: false
-          # Use pycodestyle
           use-pycodestyle: false
-          # Use Flake8
           use-flake8: true
-          # Use Black
           use-black: true
-          # Use mypy
           use-mypy: true
-          # Use isort
           use-isort: true
+
           # Extra options: pylint $(extra-pylint-options) $(python-root-list)
           # extra-pylint-options: # optional, default is 
+
           # Extra options: pycodestyle $(extra-pycodestyle-options) $(python-root-list)
           # extra-pycodestyle-options: # optional, default is 
+
           # Extra options: flake8 $(extra-flake8-options) $(python-root-list)
+          # Black's output doesn't pass all flake8 checks. We need to disable some of them.
           extra-flake8-options: --ignore=E203,E266,F401,W503 --max-line-length=88
+
           # Extra options: black --check $(extra-black-options) $(python-root-list)
           extra-black-options: --check
+
           # Extra options: mypy $(extra-mypy-options) $(python-root-list)
           extra-mypy-options: --ignore-missing-imports --namespace-packages
+
           # Extra options: isort -rc $(extra-isort-options) $(python-root-list) -c --diff 
           extra-isort-options: --check-only --profile black

--- a/src/python/zquantum/core/cost_function.py
+++ b/src/python/zquantum/core/cost_function.py
@@ -43,11 +43,14 @@ def _get_sorted_set_of_circuit_symbols(
     )
 
 
+_by_averaging = estimate_expectation_values_by_averaging
+
+
 def get_ground_state_cost_function(
     target_operator: SymbolicOperator,
     parametrized_circuit: Circuit,
     backend: QuantumBackend,
-    estimation_method: EstimateExpectationValues = estimate_expectation_values_by_averaging,
+    estimation_method: EstimateExpectationValues = _by_averaging,
     estimation_preprocessors: List[EstimationPreprocessor] = None,
     fixed_parameters: Optional[np.ndarray] = None,
     parameter_precision: Optional[float] = None,
@@ -202,7 +205,7 @@ class AnsatzBasedCostFunction:
         target_operator: SymbolicOperator,
         ansatz: Ansatz,
         backend: QuantumBackend,
-        estimation_method: EstimateExpectationValues = estimate_expectation_values_by_averaging,
+        estimation_method: EstimateExpectationValues = _by_averaging,
         estimation_preprocessors: List[EstimationPreprocessor] = None,
         fixed_parameters: Optional[np.ndarray] = None,
         parameter_precision: Optional[float] = None,

--- a/src/python/zquantum/core/cost_function.py
+++ b/src/python/zquantum/core/cost_function.py
@@ -63,14 +63,18 @@ def get_ground_state_cost_function(
         target_operator: operator to be evaluated and find the ground state of
         parametrized_circuit: parameterized circuit to prepare quantum states
         backend: backend used for evaluation
-        estimation_method: estimation_method used to compute expectation value of target operator
-        estimation_preprocessors: A list of callable functions that adhere to the EstimationPreprocessor
-            protocol and are used to create the estimation tasks.
+        estimation_method: estimation_method used to compute expectation value of target
+            operator
+        estimation_preprocessors: A list of callable functions that adhere to the
+            EstimationPreprocessor protocol and are used to create the estimation tasks.
         fixed_parameters: values for the circuit parameters that should be fixed.
-        parameter_precision: the standard deviation of the Gaussian noise to add to each parameter, if any.
-        parameter_precision_seed: seed for randomly generating parameter deviation if using parameter_precision
-        gradient_function: a function which returns a function used to compute the gradient of the cost function
-            (see from zquantum.core.gradients.finite_differences_gradient for reference)
+        parameter_precision: the standard deviation of the Gaussian noise to add to each
+            parameter, if any.
+        parameter_precision_seed: seed for randomly generating parameter deviation if
+            using parameter_precision
+        gradient_function: a function which returns a function used to compute the
+            gradient of the cost function (see
+            zquantum.core.gradients.finite_differences_gradient for reference)
 
     Returns:
         Callable
@@ -135,12 +139,12 @@ def sum_expectation_values(expectation_values: ExpectationValues) -> ValueEstima
 
     If correlations are available, the precision of the sum is computed as
 
-    \epsilon = \sqrt{\sum_k \sigma^2_k}
+    \\epsilon = \\sqrt{\\sum_k \\sigma^2_k}
 
-    where the sum runs over frames and \sigma^2_k is the estimated variance of
+    where the sum runs over frames and \\sigma^2_k is the estimated variance of
     the estimated contribution of frame k to the total. This is calculated as
 
-    \sigma^2_k = \sum_{i,j} Cov(o_{k,i}, o_{k, j})
+    \\sigma^2_k = \\sum_{i,j} Cov(o_{k,i}, o_{k, j})
 
     where Cov(o_{k,i}, o_{k, j}) is the estimated covariance in the estimated
     expectation values of operators i and j of frame k.
@@ -172,12 +176,15 @@ class AnsatzBasedCostFunction:
         target_operator: operator to be evaluated
         ansatz: ansatz used to evaluate cost function
         backend: backend used for evaluation
-        estimation_method: estimation_method used to compute expectation value of target operator
-        estimation_preprocessors: A list of callable functions that adhere to the EstimationPreprocessor
-            protocol and are used to create the estimation tasks.
+        estimation_method: estimation_method used to compute expectation value of target
+            operator
+        estimation_preprocessors: A list of callable functions that adhere to the
+            EstimationPreprocessor protocol and are used to create the estimation tasks.
         fixed_parameters: values for the circuit parameters that should be fixed.
-        parameter_precision: the standard deviation of the Gaussian noise to add to each parameter, if any.
-        parameter_precision_seed: seed for randomly generating parameter deviation if using parameter_precision
+        parameter_precision: the standard deviation of the Gaussian noise to add to each
+            parameter, if any.
+        parameter_precision_seed: seed for randomly generating parameter deviation if
+            using parameter_precision
 
     Params:
         backend: see Args
@@ -185,7 +192,8 @@ class AnsatzBasedCostFunction:
         fixed_parameters (np.ndarray): see Args
         parameter_precision: see Args
         parameter_precision_seed: see Args
-        estimation_tasks: A list of EstimationTask objects with circuits to run and operators to measure
+        estimation_tasks: A list of EstimationTask objects with circuits to run and
+            operators to measure
         circuit_symbols: A list of all symbolic parameters used in any estimation task
     """
 

--- a/src/python/zquantum/core/cost_function.py
+++ b/src/python/zquantum/core/cost_function.py
@@ -19,7 +19,7 @@ from .circuit import combine_ansatz_params, Circuit
 from .gradients import finite_differences_gradient
 from .utils import create_symbols_map, ValueEstimate
 from .measurement import ExpectationValues
-from typing import Optional, Callable, Dict, List, Any, Union
+from typing import Optional, Callable, List, Any, Union
 import numpy as np
 import sympy
 from openfermion import SymbolicOperator

--- a/src/python/zquantum/core/evolution.py
+++ b/src/python/zquantum/core/evolution.py
@@ -38,7 +38,8 @@ def time_evolution(
         terms = list(hamiltonian.get_operators())
     elif isinstance(hamiltonian, pyquil.paulis.PauliSum):
         warnings.warn(
-            "PauliSum as an input to time_evolution will be depreciated, please change to QubitOperator instead.",
+            "PauliSum as an input to time_evolution will be depreciated, please change "
+            "to QubitOperator instead.",
             DeprecationWarning,
         )
         terms = hamiltonian.terms
@@ -181,7 +182,8 @@ def time_evolution_derivatives(
         terms = list(hamiltonian.get_operators())
     elif isinstance(hamiltonian, pyquil.paulis.PauliSum):
         warnings.warn(
-            "PauliSum as an input to time_evolution_derivatives will be depreciated, please change to QubitOperator instead.",
+            "PauliSum as an input to time_evolution_derivatives will be depreciated, "
+            "please change to QubitOperator instead.",
             DeprecationWarning,
         )
         terms = hamiltonian.terms

--- a/src/python/zquantum/core/measurement.py
+++ b/src/python/zquantum/core/measurement.py
@@ -13,7 +13,6 @@ from typing import (
     Dict,
     Union,
     Any,
-    Iterable,
     cast,
 )
 
@@ -336,7 +335,7 @@ def get_parities_from_measurements(
     """
 
     # check input format
-    if isinstance(ising_operator, IsingOperator) == False:
+    if not isinstance(ising_operator, IsingOperator):
         raise TypeError("Input operator not openfermion.IsingOperator")
 
     # Count number of occurrences of bitstrings
@@ -623,11 +622,11 @@ class Measurements:
         Returns:
             expectation values of each term in the operator
         """
-        if isinstance(ising_operator, IsingOperator) == False:
         # We require operator to be IsingOperator because measurements are always
         # performed in the Z basis, so we need the operator to be Ising (containing only
         # Z terms). A general Qubit Operator could have X or Y terms which don’t get
         # directly measured.
+        if not isinstance(ising_operator, IsingOperator):
             raise TypeError("Input operator is not openfermion.IsingOperator")
 
         # Count number of occurrences of bitstrings

--- a/src/python/zquantum/core/measurement.py
+++ b/src/python/zquantum/core/measurement.py
@@ -215,9 +215,10 @@ class Parities:
             to the number of samples with even and odd parities for term P_i,
             respectively.
         correlations (list): a list of 3-dimensional numpy arrays indicating how
-            many times each product of Pauli terms was observed with even and odd parity.
-            Here correlations[i][j][k][0] and correlations[i][j][k][1] correspond to the number
-            of samples with even and odd parities term P_j P_k in frame i, respectively.
+            many times each product of Pauli terms was observed with even and odd
+            parity. Here correlations[i][j][k][0] and correlations[i][j][k][1]
+            correspond to the number of samples with even and odd parities term P_j P_k
+            in frame i, respectively.
     """
 
     def __init__(
@@ -280,13 +281,15 @@ def load_parities(file: LoadSource) -> Parities:
 
 
 def get_expectation_values_from_parities(parities: Parities) -> ExpectationValues:
-    """Get the expectation values of a set of operators (with precisions) from a set of samples (with even/odd parities) for them.
+    """Get the expectation values of a set of operators (with precisions) from a set of
+    samples (with even/odd parities) for them.
 
     Args:
-        parities (zquantum.core.measurement.Parities): Contains the number of samples with even and odd parities for each operator.
+        parities: Contains the number of samples with even and odd parities for each
+            operator.
 
     Returns:
-        A zquantum.core.measurement.ExpectationValues object: Contains the expectation values of the operators and the associated precisions.
+        Expectation values of the operators and the associated precisions.
     """
     values = []
     estimator_covariances = []
@@ -301,8 +304,9 @@ def get_expectation_values_from_parities(parities: Parities) -> ExpectationValue
         p = N0 / N
         value = 2.0 * p - 1.0
 
-        # If there are enough samples and the probability of getting a sample with even parity is not close to 0 or 1,
-        # then we can use p=N0/N to approximate this probability and plug it into the formula for the precision.
+        # If there are enough samples and the probability of getting a sample with even
+        # parity is not close to 0 or 1, then we can use p=N0/N to approximate this
+        # probability and plug it into the formula for the precision.
         if N >= 100 and p >= 0.1 and p <= 0.9:
             precision = 2.0 * np.sqrt(p * (1.0 - p)) / np.sqrt(N)
         else:
@@ -449,9 +453,10 @@ def get_expectation_value_from_frequencies(
 
 
 class Measurements:
-    """A class representing measurements from a quantum circuit. The bitstrings variable represents the internal
-    data structure of the Measurements class. It is expressed as a list of tuples wherein each tuple is a measurement
-    and the value of the tuple at a given index is the measured bit-value of the qubit (indexed from 0 -> N-1)"""
+    """A class representing measurements from a quantum circuit. The bitstrings variable
+    represents the internal data structure of the Measurements class. It is expressed as
+    a list of tuples wherein each tuple is a measurement and the value of the tuple at a
+    given index is the measured bit-value of the qubit (indexed from 0 -> N-1)"""
 
     def __init__(self, bitstrings: Optional[List[Tuple[int, ...]]] = None):
         if bitstrings is None:
@@ -464,7 +469,8 @@ class Measurements:
         """Create an instance of the Measurements class from a dictionary
 
         Args:
-            counts (dict): mapping of bitstrings to integers representing the number of times the bitstring was measured
+            counts: mapping of bitstrings to integers representing the number of times
+                the bitstring was measured
         """
         measurements = cls()
         measurements.add_counts(counts)
@@ -474,13 +480,12 @@ class Measurements:
     def get_measurements_representing_distribution(
         cls, bitstring_distribution: BitstringDistribution, number_of_samples: int
     ):
-        """Create an instance of the Measurements class that exactly (or as closely as possible) resembles the input
-        bitstring distribution.
+        """Create an instance of the Measurements class that exactly (or as closely as
+        possible) resembles the input bitstring distribution.
 
         Args:
-            bitstring_distribution (zquantum.core.bitstring_distribution.BitstringDistribution): the bitstring
-                distribution to be sampled
-            number_of_samples (int): the number of measurements
+            bitstring_distribution: the bitstring distribution to be sampled
+            number_of_samples: the number of measurements
         """
         distribution = copy.deepcopy(bitstring_distribution.distribution_dict)
 
@@ -566,7 +571,8 @@ class Measurements:
         """Get the measurements as a histogram
 
         Returns:
-            A dictionary mapping bitstrings to integers representing the number of times the bitstring was measured
+            A dictionary mapping bitstrings to integers representing the number of times
+            the bitstring was measured
         """
         bitstrings = convert_tuples_to_bitstrings(self.bitstrings)
         return dict(Counter(bitstrings))
@@ -575,9 +581,10 @@ class Measurements:
         """Add measurements from a histogram
 
         Args:
-            counts (dict): mapping of bitstrings to integers representing the number of times the bitstring was measured
-                NOTE: bitstrings are also indexed from 0 -> N-1, where the "001" bitstring represents a measurement of
-                    qubit 2 in the 1 state
+            counts: mapping of bitstrings to integers representing the number of times
+                the bitstring was measured
+                NOTE: bitstrings are also indexed from 0 -> N-1, where the "001"
+                bitstring represents a measurement of qubit 2 in the 1 state
         """
         for bitstring in counts.keys():
             measurement = []
@@ -586,11 +593,11 @@ class Measurements:
 
             self.bitstrings += [tuple(measurement)] * counts[bitstring]
 
-    def get_distribution(self):
+    def get_distribution(self) -> BitstringDistribution:
         """Get the normalized probability distribution representing the measurements
 
         Returns:
-            distribution (BitstringDistribution): bitstring distribution based on the frequency of measurements
+            distribution: bitstring distribution based on the frequency of measurements
         """
         counts = self.get_counts()
         num_measurements = len(self.bitstrings)
@@ -614,12 +621,13 @@ class Measurements:
                 diverges when only one sample is taken.
 
         Returns:
-            zquantum.core.measurement.ExpectationValues: the expectation values of each term in the operator
+            expectation values of each term in the operator
         """
-        # We require operator to be IsingOperator because measurements are always performed in the Z basis,
-        # so we need the operator to be Ising (containing only Z terms).
-        # A general Qubit Operator could have X or Y terms which don’t get directly measured.
         if isinstance(ising_operator, IsingOperator) == False:
+        # We require operator to be IsingOperator because measurements are always
+        # performed in the Z basis, so we need the operator to be Ising (containing only
+        # Z terms). A general Qubit Operator could have X or Y terms which don’t get
+        # directly measured.
             raise TypeError("Input operator is not openfermion.IsingOperator")
 
         # Count number of occurrences of bitstrings

--- a/src/python/zquantum/core/utils.py
+++ b/src/python/zquantum/core/utils.py
@@ -103,11 +103,9 @@ def bin2dec(x: List[int]) -> int:
     return dec
 
 
-"""
-The functions PAULI_X, PAULI_Y, PAULI_Z and IDENTITY below are used for 
-generating the generators of the Pauli group, which include Pauli X, Y, Z 
-operators as well as identity operator
-"""
+# The functions PAULI_X, PAULI_Y, PAULI_Z and IDENTITY below are used for
+# generating the generators of the Pauli group, which include Pauli X, Y, Z
+# operators as well as identity operator
 
 pauli_x = np.array([[0.0, 1.0], [1.0, 0.0]])
 pauli_y = np.array([[0.0, -1.0j], [1.0j, 0.0]])
@@ -163,9 +161,9 @@ def compare_unitary(u1: np.ndarray, u2: np.ndarray, tol: float = 1e-15) -> bool:
             differences in global phase.
     """
 
-    if is_unitary(u1, tol) == False:
+    if not is_unitary(u1, tol):
         raise Exception("The first input matrix is not unitary.")
-    if is_unitary(u2, tol) == False:
+    if not is_unitary(u2, tol):
         raise Exception("The second input matrix is not unitary.")
 
     test_matrix = np.dot(u1.conj().T, u2)
@@ -267,7 +265,8 @@ class ValueEstimate(float):
     @property
     def value(self):
         warnings.warn(
-            "The value attribute is deprecated. Use ValueEstimate object directly instead.",
+            "The value attribute is deprecated. Use ValueEstimate object directly "
+            "instead.",
             DeprecationWarning,
         )
         return float(self)
@@ -410,7 +409,8 @@ def get_func_from_specs(specs: Dict):
 
     """
     warnings.warn(
-        "zquantum.core.utils.get_func_from_specs will be deprecated. Please use zquantum.core.utils.create_object instead",
+        "zquantum.core.utils.get_func_from_specs will be deprecated. Please use "
+        "zquantum.core.utils.create_object instead",
         DeprecationWarning,
     )
     return create_object(specs)
@@ -476,13 +476,15 @@ def load_noise_model(file: LoadSource):
     return func(noise_model_data)
 
 
-def save_noise_model(noise_model_data, module_name, function_name, filename):
+def save_noise_model(
+        noise_model_data: dict, module_name: str, function_name: str, filename
+):
     """Save a noise model to file
 
     Args:
-        noise_model_data (dict): the serialized version of the noise model
-        module_name (str): the module name with the function to load the noise model
-        function_name (str): the function to load the noise model data into a noise model
+        noise_model_data: the serialized version of the noise model
+        module_name: the module name with the function to load the noise model
+        function_name: the function to load the noise model data into a noise model
         filename (str or file-like object): the name of the file, or a file-like object.
 
     Returns:


### PR DESCRIPTION
I've ran the same check that Github Actions do and fixed the errors for a couple of first files on the list.

Moreover, I've added [W503](https://www.flake8rules.com/rules/W503.html) to the list of rules ignored by `flake8` because this rule contradicts `black`'s output.

The command to replicate the errors locally is: 
```
flake8 --ignore=E203,E266,F401,W503 --max-line-length=88 src
```

Lastly, please take a look at https://github.com/zapatacomputing/z-quantum-core/blob/8b2a05f070e13af8f7a92934615c59079e3bde4b/src/python/zquantum/core/cost_function.py#L46-L53 – I aliased the default value because otherwise the line would be too long. Running `black` on the file didn't fix it so I've came up with this workaround but it doesn't seem idiomatic. Perhaps you have a better idea?