### PR TITLE
Statistical precision of the cost function estimates

### DIFF
--- a/src/python/zquantum/core/cost_function.py
+++ b/src/python/zquantum/core/cost_function.py
@@ -18,7 +18,7 @@ from .interfaces.functions import (
 from .circuit import combine_ansatz_params, Circuit
 from .gradients import finite_differences_gradient
 from .utils import create_symbols_map, ValueEstimate
-from .measurement import ExpectationValues
+from .measurement import ExpectationValues, expectation_values_to_real, concatenate_expectation_values
 from typing import Optional, Callable, List, Any, Union
 import numpy as np
 import sympy
@@ -263,10 +263,8 @@ class AnsatzBasedCostFunction:
             self.estimation_tasks, [symbols_map for _ in self.estimation_tasks]
         )
         expectation_values_list = self.estimation_method(self.backend, estimation_tasks)
-        partial_sums: List[Any] = [
-            np.sum(expectation_values.values)
-            for expectation_values in expectation_values_list
-        ]
-        summed_values = ValueEstimate(np.sum(partial_sums))
+        combined_expectation_values = expectation_values_to_real(
+            concatenate_expectation_values(expectation_values_list)
+        )
 
-        return summed_values
+        return sum_expectation_values(combined_expectation_values)


### PR DESCRIPTION
In the current dev branch, the `__call__` method of the `AnsatzBasedCostFunction` discards precision info when doing summation of the estimated expectation values. This is a quick fix using `concatenate_expectation_values` and `sum_expectation_values`.