### PR TITLE
Disable all checks we aren't ready for

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -35,7 +35,7 @@ jobs:
         uses: ricardochaves/python-lint@v1.3.0
         with:
           # A list of all paths to test
-          python-root-list: src/
+          python-root-list: src/python/zquantum/core
 
           use-pylint: false
           use-pycodestyle: false

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -35,9 +35,7 @@ jobs:
         uses: ricardochaves/python-lint@v1.3.0
         with:
           # A list of all paths to test
-          python-root-list: 
-            - src/python/zquantum/core
-            - tests
+          python-root-list: "src/python/zquantum/core tests"
 
           use-pylint: false
           use-pycodestyle: false

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -35,7 +35,7 @@ jobs:
         uses: ricardochaves/python-lint@v1.3.0
         with:
           # A list of all paths to test
-          python-root-list: "src/python/zquantum/core tests"
+          python-root-list: "src/python/zquantum/core tests/zquantum/core tests/acceptance_tests"
 
           use-pylint: false
           use-pycodestyle: false

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -40,8 +40,9 @@ jobs:
           use-pylint: false
           use-pycodestyle: false
           use-flake8: true
-          use-mypy: true
-          # We're not ready yet to validate black & isort
+          # We're not ready yet to validate mypy, black & isort on every PR. In the 
+          # mean time, please rely on local pre-commit hook checks.
+          use-mypy: false
           use-black: false
           use-isort: false
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -40,9 +40,10 @@ jobs:
           use-pylint: false
           use-pycodestyle: false
           use-flake8: true
-          use-black: true
           use-mypy: true
-          use-isort: true
+          # We're not ready yet to validate black & isort
+          use-black: false
+          use-isort: false
 
           # Extra options: pylint $(extra-pylint-options) $(python-root-list)
           # extra-pylint-options: # optional, default is 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -35,7 +35,9 @@ jobs:
         uses: ricardochaves/python-lint@v1.3.0
         with:
           # A list of all paths to test
-          python-root-list: src/python/zquantum/core
+          python-root-list: 
+            - src/python/zquantum/core
+            - tests
 
           use-pylint: false
           use-pycodestyle: false


### PR DESCRIPTION
We're in the middle of making our code `mypy`-, `black`-, and `isort`-compatible. It takes longer than expected, as it's often blocked by other development we do on branches. This PR turns off all the checks that are doomed to fail until we finally reformat our code. This way the checks actually _check_ code style in the transition period, safeguarding us from regression that might creep in.