### PR TITLE
Migrate circuit steps to new circuits

### DIFF
--- a/src/python/zquantum/core/wip/circuits/__init__.py
+++ b/src/python/zquantum/core/wip/circuits/__init__.py
@@ -152,6 +152,7 @@ from ._gates import (
 )
 from ._generators import create_layer_of_gates
 from ._serde import circuit_from_dict, to_dict
+from ._testing import create_random_circuit
 from ._wavefunction_operations import MultiPhaseOperation
 from .conversions.cirq_conversions import export_to_cirq, import_from_cirq
 from .conversions.pyquil_conversions import export_to_pyquil, import_from_pyquil

--- a/src/python/zquantum/core/wip/circuits/__init__.py
+++ b/src/python/zquantum/core/wip/circuits/__init__.py
@@ -150,7 +150,7 @@ from ._gates import (
     GateOperation,
     MatrixFactoryGate,
 )
-from ._generators import create_layer_of_gates
+from ._generators import add_ancilla_register, create_layer_of_gates
 from ._serde import circuit_from_dict, to_dict
 from ._testing import create_random_circuit
 from ._wavefunction_operations import MultiPhaseOperation

--- a/src/python/zquantum/core/wip/circuits/__init__.py
+++ b/src/python/zquantum/core/wip/circuits/__init__.py
@@ -151,7 +151,7 @@ from ._gates import (
     MatrixFactoryGate,
 )
 from ._generators import add_ancilla_register, create_layer_of_gates
-from ._serde import circuit_from_dict, to_dict
+from ._serde import circuit_from_dict, circuitset_from_dict, to_dict
 from ._testing import create_random_circuit
 from ._wavefunction_operations import MultiPhaseOperation
 from .conversions.cirq_conversions import export_to_cirq, import_from_cirq

--- a/src/python/zquantum/core/wip/circuits/_generators.py
+++ b/src/python/zquantum/core/wip/circuits/_generators.py
@@ -2,7 +2,7 @@ from typing import Optional, Union, cast
 
 import numpy as np
 
-from ._builtin_gates import GatePrototype
+from ._builtin_gates import GatePrototype, I
 from ._circuit import Circuit
 from ._gates import Gate
 
@@ -36,3 +36,19 @@ def create_layer_of_gates(
             circuit += gate_factory(i)
 
     return circuit
+
+
+def add_ancilla_register(circuit: Circuit, n_ancilla_qubits: int):
+    """Add a register of ancilla qubits (qubit + identity gate) to an existing circuit.
+
+    Args:
+        circuit: circuit to be extended
+        n_ancilla_qubits: number of ancilla qubits to add
+    Returns:
+        extended circuit
+    """
+    extended_circuit = circuit
+    for ancilla_qubit_i in range(n_ancilla_qubits):
+        qubit_index = circuit.n_qubits + ancilla_qubit_i
+        extended_circuit += I(qubit_index)
+    return extended_circuit

--- a/src/python/zquantum/core/wip/circuits/_serde.py
+++ b/src/python/zquantum/core/wip/circuits/_serde.py
@@ -1,5 +1,5 @@
 from functools import singledispatch
-from typing import Iterable, List
+from typing import Iterable, List, Mapping
 
 import sympy
 
@@ -7,6 +7,7 @@ from ...utils import SCHEMA_VERSION
 from . import _builtin_gates, _circuit, _gates
 
 CIRCUIT_SCHEMA = SCHEMA_VERSION + "-circuit-v2"
+CIRCUITSET_SCHEMA = SCHEMA_VERSION + "-circuitset-v2"
 
 
 def serialize_expr(expr: sympy.Expr):
@@ -84,6 +85,20 @@ def _circuit_to_dict(circuit: _circuit.Circuit):
             if custom_gate_definitions
             else {}
         ),
+    }
+
+
+@to_dict.register(list)
+def _circuitset_to_dict(circuitset: List[_circuit.Circuit]) -> Mapping:
+    """
+    Returns:
+        A mapping with keys:
+            - "schema"
+            - "circuits" - list of circuits in this circuitset
+    """
+    return {
+        "schema": CIRCUITSET_SCHEMA,
+        "circuits": _map_eager(_circuit_to_dict, circuitset),
     }
 
 
@@ -237,3 +252,11 @@ def _custom_gate_instance_from_dict(dict_, custom_gate_defs) -> _gates.Gate:
     return gate_def(
         *[deserialize_expr(param, symbol_names) for param in dict_["params"]]
     )
+
+
+def circuitset_from_dict(dict_) -> List[_circuit.Circuit]:
+    schema = dict_.get("schema")
+    if schema != CIRCUITSET_SCHEMA:
+        raise ValueError(f"Invalid circuit schema: {schema}")
+
+    return _map_eager(circuit_from_dict, dict_["circuits"])

--- a/src/python/zquantum/core/wip/circuits/_testing.py
+++ b/src/python/zquantum/core/wip/circuits/_testing.py
@@ -1,0 +1,68 @@
+import numpy as np
+import numpy.random
+
+from . import _builtin_gates
+from ._circuit import Circuit
+
+
+def create_random_circuit(
+    n_qubits: int,
+    n_gates: int,
+    rng: np.random.Generator,
+) -> Circuit:
+    """Generates random circuit acting on nqubits with ngates for testing purposes.
+    The resulting circuit it saved to file in JSON format under 'circuit.json'.
+
+    Args:
+        n_qubits: The number of qubits in the circuit
+        n_gates: The number of gates in the circuit
+        rng: Numpy random generator
+
+    Returns:
+        Generated circuit.
+    """
+    # Initialize all gates in set, not including RH or ZXZ
+    singular_zero = [
+        _builtin_gates.X,
+        _builtin_gates.Y,
+        _builtin_gates.Z,
+        _builtin_gates.H,
+        _builtin_gates.S,
+        _builtin_gates.T,
+    ]
+    singular_one = [
+        _builtin_gates.RX,
+        _builtin_gates.RY,
+        _builtin_gates.RZ,
+        _builtin_gates.PHASE,
+    ]
+    two_zero = [
+        _builtin_gates.CNOT,
+        _builtin_gates.CZ,
+        _builtin_gates.SWAP,
+    ]
+    two_one = [
+        _builtin_gates.CPHASE,
+    ]
+
+    all_gate_factories = [singular_zero, two_zero, singular_one, two_one]
+
+    # Loop to add gates to circuit
+    circuit = Circuit()
+    for gate_i in range(n_gates):
+        # Pick gate type
+        gates_list = rng.choice(all_gate_factories)
+        gate = rng.choice(gates_list)
+
+        # Pick qubit to act on (control if two qubit gate)
+
+        if gates_list in {singular_zero, singular_one}:
+            qubits = (rng.choice(range(n_qubits), size=1),)
+        else:
+            qubits = rng.choice(range(n_qubits), size=2, replace=False)
+
+        if gates_list in {singular_one, two_one}:
+            gate = gate(rng.uniform(-np.pi, np.pi, size=1))
+
+        circuit += gate(*qubits)
+    return circuit

--- a/src/python/zquantum/core/wip/circuits/_testing.py
+++ b/src/python/zquantum/core/wip/circuits/_testing.py
@@ -1,8 +1,36 @@
+from typing import Tuple
+
 import numpy as np
 import numpy.random
 
 from . import _builtin_gates
 from ._circuit import Circuit
+
+ONE_QUBIT_NO_PARAMS_GATES = [
+    _builtin_gates.X,
+    _builtin_gates.Y,
+    _builtin_gates.Z,
+    _builtin_gates.H,
+    _builtin_gates.S,
+    _builtin_gates.T,
+]
+
+ONE_QUBIT_ONE_PARAM_GATES = [
+    _builtin_gates.RX,
+    _builtin_gates.RY,
+    _builtin_gates.RZ,
+    _builtin_gates.PHASE,
+]
+
+TWO_QUBITS_NO_PARAMS_GATES = [
+    _builtin_gates.CNOT,
+    _builtin_gates.CZ,
+    _builtin_gates.SWAP,
+]
+
+TWO_QUBITS_ONE_PARAM_GATES = [
+    _builtin_gates.CPHASE,
+]
 
 
 def create_random_circuit(
@@ -22,46 +50,31 @@ def create_random_circuit(
         Generated circuit.
     """
     # Initialize all gates in set, not including RH or ZXZ
-    singular_zero = [
-        _builtin_gates.X,
-        _builtin_gates.Y,
-        _builtin_gates.Z,
-        _builtin_gates.H,
-        _builtin_gates.S,
-        _builtin_gates.T,
-    ]
-    singular_one = [
-        _builtin_gates.RX,
-        _builtin_gates.RY,
-        _builtin_gates.RZ,
-        _builtin_gates.PHASE,
-    ]
-    two_zero = [
-        _builtin_gates.CNOT,
-        _builtin_gates.CZ,
-        _builtin_gates.SWAP,
-    ]
-    two_one = [
-        _builtin_gates.CPHASE,
-    ]
 
-    all_gate_factories = [singular_zero, two_zero, singular_one, two_one]
+    all_gates_lists = [
+        ONE_QUBIT_NO_PARAMS_GATES,
+        TWO_QUBITS_NO_PARAMS_GATES,
+        ONE_QUBIT_ONE_PARAM_GATES,
+        TWO_QUBITS_ONE_PARAM_GATES,
+    ]
 
     # Loop to add gates to circuit
     circuit = Circuit()
     for gate_i in range(n_gates):
         # Pick gate type
-        gates_list = rng.choice(all_gate_factories)
+        gates_list = rng.choice(all_gates_lists)
         gate = rng.choice(gates_list)
 
         # Pick qubit to act on (control if two qubit gate)
-
-        if gates_list in {singular_zero, singular_one}:
-            qubits = (rng.choice(range(n_qubits), size=1),)
+        qubits: Tuple[int, ...]
+        if gates_list in [ONE_QUBIT_NO_PARAMS_GATES, ONE_QUBIT_ONE_PARAM_GATES]:
+            index = rng.choice(range(n_qubits))
+            qubits = (int(index),)
         else:
-            qubits = rng.choice(range(n_qubits), size=2, replace=False)
+            indices = rng.choice(range(n_qubits), size=2, replace=False)
+            qubits = tuple(int(i) for i in indices)
 
-        if gates_list in {singular_one, two_one}:
+        if gates_list in [ONE_QUBIT_ONE_PARAM_GATES, TWO_QUBITS_ONE_PARAM_GATES]:
             gate = gate(rng.uniform(-np.pi, np.pi, size=1))
 
         circuit += gate(*qubits)

--- a/src/python/zquantum/core/wip/circuits/_testing.py
+++ b/src/python/zquantum/core/wip/circuits/_testing.py
@@ -75,7 +75,8 @@ def create_random_circuit(
             qubits = tuple(int(i) for i in indices)
 
         if gates_list in [ONE_QUBIT_ONE_PARAM_GATES, TWO_QUBITS_ONE_PARAM_GATES]:
-            gate = gate(rng.uniform(-np.pi, np.pi, size=1))
+            param = rng.uniform(-np.pi, np.pi, size=1)
+            gate = gate(float(param))
 
         circuit += gate(*qubits)
     return circuit

--- a/steps/circuit.py
+++ b/steps/circuit.py
@@ -142,11 +142,11 @@ def add_ancilla_register_to_circuit(
 # Concatenate circuits in a circuitset to create a composite circuit
 def concatenate_circuits(circuit_set: Union[str, List[Circuit]]):
     if isinstance(circuit_set, str):
-        circuit_set = load_circuit_set(circuit_set)
-    result_circuit = Circuit()
-    for circuit in circuit_set:
-        result_circuit += circuit
-    save_circuit(result_circuit, "result-circuit.json")
+        with open(circuit_set) as f:
+            circuit_set = new_circuits.circuit_from_dict(json.load(f))
+    result_circuit = sum(circuit_set, new_circuits.Circuit())
+    with open("result-circuit.json", "w") as f:
+        json.dump(new_circuits.to_dict(result_circuit), f)
 
 
 # Create one circuitset from circuit and circuitset objects

--- a/steps/circuit.py
+++ b/steps/circuit.py
@@ -6,9 +6,6 @@ import numpy.random
 import zquantum.core.wip.circuits as new_circuits
 from zquantum.core.circuit import Circuit
 from zquantum.core.circuit import (
-    add_ancilla_register_to_circuit as _add_ancilla_register_to_circuit,
-)
-from zquantum.core.circuit import (
     build_circuit_layers_and_connectivity as _build_circuit_layers_and_connectivity,
 )
 from zquantum.core.circuit import build_uniform_param_grid as _build_uniform_param_grid
@@ -24,7 +21,6 @@ from zquantum.core.circuit import (
     save_circuit_template_params,
     save_parameter_grid,
 )
-from zquantum.core.testing import create_random_circuit as _create_random_circuit
 from zquantum.core.typing import Specs
 from zquantum.core.utils import create_symbols_map, load_from_specs
 
@@ -134,11 +130,13 @@ def add_ancilla_register_to_circuit(
     number_of_ancilla_qubits: int, circuit: Union[Circuit, str]
 ):
     if isinstance(circuit, str):
-        circuit = load_circuit(circuit)
-    extended_circuit = _add_ancilla_register_to_circuit(
+        with open(circuit) as f:
+            circuit = new_circuits.circuit_from_dict(json.load(f))
+    extended_circuit = new_circuits.add_ancilla_register(
         circuit, number_of_ancilla_qubits
     )
-    save_circuit(extended_circuit, "extended-circuit.json")
+    with open("extended-circuit.json", "w") as f:
+        json.dump(new_circuits.to_dict(extended_circuit), f)
 
 
 # Concatenate circuits in a circuitset to create a composite circuit

--- a/steps/circuit.py
+++ b/steps/circuit.py
@@ -59,12 +59,13 @@ def build_ansatz_circuit(
     ansatz_specs: Specs, params: Optional[Union[str, List]] = None
 ):
     ansatz = load_from_specs(ansatz_specs)
+    params_array: np.ndarray
     if params is not None:
         if isinstance(params, str):
-            params = load_circuit_template_params(params)
+            params_array = load_circuit_template_params(params)
         else:
-            params = np.array(params)
-        circuit = ansatz.get_executable_circuit(params)
+            params_array = np.array(params)
+        circuit = ansatz.get_executable_circuit(params_array)
     elif ansatz.supports_parametrized_circuits:
         circuit = ansatz.parametrized_circuit
     else:
@@ -154,18 +155,18 @@ def batch_circuits(
     circuits: List[Union[str, Circuit]],
     circuit_set: Optional[Union[str, List[Circuit]]] = None,
 ):
+    loaded_circuit_set: List[Circuit]
     if circuit_set is None:
-        circuit_set = []
-    else:
-        if isinstance(circuit_set, str):
-            circuit_set = load_circuit_set(circuit_set)
+        loaded_circuit_set = []
+    elif isinstance(circuit_set, str):
+        loaded_circuit_set = load_circuit_set(circuit_set)
 
     for circuit in circuits:
         if isinstance(circuit, str):
             circuit = load_circuit(circuit)
-        circuit_set.append(circuit)
+        loaded_circuit_set.append(circuit)
 
-    save_circuit_set(circuit_set, "circuit-set.json")
+    save_circuit_set(loaded_circuit_set, "circuit-set.json")
 
 
 def evaluate_parametrized_circuit(

--- a/steps/circuit.py
+++ b/steps/circuit.py
@@ -144,7 +144,7 @@ def add_ancilla_register_to_circuit(
 def concatenate_circuits(circuit_set: Union[str, List[Circuit]]):
     if isinstance(circuit_set, str):
         with open(circuit_set) as f:
-            circuit_set = new_circuits.circuit_from_dict(json.load(f))
+            circuit_set = new_circuits.circuitset_from_dict(json.load(f))
     result_circuit = sum(circuit_set, new_circuits.Circuit())
     with open("result-circuit.json", "w") as f:
         json.dump(new_circuits.to_dict(result_circuit), f)
@@ -159,14 +159,22 @@ def batch_circuits(
     if circuit_set is None:
         loaded_circuit_set = []
     elif isinstance(circuit_set, str):
-        loaded_circuit_set = load_circuit_set(circuit_set)
+        with open(circuit_set) as f:
+            loaded_circuit_set = new_circuits.circuitset_from_dict(json.load(f))
+    else:
+        loaded_circuit_set = circuit_set
 
     for circuit in circuits:
         if isinstance(circuit, str):
-            circuit = load_circuit(circuit)
-        loaded_circuit_set.append(circuit)
+            with open(circuit) as f:
+                loaded_circuit = new_circuits.circuit_from_dict(json.load(f))
+        else:
+            loaded_circuit = circuit
 
-    save_circuit_set(loaded_circuit_set, "circuit-set.json")
+        loaded_circuit_set.append(loaded_circuit)
+
+    with open("circuit-set.json", "w") as f:
+        json.dump(new_circuits.to_dict(loaded_circuit_set), f)
 
 
 def evaluate_parametrized_circuit(

--- a/steps/circuit.py
+++ b/steps/circuit.py
@@ -1,9 +1,10 @@
+import json
 from typing import List, Optional, Union
 
 import numpy as np
-import json
-from zquantum.core.circuit import Circuit
+import numpy.random
 import zquantum.core.wip.circuits as new_circuits
+from zquantum.core.circuit import Circuit
 from zquantum.core.circuit import (
     add_ancilla_register_to_circuit as _add_ancilla_register_to_circuit,
 )
@@ -25,7 +26,7 @@ from zquantum.core.circuit import (
 )
 from zquantum.core.testing import create_random_circuit as _create_random_circuit
 from zquantum.core.typing import Specs
-from zquantum.core.utils import load_from_specs, create_symbols_map
+from zquantum.core.utils import create_symbols_map, load_from_specs
 
 
 # Generate random parameters for an ansatz
@@ -120,8 +121,12 @@ def build_circuit_layers_and_connectivity(
 def create_random_circuit(
     number_of_qubits: int, number_of_gates: int, seed: Optional[int] = None
 ):
-    circuit = _create_random_circuit(number_of_qubits, number_of_gates, seed=seed)
-    save_circuit(circuit, "circuit.json")
+    rng = np.random.default_rng(seed)
+    circuit = new_circuits.create_random_circuit(
+        number_of_qubits, number_of_gates, rng=rng
+    )
+    with open("circuit.json", "w") as f:
+        json.dump(new_circuits.to_dict(circuit), f)
 
 
 # Add register of ancilla qubits to circuit

--- a/tests/acceptance_tests/circuit_test.py
+++ b/tests/acceptance_tests/circuit_test.py
@@ -643,7 +643,7 @@ class TestAddAncillaRegisterToCircuitPythonObject:
             number_of_gates,
             rng=np.random.default_rng(RNDSEED),
         )
-        expected_extended_cirucit = new_circuits.add_ancilla_register_to_circuit(
+        expected_extended_cirucit = new_circuits.add_ancilla_register(
             copy.deepcopy(circuit), number_of_ancilla_qubits
         )
         expected_extended_circuit_filename = "extended-circuit.json"
@@ -674,7 +674,7 @@ class TestAddAncillaRegisterToCircuitPythonObject:
 
         with open(circuit_filename) as f:
             circuit = new_circuits.circuit_from_dict(json.load(f))
-        expected_extended_circuit = new_circuits.add_ancilla_register_to_circuit(
+        expected_extended_circuit = new_circuits.add_ancilla_register(
             circuit, number_of_ancilla_qubits
         )
 

--- a/tests/acceptance_tests/circuit_test.py
+++ b/tests/acceptance_tests/circuit_test.py
@@ -4,26 +4,18 @@ import os
 
 import numpy as np
 import pytest
-from zquantum.core.circuit import Circuit
-from zquantum.core.circuit import (
-    add_ancilla_register_to_circuit as _add_ancilla_register_to_circuit,
-)
+import zquantum.core.wip.circuits as new_circuits
 from zquantum.core.circuit import (
     build_circuit_layers_and_connectivity as _build_circuit_layers_and_connectivity,
 )
 from zquantum.core.circuit import build_uniform_param_grid as _build_uniform_param_grid
 from zquantum.core.circuit import (
-    load_circuit,
     load_circuit_connectivity,
     load_circuit_layers,
-    load_circuit_set,
     load_circuit_template_params,
     load_parameter_grid,
-    save_circuit,
-    save_circuit_set,
     save_circuit_template_params,
 )
-from zquantum.core.testing import create_random_circuit as _create_random_circuit
 from zquantum.core.utils import RNDSEED, create_object
 
 from steps.circuit import (
@@ -51,9 +43,7 @@ class TestGenerateRandomAnsatzParams:
         "number_of_layers",
         [0, 1, 4, 7],
     )
-    def test_using_mock_ansatz_specs(
-        self, number_of_layers
-    ):
+    def test_using_mock_ansatz_specs(self, number_of_layers):
         # Given
         ansatz_specs = {
             "module_name": "zquantum.core.interfaces.mock_objects",
@@ -242,8 +232,8 @@ class TestBuildAnsatzCircuit:
         # Then
         try:
             circuit_filename = "circuit.json"
-            circuit = load_circuit(circuit_filename)
-            assert isinstance(circuit, Circuit)
+            with open(circuit_filename) as f:
+                circuit = new_circuits.circuit_from_dict(json.load(f))
             assert circuit == expected_circuit
         finally:
             remove_file_if_exists(circuit_filename)
@@ -266,8 +256,8 @@ class TestBuildAnsatzCircuit:
         # Then
         try:
             circuit_filename = "circuit.json"
-            circuit = load_circuit(circuit_filename)
-            assert isinstance(circuit, Circuit)
+            with open(circuit_filename) as f:
+                circuit = new_circuits.circuit_from_dict(json.load(f))
             assert circuit == expected_circuit
         finally:
             remove_file_if_exists(circuit_filename)
@@ -291,8 +281,8 @@ class TestBuildAnsatzCircuit:
         # Then
         try:
             circuit_filename = "circuit.json"
-            circuit = load_circuit(circuit_filename)
-            assert isinstance(circuit, Circuit)
+            with open(circuit_filename) as f:
+                circuit = new_circuits.circuit_from_dict(json.load(f))
             assert circuit == expected_circuit
         finally:
             remove_file_if_exists(circuit_filename)
@@ -594,7 +584,7 @@ class TestCreateRandomCircuit:
     def test_create_random_circuit(self, number_of_qubits, number_of_gates, seed):
         # Given
         expected_filename = "circuit.json"
-        expected_circuit = _create_random_circuit(
+        expected_circuit = new_circuits.create_random_circuit(
             number_of_qubits,
             number_of_gates,
             seed=seed,
@@ -609,11 +599,12 @@ class TestCreateRandomCircuit:
 
         # Then
         try:
-            circuit = load_circuit(expected_filename)
+            with open(expected_filename) as f:
+                circuit = new_circuits.circuit_from_dict(json.load(f))
             if seed is not None:
-                assert circuit.gates == expected_circuit.gates
+                assert circuit.operations == expected_circuit.operations
             else:
-                assert circuit.gates != expected_circuit.gates
+                assert circuit.operations != expected_circuit.operations
         finally:
             remove_file_if_exists(expected_filename)
 
@@ -627,11 +618,12 @@ class TestAddAncillaRegisterToCircuitPythonObject:
     def circuit_filename_and_number_of_ancilla_qubits(self, number_of_ancilla_qubits):
         number_of_qubits = 4
         number_of_gates = 10
-        circuit = _create_random_circuit(
+        circuit = new_circuits.create_random_circuit(
             number_of_qubits, number_of_gates, seed=RNDSEED
         )
         circuit_filename = "circuit.json"
-        save_circuit(circuit, circuit_filename)
+        with open(circuit_filename, "w") as f:
+            json.dump(new_circuits.to_dict(circuit), f)
 
         yield circuit_filename, number_of_ancilla_qubits
 
@@ -643,25 +635,25 @@ class TestAddAncillaRegisterToCircuitPythonObject:
         # Given
         number_of_qubits = 4
         number_of_gates = 10
-        circuit = _create_random_circuit(
+        circuit = new_circuits.create_random_circuit(
             number_of_qubits, number_of_gates, seed=RNDSEED
         )
-        expected_extended_cirucit = _add_ancilla_register_to_circuit(
+        expected_extended_cirucit = new_circuits.add_ancilla_register_to_circuit(
             copy.deepcopy(circuit), number_of_ancilla_qubits
         )
         expected_extended_circuit_filename = "extended-circuit.json"
 
         # When
-        add_ancilla_register_to_circuit(number_of_ancilla_qubits, circuit)
+        circuit = add_ancilla_register_to_circuit(number_of_ancilla_qubits, circuit)
 
         # Then
         try:
-            extended_circuit = load_circuit(expected_extended_circuit_filename)
+            with open(expected_extended_circuit_filename) as f:
+                extended_circuit = new_circuits.circuit_from_dict(json.load(f))
             assert (
-                len(extended_circuit.qubits)
-                == number_of_qubits + number_of_ancilla_qubits
+                extended_circuit.n_qubits == number_of_qubits + number_of_ancilla_qubits
             )
-            assert extended_circuit.gates == expected_extended_cirucit.gates
+            assert extended_circuit == expected_extended_cirucit
         finally:
             remove_file_if_exists(expected_extended_circuit_filename)
 
@@ -675,8 +667,9 @@ class TestAddAncillaRegisterToCircuitPythonObject:
         ) = circuit_filename_and_number_of_ancilla_qubits
         expected_extended_circuit_filename = "extended-circuit.json"
 
-        circuit = load_circuit(circuit_filename)
-        expected_extended_circuit = _add_ancilla_register_to_circuit(
+        with open(circuit_filename) as f:
+            circuit = new_circuits.circuit_from_dict(json.load(f))
+        expected_extended_circuit = new_circuits.add_ancilla_register_to_circuit(
             circuit, number_of_ancilla_qubits
         )
 
@@ -685,12 +678,12 @@ class TestAddAncillaRegisterToCircuitPythonObject:
 
         # Then
         try:
-            extended_circuit = load_circuit(expected_extended_circuit_filename)
+            with open(expected_extended_circuit_filename) as f:
+                extended_circuit = new_circuits.circuit_from_dict(json.load(f))
             assert (
-                len(extended_circuit.qubits)
-                == len(circuit.qubits) + number_of_ancilla_qubits
+                extended_circuit.n_qubits == circuit.n_qubits + number_of_ancilla_qubits
             )
-            assert extended_circuit.gates == expected_extended_circuit.gates
+            assert extended_circuit == expected_extended_circuit
         finally:
             remove_file_if_exists(expected_extended_circuit_filename)
 
@@ -705,7 +698,9 @@ class TestConcatenateCircuits:
         number_of_qubits = 4
         number_of_gates = 10
         circuit_set = [
-            _create_random_circuit(number_of_qubits, number_of_gates, seed=RNDSEED)
+            new_circuits.create_random_circuit(
+                number_of_qubits, number_of_gates, seed=RNDSEED
+            )
             for _ in range(number_of_circuits)
         ]
         return circuit_set
@@ -713,7 +708,8 @@ class TestConcatenateCircuits:
     @pytest.fixture()
     def circuit_set_filename(self, circuit_set):
         circuit_set_filename = "circuit-set.json"
-        save_circuit_set(circuit_set, circuit_set_filename)
+        with open(circuit_set_filename, "w") as f:
+            json.dump(new_circuits.to_dict(circuit_set), f)
 
         yield circuit_set_filename
 
@@ -722,17 +718,18 @@ class TestConcatenateCircuits:
     def test_concatenate_circuits_python_objects(self, circuit_set):
         # Given
         expected_concatenated_circuit_filename = "result-circuit.json"
-        expected_concatenated_circuit = Circuit()
-        for circuit in copy.deepcopy(circuit_set):
-            expected_concatenated_circuit += circuit
+        expected_concatenated_circuit = sum(
+            [circuit for circuit in circuit_set], start=new_circuits.Circuit()
+        )
 
         # When
         concatenate_circuits(circuit_set)
 
         # Then
         try:
-            concatenated_circuit = load_circuit(expected_concatenated_circuit_filename)
-            assert concatenated_circuit.gates == expected_concatenated_circuit.gates
+            with open(expected_concatenated_circuit_filename) as f:
+                concatenated_circuit = new_circuits.circuit_from_dict(json.load(f))
+            assert concatenated_circuit == expected_concatenated_circuit
         finally:
             remove_file_if_exists(expected_concatenated_circuit_filename)
 
@@ -740,17 +737,18 @@ class TestConcatenateCircuits:
         # Given
         expected_concatenated_circuit_filename = "result-circuit.json"
 
-        circuit_set = load_circuit_set(circuit_set_filename)
-        expected_concatenated_circuit = Circuit()
-        for circuit in copy.deepcopy(circuit_set):
-            expected_concatenated_circuit += circuit
-
+        with open(expected_concatenated_circuit_filename) as f:
+            circuit_set = new_circuits.circuit_seq_from_dict(json.load(f))
+        expected_concatenated_circuit = sum(
+            [circuit for circuit in circuit_set], start=new_circuits.Circuit()
+        )
         # When
         concatenate_circuits(circuit_set_filename)
 
         # Then
         try:
-            concatenated_circuit = load_circuit(expected_concatenated_circuit_filename)
+            with open(expected_concatenated_circuit_filename) as f:
+                concatenated_circuit = new_circuits.circuit_from_dict(json.load(f))
             assert concatenated_circuit.gates == expected_concatenated_circuit.gates
         finally:
             remove_file_if_exists(expected_concatenated_circuit_filename)
@@ -762,16 +760,18 @@ class TestBatchCircuits:
         number_of_qubits = 4
         number_of_gates = 10
         return [
-            _create_random_circuit(number_of_qubits, number_of_gates, seed=RNDSEED + i)
+            new_circuits.create_random_circuit(
+                number_of_qubits, number_of_gates, seed=RNDSEED + i
+            )
             for i in range(request.param)
         ]
 
     @pytest.fixture()
     def input_circuits_filenames(self, input_circuits):
-        circuit_filenames = []
-        for i, circuit in enumerate(input_circuits):
-            circuit_filenames.append("circuit-{}.json".format(i))
-            save_circuit(circuit, circuit_filenames[i])
+        circuit_filenames = [f"circuit-{i}.json" for i in range(len(input_circuits))]
+        for circuit, filename in zip(input_circuits, circuit_filenames):
+            with open(filename, "w") as f:
+                json.dump(new_circuits.to_dict(circuit), f)
 
         yield circuit_filenames
 
@@ -783,7 +783,7 @@ class TestBatchCircuits:
         number_of_qubits = 4
         number_of_gates = 10
         return [
-            _create_random_circuit(
+            new_circuits.create_random_circuit(
                 number_of_qubits, number_of_gates, seed=RNDSEED + 100 + i
             )
             for i in range(request.param)
@@ -791,48 +791,57 @@ class TestBatchCircuits:
 
     @pytest.fixture()
     def input_circuit_set_filename(self, input_circuit_set):
-        circuit_set_filename = "input-circuit-set.json"
-        save_circuit_set(input_circuit_set, circuit_set_filename)
+        filename = "input-circuit-set.json"
+        with open(filename, "w") as f:
+            json.dump(new_circuits.to_dict(input_circuit_set), f)
 
-        yield circuit_set_filename
+        yield filename
 
-        remove_file_if_exists(circuit_set_filename)
+        remove_file_if_exists(filename)
 
     def test_batch_circuits_all_artifacts_no_circuit_set(
         self, input_circuits_filenames
     ):
         # Given
-        expected_circuit_set_filename = "circuit-set.json"
-        expected_circuit_set = []
+        expected_circuit_seq_filename = "circuit-set.json"
+        expected_circuit_seq = []
         for circuit_filename in input_circuits_filenames:
-            expected_circuit_set.append(load_circuit(circuit_filename))
+            with open(circuit_filename) as f:
+                circuit = new_circuits.circuit_from_dict(json.load(f))
+            expected_circuit_seq.append(circuit)
 
         # When
         batch_circuits(input_circuits_filenames)
 
         # Then
         try:
-            circuit_set = load_circuit_set(expected_circuit_set_filename)
-            assert circuit_set == expected_circuit_set
+            with open(expected_circuit_seq_filename) as f:
+                circuit_seq = new_circuits.circuit_seq_from_dict(json.load(f))
+            assert circuit_seq == expected_circuit_seq
         finally:
-            remove_file_if_exists(expected_circuit_set_filename)
+            remove_file_if_exists(expected_circuit_seq_filename)
 
     def test_batch_circuits_all_artifacts_circuit_set_is_artifact(
         self, input_circuits_filenames, input_circuit_set_filename
     ):
         # Given
         expected_circuit_set_filename = "circuit-set.json"
-        expected_circuit_set = load_circuit_set(input_circuit_set_filename)
+        with open(input_circuit_set_filename) as f:
+            expected_circuit_seq = new_circuits.circuit_seq_from_dict(json.load(f))
         for circuit_filename in input_circuits_filenames:
-            expected_circuit_set.append(load_circuit(circuit_filename))
+            with open(circuit_filename) as f:
+                expected_circuit_seq.append(
+                    new_circuits.circuit_from_dict(json.load(f))
+                )
 
         # When
         batch_circuits(input_circuits_filenames, circuit_set=input_circuit_set_filename)
 
         # Then
         try:
-            circuit_set = load_circuit_set(expected_circuit_set_filename)
-            assert circuit_set == expected_circuit_set
+            with open(expected_circuit_set_filename) as f:
+                circuit_seq = new_circuits.circuit_seq_from_dict(json.load(f))
+            assert circuit_seq == expected_circuit_seq
         finally:
             remove_file_if_exists(expected_circuit_set_filename)
 
@@ -841,9 +850,11 @@ class TestBatchCircuits:
     ):
         # Given
         expected_circuit_set_filename = "circuit-set.json"
-        expected_circuit_set = copy.deepcopy(input_circuit_set)
+        expected_circuit_seq = copy.deepcopy(input_circuit_set)
         for circuit_filename in input_circuits_filenames:
-            expected_circuit_set.append(load_circuit(circuit_filename))
+            with open(circuit_filename) as f:
+                circuit = new_circuits.circuit_from_dict(json.load(f))
+            expected_circuit_seq.append(circuit)
 
         # When
         batch_circuits(
@@ -852,23 +863,25 @@ class TestBatchCircuits:
 
         # Then
         try:
-            circuit_set = load_circuit_set(expected_circuit_set_filename)
-            assert circuit_set == expected_circuit_set
+            with open(expected_circuit_set_filename) as f:
+                circuit_seq = new_circuits.circuit_seq_from_dict(json.load(f))
+            assert circuit_seq == expected_circuit_seq
         finally:
             remove_file_if_exists(expected_circuit_set_filename)
 
     def test_batch_circuits_all_objects_no_circuit_set(self, input_circuits):
         # Given
         expected_circuit_set_filename = "circuit-set.json"
-        expected_circuit_set = copy.deepcopy(input_circuits)
+        expected_circuit_seq = copy.deepcopy(input_circuits)
 
         # When
         batch_circuits(input_circuits)
 
         # Then
         try:
-            circuit_set = load_circuit_set(expected_circuit_set_filename)
-            assert circuit_set == expected_circuit_set
+            with open(expected_circuit_set_filename) as f:
+                circuit_seq = new_circuits.circuit_seq_from_dict(json.load(f))
+            assert circuit_seq == expected_circuit_seq
         finally:
             remove_file_if_exists(expected_circuit_set_filename)
 
@@ -877,17 +890,19 @@ class TestBatchCircuits:
     ):
         # Given
         expected_circuit_set_filename = "circuit-set.json"
-        expected_circuit_set = load_circuit_set(input_circuit_set_filename)
+        with open(input_circuit_set_filename) as f:
+            expected_circuit_seq = new_circuits.circuit_seq_from_dict(json.load(f))
         for circuit in input_circuits:
-            expected_circuit_set.append(copy.deepcopy(circuit))
+            expected_circuit_seq.append(copy.deepcopy(circuit))
 
         # When
         batch_circuits(input_circuits, circuit_set=input_circuit_set_filename)
 
         # Then
         try:
-            circuit_set = load_circuit_set(expected_circuit_set_filename)
-            assert circuit_set == expected_circuit_set
+            with open(expected_circuit_set_filename) as f:
+                circuit_seq = new_circuits.circuit_seq_from_dict(json.load(f))
+            assert circuit_seq == expected_circuit_seq
         finally:
             remove_file_if_exists(expected_circuit_set_filename)
 
@@ -896,16 +911,17 @@ class TestBatchCircuits:
     ):
         # Given
         expected_circuit_set_filename = "circuit-set.json"
-        expected_circuit_set = copy.deepcopy(input_circuit_set)
+        expected_circuit_seq = copy.deepcopy(input_circuit_set)
         for circuit in input_circuits:
-            expected_circuit_set.append(copy.deepcopy(circuit))
+            expected_circuit_seq.append(copy.deepcopy(circuit))
 
         # When
         batch_circuits(input_circuits, circuit_set=copy.deepcopy(input_circuit_set))
 
         # Then
         try:
-            circuit_set = load_circuit_set(expected_circuit_set_filename)
-            assert circuit_set == expected_circuit_set
+            with open(expected_circuit_set_filename) as f:
+                circuit_seq = new_circuits.circuit_seq_from_dict(json.load(f))
+            assert circuit_seq == expected_circuit_seq
         finally:
             remove_file_if_exists(expected_circuit_set_filename)

--- a/tests/acceptance_tests/circuit_test.py
+++ b/tests/acceptance_tests/circuit_test.py
@@ -724,7 +724,7 @@ class TestConcatenateCircuits:
         # Given
         expected_concatenated_circuit_filename = "result-circuit.json"
         expected_concatenated_circuit = sum(
-            [circuit for circuit in circuit_set], start=new_circuits.Circuit()
+            [circuit for circuit in circuit_set], new_circuits.Circuit()
         )
 
         # When

--- a/tests/acceptance_tests/circuit_test.py
+++ b/tests/acceptance_tests/circuit_test.py
@@ -704,7 +704,7 @@ class TestConcatenateCircuits:
         number_of_gates = 10
         circuit_set = [
             new_circuits.create_random_circuit(
-                number_of_qubits, number_of_gates, seed=RNDSEED
+                number_of_qubits, number_of_gates, rng=np.random.default_rng(RNDSEED)
             )
             for _ in range(number_of_circuits)
         ]
@@ -764,11 +764,12 @@ class TestBatchCircuits:
     def input_circuits(self, request):
         number_of_qubits = 4
         number_of_gates = 10
+        rng = np.random.default_rng(RNDSEED)
         return [
             new_circuits.create_random_circuit(
-                number_of_qubits, number_of_gates, seed=RNDSEED + i
+                number_of_qubits, number_of_gates, rng=rng
             )
-            for i in range(request.param)
+            for _ in range(request.param)
         ]
 
     @pytest.fixture()
@@ -787,11 +788,12 @@ class TestBatchCircuits:
     def input_circuit_set(self, request):
         number_of_qubits = 4
         number_of_gates = 10
+        rng = np.random.default_rng(RNDSEED + 100)
         return [
             new_circuits.create_random_circuit(
-                number_of_qubits, number_of_gates, seed=RNDSEED + 100 + i
+                number_of_qubits, number_of_gates, rng=rng
             )
-            for i in range(request.param)
+            for _ in range(request.param)
         ]
 
     @pytest.fixture()

--- a/tests/acceptance_tests/circuit_test.py
+++ b/tests/acceptance_tests/circuit_test.py
@@ -742,10 +742,10 @@ class TestConcatenateCircuits:
         # Given
         expected_concatenated_circuit_filename = "result-circuit.json"
 
-        with open(expected_concatenated_circuit_filename) as f:
-            circuit_set = new_circuits.circuit_seq_from_dict(json.load(f))
+        with open(circuit_set_filename) as f:
+            circuit_set = new_circuits.circuitset_from_dict(json.load(f))
         expected_concatenated_circuit = sum(
-            [circuit for circuit in circuit_set], start=new_circuits.Circuit()
+            [circuit for circuit in circuit_set], new_circuits.Circuit()
         )
         # When
         concatenate_circuits(circuit_set_filename)
@@ -754,7 +754,7 @@ class TestConcatenateCircuits:
         try:
             with open(expected_concatenated_circuit_filename) as f:
                 concatenated_circuit = new_circuits.circuit_from_dict(json.load(f))
-            assert concatenated_circuit.gates == expected_concatenated_circuit.gates
+            assert concatenated_circuit == expected_concatenated_circuit
         finally:
             remove_file_if_exists(expected_concatenated_circuit_filename)
 
@@ -810,23 +810,23 @@ class TestBatchCircuits:
         self, input_circuits_filenames
     ):
         # Given
-        expected_circuit_seq_filename = "circuit-set.json"
-        expected_circuit_seq = []
+        expected_circuitset_filename = "circuit-set.json"
+        expected_circuitset = []
         for circuit_filename in input_circuits_filenames:
             with open(circuit_filename) as f:
                 circuit = new_circuits.circuit_from_dict(json.load(f))
-            expected_circuit_seq.append(circuit)
+            expected_circuitset.append(circuit)
 
         # When
         batch_circuits(input_circuits_filenames)
 
         # Then
         try:
-            with open(expected_circuit_seq_filename) as f:
-                circuit_seq = new_circuits.circuit_seq_from_dict(json.load(f))
-            assert circuit_seq == expected_circuit_seq
+            with open(expected_circuitset_filename) as f:
+                circuitset = new_circuits.circuitset_from_dict(json.load(f))
+            assert circuitset == expected_circuitset
         finally:
-            remove_file_if_exists(expected_circuit_seq_filename)
+            remove_file_if_exists(expected_circuitset_filename)
 
     def test_batch_circuits_all_artifacts_circuit_set_is_artifact(
         self, input_circuits_filenames, input_circuit_set_filename
@@ -834,12 +834,10 @@ class TestBatchCircuits:
         # Given
         expected_circuit_set_filename = "circuit-set.json"
         with open(input_circuit_set_filename) as f:
-            expected_circuit_seq = new_circuits.circuit_seq_from_dict(json.load(f))
+            expected_circuitset = new_circuits.circuitset_from_dict(json.load(f))
         for circuit_filename in input_circuits_filenames:
             with open(circuit_filename) as f:
-                expected_circuit_seq.append(
-                    new_circuits.circuit_from_dict(json.load(f))
-                )
+                expected_circuitset.append(new_circuits.circuit_from_dict(json.load(f)))
 
         # When
         batch_circuits(input_circuits_filenames, circuit_set=input_circuit_set_filename)
@@ -847,8 +845,8 @@ class TestBatchCircuits:
         # Then
         try:
             with open(expected_circuit_set_filename) as f:
-                circuit_seq = new_circuits.circuit_seq_from_dict(json.load(f))
-            assert circuit_seq == expected_circuit_seq
+                circuitset = new_circuits.circuitset_from_dict(json.load(f))
+            assert circuitset == expected_circuitset
         finally:
             remove_file_if_exists(expected_circuit_set_filename)
 
@@ -857,11 +855,11 @@ class TestBatchCircuits:
     ):
         # Given
         expected_circuit_set_filename = "circuit-set.json"
-        expected_circuit_seq = copy.deepcopy(input_circuit_set)
+        expected_circuitset = copy.deepcopy(input_circuit_set)
         for circuit_filename in input_circuits_filenames:
             with open(circuit_filename) as f:
                 circuit = new_circuits.circuit_from_dict(json.load(f))
-            expected_circuit_seq.append(circuit)
+            expected_circuitset.append(circuit)
 
         # When
         batch_circuits(
@@ -871,15 +869,15 @@ class TestBatchCircuits:
         # Then
         try:
             with open(expected_circuit_set_filename) as f:
-                circuit_seq = new_circuits.circuit_seq_from_dict(json.load(f))
-            assert circuit_seq == expected_circuit_seq
+                circuitset = new_circuits.circuitset_from_dict(json.load(f))
+            assert circuitset == expected_circuitset
         finally:
             remove_file_if_exists(expected_circuit_set_filename)
 
     def test_batch_circuits_all_objects_no_circuit_set(self, input_circuits):
         # Given
         expected_circuit_set_filename = "circuit-set.json"
-        expected_circuit_seq = copy.deepcopy(input_circuits)
+        expected_circuitset = copy.deepcopy(input_circuits)
 
         # When
         batch_circuits(input_circuits)
@@ -887,8 +885,8 @@ class TestBatchCircuits:
         # Then
         try:
             with open(expected_circuit_set_filename) as f:
-                circuit_seq = new_circuits.circuit_seq_from_dict(json.load(f))
-            assert circuit_seq == expected_circuit_seq
+                circuitset = new_circuits.circuitset_from_dict(json.load(f))
+            assert circuitset == expected_circuitset
         finally:
             remove_file_if_exists(expected_circuit_set_filename)
 
@@ -898,9 +896,9 @@ class TestBatchCircuits:
         # Given
         expected_circuit_set_filename = "circuit-set.json"
         with open(input_circuit_set_filename) as f:
-            expected_circuit_seq = new_circuits.circuit_seq_from_dict(json.load(f))
+            expected_circuitset = new_circuits.circuitset_from_dict(json.load(f))
         for circuit in input_circuits:
-            expected_circuit_seq.append(copy.deepcopy(circuit))
+            expected_circuitset.append(copy.deepcopy(circuit))
 
         # When
         batch_circuits(input_circuits, circuit_set=input_circuit_set_filename)
@@ -908,8 +906,8 @@ class TestBatchCircuits:
         # Then
         try:
             with open(expected_circuit_set_filename) as f:
-                circuit_seq = new_circuits.circuit_seq_from_dict(json.load(f))
-            assert circuit_seq == expected_circuit_seq
+                circuitset = new_circuits.circuitset_from_dict(json.load(f))
+            assert circuitset == expected_circuitset
         finally:
             remove_file_if_exists(expected_circuit_set_filename)
 
@@ -918,9 +916,9 @@ class TestBatchCircuits:
     ):
         # Given
         expected_circuit_set_filename = "circuit-set.json"
-        expected_circuit_seq = copy.deepcopy(input_circuit_set)
+        expected_circuitset = copy.deepcopy(input_circuit_set)
         for circuit in input_circuits:
-            expected_circuit_seq.append(copy.deepcopy(circuit))
+            expected_circuitset.append(copy.deepcopy(circuit))
 
         # When
         batch_circuits(input_circuits, circuit_set=copy.deepcopy(input_circuit_set))
@@ -928,7 +926,7 @@ class TestBatchCircuits:
         # Then
         try:
             with open(expected_circuit_set_filename) as f:
-                circuit_seq = new_circuits.circuit_seq_from_dict(json.load(f))
-            assert circuit_seq == expected_circuit_seq
+                circuitset = new_circuits.circuitset_from_dict(json.load(f))
+            assert circuitset == expected_circuitset
         finally:
             remove_file_if_exists(expected_circuit_set_filename)

--- a/tests/acceptance_tests/circuit_test.py
+++ b/tests/acceptance_tests/circuit_test.py
@@ -3,6 +3,7 @@ import json
 import os
 
 import numpy as np
+import numpy.random
 import pytest
 import zquantum.core.wip.circuits as new_circuits
 from zquantum.core.circuit import (
@@ -587,7 +588,7 @@ class TestCreateRandomCircuit:
         expected_circuit = new_circuits.create_random_circuit(
             number_of_qubits,
             number_of_gates,
-            seed=seed,
+            rng=np.random.default_rng(seed),
         )
 
         # When
@@ -619,7 +620,9 @@ class TestAddAncillaRegisterToCircuitPythonObject:
         number_of_qubits = 4
         number_of_gates = 10
         circuit = new_circuits.create_random_circuit(
-            number_of_qubits, number_of_gates, seed=RNDSEED
+            number_of_qubits,
+            number_of_gates,
+            rng=np.random.default_rng(RNDSEED),
         )
         circuit_filename = "circuit.json"
         with open(circuit_filename, "w") as f:
@@ -636,7 +639,9 @@ class TestAddAncillaRegisterToCircuitPythonObject:
         number_of_qubits = 4
         number_of_gates = 10
         circuit = new_circuits.create_random_circuit(
-            number_of_qubits, number_of_gates, seed=RNDSEED
+            number_of_qubits,
+            number_of_gates,
+            rng=np.random.default_rng(RNDSEED),
         )
         expected_extended_cirucit = new_circuits.add_ancilla_register_to_circuit(
             copy.deepcopy(circuit), number_of_ancilla_qubits


### PR DESCRIPTION
Migrated functions in `steps/circuit` to use new circuits. This required adding some missing pieces:
- (de)serialization for circuitsets. We thought about using this opportunity to change the name,as some people dislike using `set` to name lists, but decided to keep `circuitset`. Changing this would require to break backwards compatibility in step functions.
- random circuit generator added to `_generators`

(paired with @dexter2206)