### PR TITLE
Custom gate fallback for importing gates from Cirq

### DIFF
--- a/src/python/zquantum/core/wip/circuits/conversions/cirq_conversions.py
+++ b/src/python/zquantum/core/wip/circuits/conversions/cirq_conversions.py
@@ -247,7 +247,7 @@ def import_from_cirq(obj):
 
 
 @import_from_cirq.register
-def convert_qasm_u_gate_to_zquantum_gate(
+def _convert_qasm_u_gate_to_zquantum_gate(
     ugate: cirq.circuits.qasm_output.QasmUGate,
 ) -> _gates.Gate:
     angles = (
@@ -257,7 +257,7 @@ def convert_qasm_u_gate_to_zquantum_gate(
 
 
 @import_from_cirq.register
-def convert_eigengate_to_zquantum_gate(eigengate: cirq.EigenGate) -> _gates.Gate:
+def _convert_eigengate_to_zquantum_gate(eigengate: cirq.EigenGate) -> _gates.Gate:
     key = (type(eigengate), eigengate.global_shift, eigengate.exponent)
     try:
         return EIGENGATE_SPECIAL_CASES[key]
@@ -271,14 +271,14 @@ def convert_eigengate_to_zquantum_gate(eigengate: cirq.EigenGate) -> _gates.Gate
 
 
 @import_from_cirq.register
-def convert_cirq_identity_gate_to_zquantum_gate(
+def _convert_cirq_identity_gate_to_zquantum_gate(
     identity_gate: cirq.IdentityGate,
 ) -> _gates.Gate:
     return _builtin_gates.I
 
 
 @import_from_cirq.register
-def import_cirq_controlled_gate(controlled_gate: cirq.ControlledGate) -> _gates.Gate:
+def _import_cirq_controlled_gate(controlled_gate: cirq.ControlledGate) -> _gates.Gate:
     return import_from_cirq(controlled_gate.sub_gate).controlled(
         controlled_gate.num_controls()
     )
@@ -286,7 +286,7 @@ def import_cirq_controlled_gate(controlled_gate: cirq.ControlledGate) -> _gates.
 
 @import_from_cirq.register(cirq.GateOperation)
 @import_from_cirq.register(cirq.ControlledOperation)
-def convert_gate_operation_to_zquantum(operation) -> _gates.GateOperation:
+def _convert_gate_operation_to_zquantum(operation) -> _gates.GateOperation:
     if not all(isinstance(qubit, cirq.LineQubit) for qubit in operation.qubits):
         raise NotImplementedError(
             f"Failed to import {operation}. Grid qubits are not yet supported."
@@ -296,7 +296,7 @@ def convert_gate_operation_to_zquantum(operation) -> _gates.GateOperation:
 
 
 @import_from_cirq.register
-def import_circuit_from_cirq(circuit: cirq.Circuit) -> _circuit.Circuit:
+def _import_circuit_from_cirq(circuit: cirq.Circuit) -> _circuit.Circuit:
     return _circuit.Circuit(
         [import_from_cirq(op) for op in chain.from_iterable(circuit.moments)]
     )

--- a/src/python/zquantum/core/wip/circuits/conversions/cirq_conversions.py
+++ b/src/python/zquantum/core/wip/circuits/conversions/cirq_conversions.py
@@ -252,7 +252,14 @@ class NonNativeGate:
 
 
 def _import_non_built_in_gate(gate) -> NonNativeGate:
-    return NonNativeGate(matrix=cirq.unitary(gate), cirq_class=type(gate))
+    try:
+        matrix = cirq.unitary(gate)
+    except TypeError as e:
+        raise NotImplementedError(
+            f"Can't import gate {gate} from cirq, even as a custom definition"
+        ) from e
+
+    return NonNativeGate(matrix=matrix, cirq_class=type(gate))
 
 
 @singledispatch

--- a/src/python/zquantum/core/wip/circuits/conversions/cirq_conversions.py
+++ b/src/python/zquantum/core/wip/circuits/conversions/cirq_conversions.py
@@ -228,17 +228,18 @@ def _export_circuit_to_cirq(circuit: _circuit.Circuit) -> cirq.Circuit:
 
 @singledispatch
 def import_from_cirq(obj):
-    """Import given Cirq object, converting it to its Zquantum native counterpart.
+    """Import given Cirq object, converting it to its ZQuantum counterpart.
 
-    Currently we support gates corresponding to Zquantum builtin gates, operations
-    on such gates and circuits composed of such gates.
+    Gates corresponding to ZQuantum built-in gates, operations on such gates and
+    circuits composed of such gates will use the native definitions, e.g. `cirq.X` will
+    become `circuits.X`.
 
-    Also note that only objects using only LineQubits are supported, as currently
-    there is no notion of GridQubit in Zquantum.
+    Importing gates from Cirq that don't have built-in counterparts in ZQuantum will
+    result in custom gates. See `help(zquantum.core.wip.circuits)` for examples of
+    custom gates.
 
-    Raises:
-        NotImplementedError: if the object to be imported is of currently unsupported
-            type.
+    Also note that only objects using only LineQubits are supported, as currently there
+    is no notion of GridQubit in ZQuantum circuits.
     """
     try:
         return CIRQ_GATE_SPECIAL_CASES[obj]

--- a/tests/zquantum/core/wip/circuits/conversions/cirq_conversions_test.py
+++ b/tests/zquantum/core/wip/circuits/conversions/cirq_conversions_test.py
@@ -230,6 +230,14 @@ class TestExportingToQiskit:
         )
 
 
+def _is_a_builtin_gate(gate: _gates.Gate):
+    try:
+        _builtin_gates.builtin_gate_by_name(gate.name)
+        return True
+    except KeyError:
+        return False
+
+
 class TestImportingFromCirq:
     @pytest.mark.parametrize("zquantum_circuit, cirq_circuit", EQUIVALENT_CIRCUITS)
     def test_gives_equivalent_circuit(self, zquantum_circuit, cirq_circuit):
@@ -240,7 +248,7 @@ class TestImportingFromCirq:
     def test_with_cirq_only_gates_returns_custom_gates(self, cirq_circuit):
         circuit = import_from_cirq(cirq_circuit)
         for operation in circuit.operations:
-            assert isinstance(operation.gate, _gates.CustomGateDefinition)
+            assert not _is_a_builtin_gate(operation.gate)
 
     @pytest.mark.parametrize("cirq_circuit", UNSUPPORTED_CIRQ_CIRCUITS)
     def test_importing_circuit_with_unsupported_gates(self, cirq_circuit):

--- a/tests/zquantum/core/wip/circuits/conversions/cirq_conversions_test.py
+++ b/tests/zquantum/core/wip/circuits/conversions/cirq_conversions_test.py
@@ -2,7 +2,7 @@ import cirq
 import numpy as np
 import pytest
 import sympy
-from zquantum.core.wip.circuits import _builtin_gates, _circuit
+from zquantum.core.wip.circuits import _builtin_gates, _circuit, _gates
 from zquantum.core.wip.circuits.conversions.cirq_conversions import (
     export_to_cirq,
     import_from_cirq,
@@ -164,9 +164,14 @@ class CustomGate(cirq.Gate):
         return f"R({self.theta})"
 
 
-UNSUPPORTED_CIRQ_CIRCUITS = [
+CIRQ_ONLY_CIRCUITS = [
     cirq.Circuit([cirq.ZPowGate(exponent=1.2, global_shift=0.1)(lq(1))]),
     cirq.Circuit([cirq.CCXPowGate(exponent=-0.1, global_shift=THETA)(*lq.range(3))]),
+    cirq.Circuit([CustomGate(np.pi)(lq(1))]),
+]
+
+
+UNSUPPORTED_CIRQ_CIRCUITS = [
     cirq.Circuit([CustomGate(GAMMA)(lq(1))]),
 ]
 
@@ -227,13 +232,17 @@ class TestExportingToQiskit:
 
 class TestImportingFromCirq:
     @pytest.mark.parametrize("zquantum_circuit, cirq_circuit", EQUIVALENT_CIRCUITS)
-    def test_importing_circuit_gives_equivalent_circuit(
-        self, zquantum_circuit, cirq_circuit
-    ):
+    def test_gives_equivalent_circuit(self, zquantum_circuit, cirq_circuit):
         imported = import_from_cirq(cirq_circuit)
         assert imported == zquantum_circuit
 
+    @pytest.mark.parametrize("cirq_circuit", CIRQ_ONLY_CIRCUITS)
+    def test_with_cirq_only_gates_returns_custom_gates(self, cirq_circuit):
+        circuit = import_from_cirq(cirq_circuit)
+        for operation in circuit.operations:
+            assert isinstance(operation.gate, _gates.CustomGateDefinition)
+
     @pytest.mark.parametrize("cirq_circuit", UNSUPPORTED_CIRQ_CIRCUITS)
-    def test_importing_circuit_with_unsupported_gates_raises(self, cirq_circuit):
+    def test_importing_circuit_with_unsupported_gates(self, cirq_circuit):
         with pytest.raises(NotImplementedError):
             import_from_cirq(cirq_circuit)

--- a/tests/zquantum/core/wip/circuits/conversions/cirq_conversions_test.py
+++ b/tests/zquantum/core/wip/circuits/conversions/cirq_conversions_test.py
@@ -251,6 +251,6 @@ class TestImportingFromCirq:
             assert not _is_a_builtin_gate(operation.gate)
 
     @pytest.mark.parametrize("cirq_circuit", UNSUPPORTED_CIRQ_CIRCUITS)
-    def test_importing_circuit_with_unsupported_gates(self, cirq_circuit):
+    def test_with_unsupported_gates_raises_not_implemented_error(self, cirq_circuit):
         with pytest.raises(NotImplementedError):
             import_from_cirq(cirq_circuit)


### PR DESCRIPTION
We don't have support for some gates in Cirq, e.g. `XPowGate`. When a developer ran `import_from_cirq` the circuit importer would fail with `NotImplementedError`. This PR adds fallback handling for scenarios like that by returning a circuit with custom gate definitions.