### PR TITLE
Account for constant terms in time evolution hamiltonians

### DIFF
--- a/src/python/zquantum/core/evolution.py
+++ b/src/python/zquantum/core/evolution.py
@@ -135,7 +135,7 @@ def _time_evolution_for_term_qubit_operator(
     circuit = circuits.Circuit()
 
     # If constant term, return empty circuit.
-    if term_components is None:
+    if not term_components:
         return circuit
 
     for i, (term_type, qubit_id) in enumerate(zip(term_types, qubit_indices)):

--- a/src/python/zquantum/core/evolution.py
+++ b/src/python/zquantum/core/evolution.py
@@ -132,6 +132,12 @@ def _time_evolution_for_term_qubit_operator(
     qubit_indices = [component[0] for component in term_components]
     coefficient = list(term.terms.values())[0]
 
+    circuit = circuits.Circuit()
+
+    # If constant term, return empty circuit.
+    if term_components is None:
+        return circuit
+
     for i, (term_type, qubit_id) in enumerate(zip(term_types, qubit_indices)):
         if term_type == "X":
             base_changes.append(H(qubit_id))
@@ -144,15 +150,13 @@ def _time_evolution_for_term_qubit_operator(
         else:
             cnot_gates.append(CNOT(qubit_id, qubit_indices[i + 1]))
 
-    circuit = circuits.Circuit()
     for gate in base_changes:
         circuit += gate
 
     for gate in cnot_gates:
         circuit += gate
 
-    if central_gate:
-        circuit += central_gate
+    circuit += central_gate
 
     for gate in reversed(cnot_gates):
         circuit += gate

--- a/src/python/zquantum/core/evolution.py
+++ b/src/python/zquantum/core/evolution.py
@@ -151,7 +151,8 @@ def _time_evolution_for_term_qubit_operator(
     for gate in cnot_gates:
         circuit += gate
 
-    circuit += central_gate
+    if central_gate:
+        circuit += central_gate
 
     for gate in reversed(cnot_gates):
         circuit += gate

--- a/tests/zquantum/core/evolution_test.py
+++ b/tests/zquantum/core/evolution_test.py
@@ -73,12 +73,18 @@ def _cirq_exponentiate_hamiltonian(hamiltonian, qubits, time, trotter_order):
             np.diag([1j, -1j, -1j, 1j])[::-1],
         ),
         (QubitOperator("[Z0 Z1]"), np.pi, -np.eye(4)),
+        (QubitOperator((), 1), np.pi, []),
     ],
 )
 class TestTimeEvolutionOfTerm:
     def test_evolving_pauli_term_with_numerical_time_gives_correct_unitary(
         self, term, time, expected_unitary
     ):
+        # If constant term, check is empty circuit.
+        if isinstance(term, QubitOperator) and () in term.terms:
+            assert time_evolution_for_term(term, time) == circuits.Circuit()
+            return
+
         actual_unitary = time_evolution_for_term(term, time).to_unitary()
         np.testing.assert_array_almost_equal(actual_unitary, expected_unitary)
 
@@ -88,6 +94,11 @@ class TestTimeEvolutionOfTerm:
         time_symbol = sympy.Symbol("t")
         symbol_map = {time_symbol: time}
         evolution_circuit = time_evolution_for_term(term, time_symbol)
+
+        # If constant term, check is empty circuit.
+        if isinstance(term, QubitOperator) and () in term.terms:
+            assert evolution_circuit == circuits.Circuit()
+            return
 
         actual_unitary = evolution_circuit.bind(symbol_map).to_unitary()
         np.testing.assert_array_almost_equal(actual_unitary, expected_unitary)


### PR DESCRIPTION
Constant terms cause a bug because `central_gate` is `None`. This PR changes that - `central_gate` will only be added to circuit if its value is not `None`. 