### PR TITLE
Fix importing cirq Y in power form

### DIFF
--- a/src/python/zquantum/core/wip/circuits/conversions/cirq_conversions.py
+++ b/src/python/zquantum/core/wip/circuits/conversions/cirq_conversions.py
@@ -111,6 +111,12 @@ ZQUANTUM_BUILTIN_GATE_NAME_TO_CIRQ_GATE: Dict[str, Callable] = {
 }
 
 
+CIRQ_GATE_TO_ZQUANTUM_BUILTIN_GATE_NAME = {
+    cirq_factory: name
+    for name, cirq_factory in ZQUANTUM_BUILTIN_GATE_NAME_TO_CIRQ_GATE.items()
+}
+
+
 EIGENGATE_SPECIAL_CASES = {
     (type(cirq.X), cirq.X.global_shift, cirq.X.exponent): _builtin_gates.X,
     (type(cirq.Y), cirq.Y.global_shift, cirq.Y.exponent): _builtin_gates.Y,
@@ -126,6 +132,21 @@ EIGENGATE_SPECIAL_CASES = {
         cirq.ISWAP.global_shift,
         cirq.ISWAP.exponent,
     ): _builtin_gates.ISWAP,
+    (
+        cirq.ops.common_gates.XPowGate,
+        cirq.X.global_shift,
+        cirq.X.exponent,
+    ): _builtin_gates.X,
+    (
+        cirq.ops.common_gates.YPowGate,
+        cirq.Y.global_shift,
+        cirq.Y.exponent,
+    ): _builtin_gates.Y,
+    (
+        cirq.ops.common_gates.ZPowGate,
+        cirq.Z.global_shift,
+        cirq.Z.exponent,
+    ): _builtin_gates.Z,
 }
 
 EIGENGATE_ROTATIONS = {

--- a/src/python/zquantum/core/wip/circuits/conversions/cirq_conversions.py
+++ b/src/python/zquantum/core/wip/circuits/conversions/cirq_conversions.py
@@ -111,12 +111,6 @@ ZQUANTUM_BUILTIN_GATE_NAME_TO_CIRQ_GATE: Dict[str, Callable] = {
 }
 
 
-CIRQ_GATE_TO_ZQUANTUM_BUILTIN_GATE_NAME = {
-    cirq_factory: name
-    for name, cirq_factory in ZQUANTUM_BUILTIN_GATE_NAME_TO_CIRQ_GATE.items()
-}
-
-
 EIGENGATE_SPECIAL_CASES = {
     (type(cirq.X), cirq.X.global_shift, cirq.X.exponent): _builtin_gates.X,
     (type(cirq.Y), cirq.Y.global_shift, cirq.Y.exponent): _builtin_gates.Y,

--- a/tests/zquantum/core/wip/circuits/conversions/cirq_conversions_test.py
+++ b/tests/zquantum/core/wip/circuits/conversions/cirq_conversions_test.py
@@ -11,21 +11,21 @@ from zquantum.core.wip.circuits.conversions.cirq_conversions import (
 
 # --------- gates ---------
 
+EQUIVALENT_IDENTITY_GATES = [
+    (_builtin_gates.I, cirq.I),
+]
+
 EQUIVALENT_NON_PARAMETRIC_GATES = [
     (_builtin_gates.X, cirq.X),
     (_builtin_gates.Y, cirq.Y),
     (_builtin_gates.Z, cirq.Z),
     (_builtin_gates.H, cirq.H),
-    (_builtin_gates.I, cirq.I),
     (_builtin_gates.S, cirq.S),
     (_builtin_gates.T, cirq.T),
     (_builtin_gates.CNOT, cirq.CNOT),
     (_builtin_gates.CZ, cirq.CZ),
     (_builtin_gates.SWAP, cirq.SWAP),
     (_builtin_gates.ISWAP, cirq.ISWAP),
-    (_builtin_gates.X, cirq.X ** 1),
-    (_builtin_gates.Y, cirq.Y ** 1),
-    (_builtin_gates.Z, cirq.Z ** 1),
 ]
 
 EQUIVALENT_PARAMETRIC_GATES = [
@@ -69,6 +69,7 @@ EQUIVALENT_U3_GATES = [
 @pytest.mark.parametrize(
     "zquantum_gate,cirq_gate",
     [
+        *EQUIVALENT_IDENTITY_GATES,
         *EQUIVALENT_NON_PARAMETRIC_GATES,
         *EQUIVALENT_PARAMETRIC_GATES,
         *EQUIVALENT_U3_GATES,
@@ -88,6 +89,23 @@ class TestGateConversion:
         self, zquantum_gate, cirq_gate
     ):
         assert import_from_cirq(cirq_gate) == zquantum_gate
+
+
+@pytest.mark.parametrize(
+    "zquantum_gate,cirq_gate",
+    [
+        *EQUIVALENT_NON_PARAMETRIC_GATES,
+        *EQUIVALENT_PARAMETRIC_GATES,
+    ],
+)
+def test_importing_gate_in_power_form_gives_expected_gate(zquantum_gate, cirq_gate):
+    pow_gate = cirq_gate ** 1.0
+    if "PowGate" not in str(type(pow_gate)):
+        raise TypeError(
+            f"This test expects power gates. Generated {type(pow_gate)} instead"
+        )
+
+    assert import_from_cirq(pow_gate) == zquantum_gate
 
 
 # circuits ---------

--- a/tests/zquantum/core/wip/circuits/conversions/cirq_conversions_test.py
+++ b/tests/zquantum/core/wip/circuits/conversions/cirq_conversions_test.py
@@ -23,6 +23,9 @@ EQUIVALENT_NON_PARAMETRIC_GATES = [
     (_builtin_gates.CZ, cirq.CZ),
     (_builtin_gates.SWAP, cirq.SWAP),
     (_builtin_gates.ISWAP, cirq.ISWAP),
+    (_builtin_gates.X, cirq.X ** 1),
+    (_builtin_gates.Y, cirq.Y ** 1),
+    (_builtin_gates.Z, cirq.Z ** 1),
 ]
 
 EQUIVALENT_PARAMETRIC_GATES = [


### PR DESCRIPTION
Some other libraries we use return cirq circuits with gates in the form of `*PowGate` with exponent equal to `1.0`. They're strange creatures, see the debugger snippet below:
```
(Pdb) p gate
cirq.Y
(Pdb) p str(gate)
'Y'
(Pdb) p type(gate)
<class 'cirq.ops.common_gates.YPowGate'>
(Pdb) p repr(gate)
'cirq.Y'
(Pdb) p gate.exponent
1.0
(Pdb) p gate.global_shift
0.0
(Pdb) p gate == cirq.Y
True
(Pdb) p type(gate) == type(cirq.Y)
False
```

This PR extends our circuit importer to handle special cases of Pow Gates like the above.