### PR TITLE
Fix typo in measure step

### DIFF
--- a/steps/measure.py
+++ b/steps/measure.py
@@ -77,7 +77,7 @@ def run_circuitset_and_measure(
             device_connectivity
         )
 
-    circuit_set = circuits.load_circuit_set(circuitset)
+    circuit_set = circuits.load_circuitset(circuitset)
     backend = create_object(backend_specs)
 
     measurements_set = backend.run_circuitset_and_measure(


### PR DESCRIPTION
Fixes the error when using `measure` step in a workflow:
```
"/app/qeruntime/python3/run", line 253, in run_command
[runtime] 2021-06-07T13:12:16.541Z     return py_function(**kwargs)
[runtime] 2021-06-07T13:12:16.541Z   File "/app/step/z-quantum-core/steps/measure.py", line 80, in run_circuitset_and_measure
[runtime] 2021-06-07T13:12:16.541Z     circuit_set = circuits.load_circuit_set(circuitset)
[runtime] 2021-06-07T13:12:16.541Z Traceback (most recent call last):
[runtime] 2021-06-07T13:12:16.542Z AttributeError: module 'zquantum.core.circuits' has no attribute 'load_circuit_set'
```