### PR TITLE
Single source of "if-else" for path management

### DIFF
--- a/src/python/zquantum/core/serialization.py
+++ b/src/python/zquantum/core/serialization.py
@@ -1,8 +1,10 @@
 """Serialization module."""
 import json
+import os
+from contextlib import contextmanager
 from numbers import Number
 from operator import attrgetter
-from typing import Any, Callable, Dict, Iterator
+from typing import Any, Callable, Dict, Iterator, Union
 
 import numpy as np
 from scipy.optimize import OptimizeResult
@@ -10,7 +12,7 @@ from scipy.optimize import OptimizeResult
 from .bitstring_distribution import BitstringDistribution, is_bitstring_distribution
 from .history.recorder import HistoryEntry, HistoryEntryWithArtifacts
 from .interfaces.optimizer import optimization_result
-from .typing import AnyPath, LoadSource
+from .typing import AnyPath, DumpTarget, LoadSource
 from .utils import (
     SCHEMA_VERSION,
     ValueEstimate,
@@ -107,6 +109,19 @@ def load_optimization_results(filename: AnyPath):
         return json.load(source_file, cls=OrquestraDecoder)
 
 
+@contextmanager
+def ensure_open(path_like: Union[LoadSource, DumpTarget], mode="r"):
+    # str | bytes | PathLike | Readable
+    if isinstance(path_like, (str, bytes, os.PathLike)):
+        with open(path_like, mode) as f:
+            yield f
+    else:
+        # Readable | Writable
+        if set(mode).intersection(set("wxa+")) and not path_like.writable():
+            raise ValueError(f"File isn't writable, can't ensure mode {mode}")
+        yield path_like
+
+
 def save_array(array: np.ndarray, filename: AnyPath) -> None:
     """Saves array to a file.
 
@@ -117,7 +132,7 @@ def save_array(array: np.ndarray, filename: AnyPath) -> None:
 
     dictionary: Dict[str, Any] = {"schema": SCHEMA_VERSION + "-array"}
     dictionary["array"] = convert_array_to_dict(array)
-    with open(filename, "w") as f:
+    with ensure_open(filename, "w") as f:
         f.write(json.dumps(dictionary))
 
 
@@ -131,10 +146,7 @@ def load_array(file: LoadSource):
         dict: the circuit template
     """
 
-    if isinstance(file, str):
-        with open(file, "r") as f:
-            data = json.load(f)
-    else:
-        data = json.load(file)
+    with ensure_open(file, "r") as f:
+        data = json.load(f)
 
     return convert_dict_to_array(data["array"])

--- a/src/python/zquantum/core/typing.py
+++ b/src/python/zquantum/core/typing.py
@@ -9,9 +9,15 @@ class Readable(Protocol):
     def read(self) -> str:
         pass
 
+    def writable(self) -> bool:
+        pass
+
 
 class Writeable(Protocol):
     def write(self, content: str):
+        pass
+
+    def writable(self) -> bool:
         pass
 
 

--- a/src/python/zquantum/core/wip/circuits/_serde.py
+++ b/src/python/zquantum/core/wip/circuits/_serde.py
@@ -274,4 +274,8 @@ def ensure_open(path_like: Union[LoadSource, DumpTarget], mode="r"):
             yield f
     else:
         # Readable | Writable
+        if set(mode).intersection(set("wxa+")):
+            if not path_like.writable():
+                raise ValueError(f"File isn't writable, can't ensure mode {mode}")
+
         yield path_like

--- a/src/python/zquantum/core/wip/circuits/_serde.py
+++ b/src/python/zquantum/core/wip/circuits/_serde.py
@@ -1,7 +1,11 @@
+import json
+import os
+from contextlib import contextmanager
 from functools import singledispatch
-from typing import Iterable, List, Mapping
+from typing import Iterable, List, Mapping, Union
 
 import sympy
+from zquantum.core.typing import DumpTarget, LoadSource
 
 from ...utils import SCHEMA_VERSION
 from . import _builtin_gates, _circuit, _gates
@@ -260,3 +264,14 @@ def circuitset_from_dict(dict_) -> List[_circuit.Circuit]:
         raise ValueError(f"Invalid circuit schema: {schema}")
 
     return _map_eager(circuit_from_dict, dict_["circuits"])
+
+
+@contextmanager
+def ensure_open(path_like: Union[LoadSource, DumpTarget], mode="r"):
+    # str | bytes | PathLike | Readable
+    if isinstance(path_like, (str, bytes, os.PathLike)):
+        with open(path_like, mode) as f:
+            yield f
+    else:
+        # Readable | Writable
+        yield path_like

--- a/src/python/zquantum/core/wip/circuits/_serde.py
+++ b/src/python/zquantum/core/wip/circuits/_serde.py
@@ -264,18 +264,3 @@ def circuitset_from_dict(dict_) -> List[_circuit.Circuit]:
         raise ValueError(f"Invalid circuit schema: {schema}")
 
     return _map_eager(circuit_from_dict, dict_["circuits"])
-
-
-@contextmanager
-def ensure_open(path_like: Union[LoadSource, DumpTarget], mode="r"):
-    # str | bytes | PathLike | Readable
-    if isinstance(path_like, (str, bytes, os.PathLike)):
-        with open(path_like, mode) as f:
-            yield f
-    else:
-        # Readable | Writable
-        if set(mode).intersection(set("wxa+")):
-            if not path_like.writable():
-                raise ValueError(f"File isn't writable, can't ensure mode {mode}")
-
-        yield path_like

--- a/tests/zquantum/core/serialization_test.py
+++ b/tests/zquantum/core/serialization_test.py
@@ -1,6 +1,9 @@
 """Test cases for serialization module."""
+import io
 import json
 import os
+import pathlib
+import tempfile
 
 import numpy as np
 import pytest
@@ -11,6 +14,7 @@ from zquantum.core.interfaces.optimizer import optimization_result
 from zquantum.core.serialization import (
     OrquestraDecoder,
     OrquestraEncoder,
+    ensure_open,
     load_optimization_results,
     save_optimization_results,
 )
@@ -250,3 +254,102 @@ def test_load_optimization_results_successfully_loads_optimization_result_from_f
     assert optimization_results_equal(result_to_serialize, loaded_data)
 
     os.remove(optimization_result_filename)
+
+
+@pytest.fixture
+def tmp_path():
+    with tempfile.NamedTemporaryFile() as tmp_file:
+        yield tmp_file.name
+
+
+@pytest.mark.parametrize(
+    "example_contents",
+    [
+        json.dumps({"hello": "world"}),
+        "",
+        "Zażółć gęślą jaźń",
+    ],
+)
+class TestEnsureOpen:
+    @pytest.mark.parametrize(
+        "path_mapper",
+        [
+            str,
+            lambda path: path.encode(),
+            pathlib.Path,
+        ],
+    )
+    def test_reading_from_path(self, tmp_path: str, path_mapper, example_contents):
+        with open(tmp_path, "w") as f:
+            f.write(example_contents)
+
+        path = path_mapper(tmp_path)
+        with ensure_open(path) as f:
+            read_contents = f.read()
+
+        assert read_contents == example_contents
+
+    def test_reading_from_open_file(self, tmp_path: str, example_contents):
+        with open(tmp_path, "w") as f:
+            f.write(example_contents)
+
+        with open(tmp_path) as open_file:
+            with ensure_open(open_file) as f:
+                read_contents = f.read()
+
+        assert read_contents == example_contents
+
+    def test_reading_from_io(self, example_contents):
+        buffer = io.StringIO()
+        buffer.write(example_contents)
+        buffer.seek(0)
+
+        with ensure_open(buffer) as f:
+            read_contents = f.read()
+
+        assert read_contents == example_contents
+
+    @pytest.mark.parametrize(
+        "path_mapper",
+        [
+            str,
+            lambda path: path.encode(),
+            pathlib.Path,
+        ],
+    )
+    def test_writing_to_path(self, tmp_path: str, path_mapper, example_contents):
+        path = path_mapper(tmp_path)
+        with ensure_open(path, "w") as f:
+            f.write(example_contents)
+
+        with open(tmp_path) as f:
+            read_contents = f.read()
+
+        assert read_contents == example_contents
+
+    def test_writing_to_open_file(self, tmp_path: str, example_contents):
+        with open(tmp_path, "w") as open_file:
+            with ensure_open(open_file, "w") as f:
+                f.write(example_contents)
+
+        with open(tmp_path) as f:
+            read_contents = f.read()
+
+        assert read_contents == example_contents
+
+    def test_writing_to_io(self, example_contents):
+        buffer = io.StringIO()
+        with ensure_open(buffer) as f:
+            f.write(example_contents)
+
+        buffer.seek(0)
+        read_contents = buffer.read()
+
+        assert read_contents == example_contents
+
+
+def test_ensure_open_with_write_flag_and_read_only_file_raises_error(tmp_path: str):
+    with open(tmp_path) as open_file:
+        with pytest.raises(ValueError):
+            with ensure_open(open_file, "w"):
+                pass

--- a/tests/zquantum/core/wip/circuits/_serde_test.py
+++ b/tests/zquantum/core/wip/circuits/_serde_test.py
@@ -264,3 +264,41 @@ class TestEnsureOpen:
             read_contents = f.read()
 
         assert read_contents == example_contents
+
+    @pytest.mark.parametrize(
+        "path_mapper",
+        [
+            str,
+            lambda path: path.encode(),
+            pathlib.Path,
+        ],
+    )
+    def test_writing_to_path(self, tmp_path: str, path_mapper, example_contents):
+        path = path_mapper(tmp_path)
+        with ensure_open(path, "w") as f:
+            f.write(example_contents)
+
+        with open(tmp_path) as f:
+            read_contents = f.read()
+
+        assert read_contents == example_contents
+
+    def test_writing_to_open_file(self, tmp_path: str, example_contents):
+        with open(tmp_path, "w") as open_file:
+            with ensure_open(open_file, "w") as f:
+                f.write(example_contents)
+
+        with open(tmp_path) as f:
+            read_contents = f.read()
+
+        assert read_contents == example_contents
+
+    def test_writing_to_io(self, example_contents):
+        buffer = io.StringIO()
+        with ensure_open(buffer) as f:
+            f.write(example_contents)
+
+        buffer.seek(0)
+        read_contents = buffer.read()
+
+        assert read_contents == example_contents

--- a/tests/zquantum/core/wip/circuits/_serde_test.py
+++ b/tests/zquantum/core/wip/circuits/_serde_test.py
@@ -213,6 +213,12 @@ class TestExpressionSerialization:
         assert deserialized - expr == 0
 
 
+@pytest.fixture
+def tmp_path():
+    with tempfile.NamedTemporaryFile() as tmp_file:
+        yield tmp_file.name
+
+
 @pytest.mark.parametrize(
     "example_contents",
     [
@@ -222,11 +228,6 @@ class TestExpressionSerialization:
     ],
 )
 class TestEnsureOpen:
-    @pytest.yield_fixture
-    def tmp_path(self):
-        with tempfile.NamedTemporaryFile() as tmp_file:
-            yield tmp_file.name
-
     @pytest.mark.parametrize(
         "path_mapper",
         [
@@ -302,3 +303,10 @@ class TestEnsureOpen:
         read_contents = buffer.read()
 
         assert read_contents == example_contents
+
+
+def test_ensure_open_with_write_flag_and_read_only_file_raises_error(tmp_path: str):
+    with open(tmp_path) as open_file:
+        with pytest.raises(ValueError):
+            with ensure_open(open_file, "w"):
+                pass


### PR DESCRIPTION
We need to read/write new circuits from/to files. There's a lot of copy+paste involved until we add similar helpers like we had for old circuits. This helper abstracts away the if-else for `str`, `pathlib`, etc.