### PR TITLE
Compatibility with older sympy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setuptools.setup(
         "networkx==2.4",
         "numpy>=1.20",
         "scipy>=1.4.1",
-        "sympy>=1.7",
+        "sympy>=1.5",
         "openfermion>=1.0.0",
         "openfermioncirq==0.4.0",
         "lea>=3.2.0",

--- a/src/python/zquantum/core/circuits/symbolic/sympy_expressions.py
+++ b/src/python/zquantum/core/circuits/symbolic/sympy_expressions.py
@@ -4,6 +4,19 @@ from functools import singledispatch
 from numbers import Number
 
 import sympy
+import sympy.core
+
+try:
+    # for sympy>=1.6 - import the module as usual
+    import sympy.core.numbers as sympy_numbers
+except ImportError:
+    # for sympy<=1.5.1
+    # There's a wildcard import in sympy that messes up the imports. This is a
+    # workaround to be able to work with sympy numbers from both old and recent sympy
+    # versions. See more at:
+    # https://github.com/sympy/sympy/blob/70381f282f2d9d039da860e391fe51649df2779d/sympy/__init__.py#L57
+    sympy_numbers = sympy.numbers
+
 
 from .expressions import ExpressionDialect, FunctionCall, Symbol
 
@@ -55,7 +68,7 @@ def native_float_from_sympy_rational(number: sympy.Rational):
 
 @expression_from_sympy.register
 def native_imaginary_unit_from_sympy_imaginary_unit(
-    _unit: sympy.core.numbers.ImaginaryUnit,
+    _unit: sympy_numbers.ImaginaryUnit,
 ):
     return 1j
 


### PR DESCRIPTION
Some projects couldn't be migrated to use the new circuits because of dependency conflict on sympy version. This PR makes z-quantum-core compatible with both sympy 1.5 and >=1.6.

Turns out circuit conversions was the only affected place that I found. In the future, if we have more functionality that would break when using `sympy==1.5` we would probably have to use workarounds similar to the one proposed in this PR.

 cc @martamau @simonwa7.