### PR TITLE
Updating cirq conversions to give sympy matrix for custom gates

### DIFF
--- a/src/python/zquantum/core/circuits/conversions/cirq_conversions.py
+++ b/src/python/zquantum/core/circuits/conversions/cirq_conversions.py
@@ -262,7 +262,7 @@ def import_from_cirq(obj):
 
 @dataclass
 class NonNativeGate:
-    matrix: sympy.Matrix
+    matrix: np.ndarray
     cirq_class: type
 
 
@@ -352,7 +352,7 @@ def _convert_gate_operation_to_zquantum(operation) -> _gates.GateOperation:
             gate_name=_gen_custom_gate_name(
                 imported_gate.cirq_class, imported_gate.matrix
             ),
-            matrix=imported_gate.matrix,
+            matrix=sympy.Matrix(imported_gate.matrix),
             params_ordering=(),
         )
         return custom_gate()(*qubit_indices)


### PR DESCRIPTION
This PR fixes the issue @jgonthier encountered where gates imported form cirq as custom gates would raise an exception when constructing the unitary.

In a ideal world this would have been caught by static type checking. I think it was missed however because mypy does not provide type hints.