### PR TITLE
Remove references to old circuits from circuit & optimize steps

### DIFF
--- a/src/python/zquantum/core/circuit/_circuit_template.py
+++ b/src/python/zquantum/core/circuit/_circuit_template.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, TextIO, Tuple
 import numpy as np
 
 from ..circuit import Circuit, Gate, Qubit
+from ..interfaces.ansatz_utils import combine_ansatz_params
 from ..utils import SCHEMA_VERSION, convert_array_to_dict, convert_dict_to_array
 
 
@@ -103,19 +104,6 @@ def build_ansatz_circuit(ansatz: dict, params: np.ndarray) -> Circuit:
     qprog = func(params, **ansatz["ansatz_kwargs"])
 
     return qprog
-
-
-def combine_ansatz_params(params1: np.ndarray, params2: np.ndarray) -> np.ndarray:
-    """Combine two sets of ansatz parameters.
-
-    Args:
-        params1 (numpy.ndarray): the first set of parameters
-        params2 (numpy.ndarray): the second set of parameters
-
-    Returns:
-        numpy.ndarray: the combined parameters
-    """
-    return np.concatenate((params1, params2))
 
 
 class ParameterGrid:

--- a/src/python/zquantum/core/interfaces/ansatz_utils.py
+++ b/src/python/zquantum/core/interfaces/ansatz_utils.py
@@ -1,5 +1,7 @@
 from functools import wraps
 
+import numpy as np
+
 
 class _InvalidatingSetter(object):
     """Setter descriptor that sets target object's _parametrized_circuit to None.
@@ -67,3 +69,16 @@ class DynamicProperty:
 
 def ansatz_property(name: str, default_value=None):
     return _InvalidatingSetter(DynamicProperty(name, default_value))
+
+
+def combine_ansatz_params(params1: np.ndarray, params2: np.ndarray) -> np.ndarray:
+    """Combine two sets of ansatz parameters.
+
+    Args:
+        params1 (numpy.ndarray): the first set of parameters
+        params2 (numpy.ndarray): the second set of parameters
+
+    Returns:
+        numpy.ndarray: the combined parameters
+    """
+    return np.concatenate((params1, params2))

--- a/src/python/zquantum/core/serialization.py
+++ b/src/python/zquantum/core/serialization.py
@@ -122,6 +122,9 @@ def ensure_open(path_like: Union[LoadSource, DumpTarget], mode="r"):
         yield path_like
 
 
+ARRAY_SCHEMA = SCHEMA_VERSION + "-array"
+
+
 def save_array(array: np.ndarray, path_like: DumpTarget) -> None:
     """Saves array to a file.
 
@@ -130,7 +133,7 @@ def save_array(array: np.ndarray, path_like: DumpTarget) -> None:
         filename: the name of the file
     """
 
-    dictionary: Dict[str, Any] = {"schema": SCHEMA_VERSION + "-array"}
+    dictionary: Dict[str, Any] = {"schema": ARRAY_SCHEMA}
     dictionary["array"] = convert_array_to_dict(array)
     with ensure_open(path_like, "w") as f:
         f.write(json.dumps(dictionary))

--- a/steps/circuit.py
+++ b/steps/circuit.py
@@ -6,7 +6,7 @@ import numpy.random
 import zquantum.core.wip.circuits as new_circuits
 import zquantum.core.wip.circuits.layouts as layouts
 from zquantum.core import serialization
-from zquantum.core.circuit import combine_ansatz_params as _combine_ansatz_params
+from zquantum.core.interfaces import ansatz_utils
 from zquantum.core.typing import Specs
 from zquantum.core.utils import create_symbols_map, load_from_specs
 from zquantum.core.wip.circuits import Circuit
@@ -37,7 +37,7 @@ def generate_random_ansatz_params(
 def combine_ansatz_params(params1: str, params2: str):
     parameters1 = serialization.load_array(params1)
     parameters2 = serialization.load_array(params2)
-    combined_params = _combine_ansatz_params(parameters1, parameters2)
+    combined_params = ansatz_utils.combine_ansatz_params(parameters1, parameters2)
     layouts.save_circuit_template_params(combined_params, "combined-params.json")
 
 

--- a/steps/circuit.py
+++ b/steps/circuit.py
@@ -35,7 +35,7 @@ def generate_random_ansatz_params(
         np.random.seed(seed)
 
     params = np.random.uniform(min_value, max_value, number_of_parameters)
-    layouts.save_circuit_template_params(params, "params.json")
+    serialization.save_array(params, "params.json")
 
 
 # Combine two sets of ansatz parameters
@@ -43,7 +43,7 @@ def combine_ansatz_params(params1: str, params2: str):
     parameters1 = serialization.load_array(params1)
     parameters2 = serialization.load_array(params2)
     combined_params = ansatz_utils.combine_ansatz_params(parameters1, parameters2)
-    layouts.save_circuit_template_params(combined_params, "combined-params.json")
+    serialization.save_array(combined_params, "combined-params.json")
 
 
 # Build circuit from ansatz
@@ -98,7 +98,7 @@ def add_ancilla_register_to_circuit(
     if isinstance(circuit, str):
         circuit = load_circuit(circuit)
     extended_circuit = circuits.add_ancilla_register(circuit, number_of_ancilla_qubits)
-    save_circuit("extended-circuit.json", extended_circuit)
+    save_circuit(extended_circuit, "extended-circuit.json")
 
 
 # Concatenate circuits in a circuitset to create a composite circuit
@@ -106,7 +106,7 @@ def concatenate_circuits(circuit_set: Union[str, List[Circuit]]):
     if isinstance(circuit_set, str):
         circuit_set = load_circuitset(circuit_set)
     result_circuit = sum(circuit_set, Circuit())
-    save_circuitset(result_circuit)
+    save_circuitset(result_circuit, "result-circuit.json")
 
 
 # Create one circuitset from circuit and circuitset objects

--- a/steps/circuit.py
+++ b/steps/circuit.py
@@ -1,15 +1,20 @@
-import json
 from typing import List, Optional, Union
 
 import numpy as np
 import numpy.random
-import zquantum.core.wip.circuits as new_circuits
 import zquantum.core.wip.circuits.layouts as layouts
 from zquantum.core import serialization
 from zquantum.core.interfaces import ansatz_utils
 from zquantum.core.typing import Specs
 from zquantum.core.utils import create_symbols_map, load_from_specs
-from zquantum.core.wip.circuits import Circuit
+from zquantum.core.wip import circuits
+from zquantum.core.wip.circuits import (
+    Circuit,
+    load_circuit,
+    load_circuitset,
+    save_circuit,
+    save_circuitset,
+)
 
 
 # Generate random parameters for an ansatz
@@ -61,7 +66,7 @@ def build_ansatz_circuit(
                 "Ansatz is not parametrizable and no parameters has been provided."
             )
         )
-    new_circuits.save_circuit(circuit, "circuit.json")
+    save_circuit(circuit, "circuit.json")
 
 
 # Build circuit layers and connectivity
@@ -82,10 +87,8 @@ def create_random_circuit(
     number_of_qubits: int, number_of_gates: int, seed: Optional[int] = None
 ):
     rng = np.random.default_rng(seed)
-    circuit = new_circuits.create_random_circuit(
-        number_of_qubits, number_of_gates, rng=rng
-    )
-    new_circuits.save_circuit(circuit, "circuit.json")
+    circuit = circuits.create_random_circuit(number_of_qubits, number_of_gates, rng=rng)
+    save_circuit(circuit, "circuit.json")
 
 
 # Add register of ancilla qubits to circuit
@@ -93,19 +96,17 @@ def add_ancilla_register_to_circuit(
     number_of_ancilla_qubits: int, circuit: Union[Circuit, str]
 ):
     if isinstance(circuit, str):
-        circuit = new_circuits.load_circuit(circuit)
-    extended_circuit = new_circuits.add_ancilla_register(
-        circuit, number_of_ancilla_qubits
-    )
-    new_circuits.save_circuit("extended-circuit.json", extended_circuit)
+        circuit = load_circuit(circuit)
+    extended_circuit = circuits.add_ancilla_register(circuit, number_of_ancilla_qubits)
+    save_circuit("extended-circuit.json", extended_circuit)
 
 
 # Concatenate circuits in a circuitset to create a composite circuit
 def concatenate_circuits(circuit_set: Union[str, List[Circuit]]):
     if isinstance(circuit_set, str):
-        circuit_set = new_circuits.load_circuit_set(circuit_set)
-    result_circuit = sum(circuit_set, new_circuits.Circuit())
-    new_circuits.save_circuitset(result_circuit)
+        circuit_set = load_circuitset(circuit_set)
+    result_circuit = sum(circuit_set, Circuit())
+    save_circuitset(result_circuit)
 
 
 # Create one circuitset from circuit and circuitset objects
@@ -117,32 +118,31 @@ def batch_circuits(
     if circuit_set is None:
         loaded_circuit_set = []
     elif isinstance(circuit_set, str):
-        loaded_circuit_set = new_circuits.load_circuitset(circuit_set)
+        loaded_circuit_set = load_circuitset(circuit_set)
     else:
         loaded_circuit_set = circuit_set
 
     for circuit in circuits:
         if isinstance(circuit, str):
-            loaded_circuit = new_circuits.load_circuits(circuit)
+            loaded_circuit = load_circuit(circuit)
         else:
             loaded_circuit = circuit
 
         loaded_circuit_set.append(loaded_circuit)
 
-    with open("circuit-set.json", "w") as f:
-        json.dump(new_circuits.to_dict(loaded_circuit_set), f)
+    save_circuitset(loaded_circuit_set, "circuit-set.json")
 
 
 def evaluate_parametrized_circuit(
-    parametrized_circuit: Union[str, new_circuits.Circuit],
+    parametrized_circuit: Union[str, Circuit],
     parameters: Union[str, np.ndarray],
 ):
     if isinstance(parametrized_circuit, str):
-        parametrized_circuit = new_circuits.load_circuit(parametrized_circuit)
+        parametrized_circuit = load_circuit(parametrized_circuit)
 
     if isinstance(parameters, str):
         parameters = serialization.load_array(parameters)
 
     symbols_map = create_symbols_map(parametrized_circuit.symbolic_params, parameters)
     bound_circuit = parametrized_circuit.bind(symbols_map)
-    new_circuits.save_circuit(bound_circuit, "evaluated-circuit.json")
+    save_circuit(bound_circuit, "evaluated-circuit.json")

--- a/steps/optimize.py
+++ b/steps/optimize.py
@@ -4,7 +4,6 @@ from typing import List, Optional, Union
 import numpy as np
 import zquantum.core.wip.circuits as new_circuits
 from openfermion import SymbolicOperator
-from zquantum.core.circuit import load_parameter_grid
 from zquantum.core.cost_function import (
     AnsatzBasedCostFunction,
     get_ground_state_cost_function,
@@ -56,19 +55,10 @@ def optimize_parametrized_circuit_for_ground_state_of_operator(
             parameter, if any.
         parameter_precision_seed: seed for randomly generating parameter deviation if
             using parameter_precision
-        kwaargs:
-            The following keyword arguments are handled explicitly when appropriate:
-            - parameter_grid: A parameter grid artifact that defines a 2D grid for
-                parameter values
+        kwargs: unused, exists for compatibility
     """
     if isinstance(optimizer_specs, str):
         optimizer_specs = json.loads(optimizer_specs)
-
-    parameter_grid = kwargs.pop("parameter_grid", None)
-    # Load parameter grid
-    if parameter_grid is not None:
-        parameter_grid = load_parameter_grid(parameter_grid)
-        optimizer_specs["grid"] = parameter_grid
 
     optimizer = create_object(optimizer_specs)
 
@@ -163,18 +153,10 @@ def optimize_ansatz_based_cost_function(
             using parameter_precision
         kwargs:
             The following key word arguments are handled explicitly when appropriate:
-                - parameter_grid: A parameter grid artifact that defines a 2D grid for
-                    parameter values
                 - thetas: A list of thetas used to initialize the WarmStartQAOAAnsatz
     """
     if isinstance(optimizer_specs, str):
         optimizer_specs = json.loads(optimizer_specs)
-
-    parameter_grid = kwargs.pop("parameter_grid", None)
-    # Load parameter grid
-    if parameter_grid is not None:
-        parameter_grid = load_parameter_grid(parameter_grid)
-        optimizer_specs["grid"] = parameter_grid
 
     optimizer = create_object(optimizer_specs)
 

--- a/steps/optimize.py
+++ b/steps/optimize.py
@@ -4,18 +4,18 @@ from typing import List, Optional, Union
 import numpy as np
 import zquantum.core.wip.circuits as new_circuits
 from openfermion import SymbolicOperator
-from zquantum.core.circuit import (
-    load_circuit_template_params,
-    load_parameter_grid,
-    save_circuit_template_params,
-)
+from zquantum.core.circuit import load_parameter_grid
 from zquantum.core.cost_function import (
     AnsatzBasedCostFunction,
     get_ground_state_cost_function,
 )
 from zquantum.core.estimation import estimate_expectation_values_by_averaging
 from zquantum.core.openfermion import load_qubit_operator
-from zquantum.core.serialization import save_optimization_results
+from zquantum.core.serialization import (
+    load_array,
+    save_array,
+    save_optimization_results,
+)
 from zquantum.core.typing import Specs
 from zquantum.core.utils import create_object, load_list
 from zquantum.core.wip.circuits import Circuit
@@ -103,11 +103,11 @@ def optimize_parametrized_circuit_for_ground_state_of_operator(
 
     if initial_parameters is not None:
         if isinstance(initial_parameters, str):
-            initial_parameters = load_circuit_template_params(initial_parameters)
+            initial_parameters = load_array(initial_parameters)
 
     if fixed_parameters is not None:
         if isinstance(fixed_parameters, str):
-            fixed_parameters = load_circuit_template_params(fixed_parameters)
+            fixed_parameters = load_array(fixed_parameters)
 
     cost_function = get_ground_state_cost_function(
         target_operator,
@@ -123,9 +123,7 @@ def optimize_parametrized_circuit_for_ground_state_of_operator(
     optimization_results = optimizer.minimize(cost_function, initial_parameters)
 
     save_optimization_results(optimization_results, "optimization-results.json")
-    save_circuit_template_params(
-        optimization_results.opt_params, "optimized-parameters.json"
-    )
+    save_array(optimization_results.opt_params, "optimized-parameters.json")
 
 
 def optimize_ansatz_based_cost_function(
@@ -217,11 +215,11 @@ def optimize_ansatz_based_cost_function(
 
     if initial_parameters is not None:
         if isinstance(initial_parameters, str):
-            initial_parameters = load_circuit_template_params(initial_parameters)
+            initial_parameters = load_array(initial_parameters)
 
     if fixed_parameters is not None:
         if isinstance(fixed_parameters, str):
-            fixed_parameters = load_circuit_template_params(fixed_parameters)
+            fixed_parameters = load_array(fixed_parameters)
 
     cost_function = AnsatzBasedCostFunction(
         target_operator,
@@ -237,6 +235,4 @@ def optimize_ansatz_based_cost_function(
     optimization_results = optimizer.minimize(cost_function, initial_parameters)
 
     save_optimization_results(optimization_results, "optimization-results.json")
-    save_circuit_template_params(
-        optimization_results.opt_params, "optimized-parameters.json"
-    )
+    save_array(optimization_results.opt_params, "optimized-parameters.json")

--- a/tests/acceptance_tests/operators_test.py
+++ b/tests/acceptance_tests/operators_test.py
@@ -9,15 +9,16 @@ from openfermion import (
     get_ground_state,
     get_sparse_operator,
 )
-from operators import (
-    concatenate_qubit_operator_lists,
-    get_one_qubit_hydrogen_hamiltonian,
-)
 from zquantum.core.openfermion import (
     load_qubit_operator,
     load_qubit_operator_set,
     save_interaction_operator,
     save_qubit_operator_set,
+)
+
+from steps.operators import (
+    concatenate_qubit_operator_lists,
+    get_one_qubit_hydrogen_hamiltonian,
 )
 
 h2_hamiltonian_grouped = [

--- a/tests/acceptance_tests/optimize_test.py
+++ b/tests/acceptance_tests/optimize_test.py
@@ -106,8 +106,8 @@ class TestOptimizeParamterizedCircuit:
         with open(initial_parameters_path, "w") as f:
             json.dump(
                 {
-                    "schema": "zapata-v1-circuit_template_params",
-                    "parameters": {"real": [1.0, 1.0]},
+                    "schema": "zapata-v1-array",
+                    "array": {"real": [1.0, 1.0]},
                 },
                 f,
             )
@@ -116,8 +116,8 @@ class TestOptimizeParamterizedCircuit:
         with open(fixed_parameters_path, "w") as f:
             json.dump(
                 {
-                    "schema": "zapata-v1-circuit_template_params",
-                    "parameters": {"real": [1.0]},
+                    "schema": "zapata-v1-array",
+                    "array": {"real": [1.0]},
                 },
                 f,
             )
@@ -169,5 +169,5 @@ class TestOptimizeParamterizedCircuit:
         os.remove(optimization_results_path)
         os.remove("optimized-parameters.json")
         os.remove(circuit_path)
-        os.remove("initial_parameters.json")
+        os.remove(initial_parameters_path)
         os.remove(fixed_parameters_path)

--- a/tests/zquantum/core/circuit/_circuit_template_test.py
+++ b/tests/zquantum/core/circuit/_circuit_template_test.py
@@ -68,18 +68,6 @@ class TestCircuitTemplate(unittest.TestCase):
         np.testing.assert_array_equal(params, recreated_params)
         os.remove(filename)
 
-    def test_combine_ansatz_params(self):
-        # Given
-        params1 = np.array([1.0, 2.0])
-        params2 = np.array([3.0, 4.0])
-        target_params = np.array([1.0, 2.0, 3.0, 4.0])
-
-        # When
-        combined_params = combine_ansatz_params(params1, params2)
-
-        # Then
-        self.assertTrue(np.allclose(combined_params, target_params))
-
 
 class TestParameterGrid(unittest.TestCase):
     def test_dict_io(self):

--- a/tests/zquantum/core/interfaces/ansatz_utils_test.py
+++ b/tests/zquantum/core/interfaces/ansatz_utils_test.py
@@ -2,9 +2,12 @@
 import unittest
 from unittest import mock
 
+import numpy as np
+import numpy.testing
 from zquantum.core.interfaces.ansatz_utils import (
     DynamicProperty,
     ansatz_property,
+    combine_ansatz_params,
     invalidates_parametrized_circuit,
 )
 
@@ -31,7 +34,6 @@ class PseudoAnsatz:
 
 
 class DynamicPropertyTests(unittest.TestCase):
-
     def test_uses_default_value_if_not_overwritten(self):
         class MyCls:
             x = DynamicProperty(name="x", default_value=-15)
@@ -81,7 +83,6 @@ class TestAnsatzProperty(unittest.TestCase):
 
 
 class InvalidatesParametrizedCircuitTest(unittest.TestCase):
-
     def test_resets_parametrized_circuit(self):
         ansatz = PseudoAnsatz(n_layers=10)
 
@@ -103,3 +104,13 @@ class InvalidatesParametrizedCircuitTest(unittest.TestCase):
 
         # Check that arguments were passed to underlying method
         method_mock.assert_called_once_with(ansatz, 2.0, 1.0, x=100, label="test")
+
+
+def test_combine_ansatz_params():
+    params1 = np.array([1.0, 2.0])
+    params2 = np.array([3.0, 4.0])
+    target_params = np.array([1.0, 2.0, 3.0, 4.0])
+
+    combined_params = combine_ansatz_params(params1, params2)
+
+    np.testing.assert_array_equal(combined_params, target_params)


### PR DESCRIPTION
Note: this breaks backwards compatibility with `optimize` steps artifacts - the schema for `load_circuit_template_params` and `save_array` is different.