### PR TITLE
Fix Qiskit conversions

### DIFF
--- a/src/python/zquantum/core/circuits/symbolic/qiskit_expressions.py
+++ b/src/python/zquantum/core/circuits/symbolic/qiskit_expressions.py
@@ -13,7 +13,7 @@ from numbers import Number
 import qiskit
 
 from .expressions import ExpressionDialect, reduction
-from .sympy_expressions import expression_from_sympy
+from .symengine_expressions import expression_from_symengine
 
 
 @singledispatch
@@ -36,8 +36,8 @@ def _expr_from_qiskit_param_expr(
     # At the moment of writing this the qiskit version that we use (0.23.2) as well
     # as the newest version 0.23.5) does not provide a better way to access symbolic
     # expression wrapped by ParameterExpression.
-    sympy_expr = qiskit_expr._symbol_expr
-    return expression_from_sympy(sympy_expr)
+    symengine_expr = qiskit_expr._symbol_expr
+    return expression_from_symengine(symengine_expr)
 
 
 def integer_pow(base, exponent: int):

--- a/src/python/zquantum/core/circuits/symbolic/qiskit_expressions.py
+++ b/src/python/zquantum/core/circuits/symbolic/qiskit_expressions.py
@@ -14,6 +14,7 @@ import qiskit
 
 from .expressions import ExpressionDialect, reduction
 from .symengine_expressions import expression_from_symengine
+from .sympy_expressions import expression_from_sympy
 
 
 @singledispatch
@@ -36,8 +37,11 @@ def _expr_from_qiskit_param_expr(
     # At the moment of writing this the qiskit version that we use (0.23.2) as well
     # as the newest version 0.23.5) does not provide a better way to access symbolic
     # expression wrapped by ParameterExpression.
-    symengine_expr = qiskit_expr._symbol_expr
-    return expression_from_symengine(symengine_expr)
+    inner_expr = qiskit_expr._symbol_expr
+    try:
+        return expression_from_symengine(inner_expr)
+    except NotImplementedError:
+        return expression_from_sympy(inner_expr)
 
 
 def integer_pow(base, exponent: int):

--- a/src/python/zquantum/core/circuits/symbolic/symengine_expressions.py
+++ b/src/python/zquantum/core/circuits/symbolic/symengine_expressions.py
@@ -1,0 +1,157 @@
+"""Utilities for converting symengine expressions to our native Expression format."""
+import operator
+from functools import singledispatch
+from numbers import Number
+
+import symengine
+from symengine.lib.symengine_wrapper import ImaginaryUnit
+
+from .expressions import ExpressionDialect, FunctionCall, Symbol, reduction
+
+
+def is_multiplication_by_reciprocal(symengine_mul: symengine.Mul) -> bool:
+    """Check if given symengine multiplication is of the form x * (1 / y)."""
+    args = symengine_mul.args
+    return (
+        len(args) == 2 and isinstance(args[1], symengine.Pow) and args[1].args[1] == -1
+    )
+
+
+def is_right_addition_of_negation(symengine_add: symengine.Add) -> bool:
+    """Check if given symengine addition is of the form x + (-y)."""
+    args = symengine_add.args
+    return (
+        len(args) == 2 and isinstance(args[1], symengine.Mul) and args[1].args[0] == -1
+    )
+
+
+def is_left_addition_of_negation(symengine_add: symengine.Add) -> bool:
+    """Check if given symengine addition is of the form (-x) + y."""
+    args = symengine_add.args
+    return (
+        len(args) == 2 and isinstance(args[0], symengine.Mul) and args[0].args[0] == -1
+    )
+
+
+@singledispatch
+def expression_from_symengine(expression):
+    """Parse symengine expression into intermediate expression tree."""
+    raise NotImplementedError(
+        f"Expression {expression} of type {type(expression)} is currently not supported"
+    )
+
+
+@expression_from_symengine.register
+def identity(number: Number):
+    return number
+
+
+@expression_from_symengine.register
+def symbol_from_symengine(symbol: symengine.Symbol):
+    return Symbol(str(symbol))
+
+
+@expression_from_symengine.register
+def native_integer_from_symengine_integer(number: symengine.Integer):
+    return int(number)
+
+
+@expression_from_symengine.register
+def native_float_from_symengine_float(number: symengine.Float):
+    return float(number)
+
+
+@expression_from_symengine.register
+def native_float_from_symengine_rational(number: symengine.Rational):
+    return float(number)
+
+
+@expression_from_symengine.register
+def native_imaginary_unit_from_symengine_imaginary_unit(
+    _unit: ImaginaryUnit,
+):
+    return 1j
+
+
+def _negate_symengine_expr(expr):
+    return expr * (-1)
+
+
+@expression_from_symengine.register
+def addition_from_symengine_add(add: symengine.Add):
+    if is_left_addition_of_negation(add):
+        return FunctionCall(
+            "sub",
+            (
+                expression_from_symengine(add.args[1]),
+                expression_from_symengine(_negate_symengine_expr(add.args[0])),
+            ),
+        )
+    elif is_right_addition_of_negation(add):
+        return FunctionCall(
+            "sub",
+            (
+                expression_from_symengine(add.args[0]),
+                expression_from_symengine(_negate_symengine_expr(add.args[1])),
+            ),
+        )
+    return FunctionCall("add", expression_from_symengine(add.args))
+
+
+@expression_from_symengine.register
+def multiplication_from_symengine_mul(mul: symengine.Mul):
+    if is_multiplication_by_reciprocal(mul):
+        return FunctionCall(
+            "div",
+            (
+                expression_from_symengine(mul.args[0]),
+                expression_from_symengine(mul.args[1].args[0]),
+            ),
+        )
+    else:
+        return FunctionCall("mul", expression_from_symengine(mul.args))
+
+
+@expression_from_symengine.register
+def power_from_symengine_pow(power: symengine.Pow):
+    if power.args[1] == -1:
+        return FunctionCall("div", (1, expression_from_symengine(power.args[0])))
+    elif power.args[1] == 0.5:
+        return FunctionCall("sqrt", (expression_from_symengine(power.args[0]),))
+    elif power.args[0] == symengine.E:
+        return FunctionCall("exp", (expression_from_symengine(power.args[1]),))
+    else:
+        return FunctionCall("pow", expression_from_symengine(power.args))
+
+
+@expression_from_symengine.register
+def function_call_from_symengine_function(function: symengine.Function):
+    return FunctionCall(
+        str(type(function).__name__), expression_from_symengine(function.args)
+    )
+
+
+@expression_from_symengine.register
+def expression_tuple_from_tuple_of_symengine_args(args: tuple):
+    return tuple(expression_from_symengine(arg) for arg in args)
+
+
+# Dialect defining conversion of intermediate expression tree to
+# the expression based on symengine functions/Symbols
+# This is intended to be passed by a `dialect` argument of `translate_expression`.
+SYMENGINE_DIALECT = ExpressionDialect(
+    symbol_factory=lambda symbol: symengine.Symbol(symbol.name),
+    number_factory=lambda number: number,
+    known_functions={
+        "add": reduction(operator.add),
+        "mul": reduction(operator.mul),
+        "div": operator.truediv,
+        "sub": operator.sub,
+        "pow": operator.pow,
+        "cos": symengine.cos,
+        "sin": symengine.sin,
+        "exp": symengine.exp,
+        "sqrt": symengine.sqrt,
+        "tan": symengine.tan,
+    },
+)

--- a/tests/zquantum/core/circuits/symbolic/symengine_expressions_test.py
+++ b/tests/zquantum/core/circuits/symbolic/symengine_expressions_test.py
@@ -1,0 +1,227 @@
+"""Test cases for symengine_expressions module."""
+import pytest
+import symengine
+from zquantum.core.circuits.symbolic.expressions import FunctionCall, Symbol
+from zquantum.core.circuits.symbolic.symengine_expressions import (
+    SYMENGINE_DIALECT,
+    expression_from_symengine,
+    is_left_addition_of_negation,
+    is_multiplication_by_reciprocal,
+    is_right_addition_of_negation,
+)
+from zquantum.core.circuits.symbolic.translations import translate_expression
+
+
+def _to_symengine(expr):
+    return translate_expression(expr, SYMENGINE_DIALECT)
+
+
+@pytest.mark.parametrize("number", [3, 4.0, 1j, 3.0 - 2j])
+def test_native_numbers_are_preserved(number):
+    assert expression_from_symengine(number) == number
+
+
+@pytest.mark.parametrize(
+    "symengine_symbol, expected_symbol",
+    [
+        (symengine.Symbol("theta"), Symbol("theta")),
+        (symengine.Symbol("x"), Symbol("x")),
+        (symengine.Symbol("c_i"), Symbol("c_i")),
+    ],
+)
+def test_symbols_are_converted_to_instance_of_symbol_class(
+    symengine_symbol, expected_symbol
+):
+    assert expression_from_symengine(symengine_symbol) == expected_symbol
+
+
+@pytest.mark.parametrize(
+    "symengine_number, expected_number, expected_class",
+    [
+        (symengine.sympify(2), 2, int),
+        (symengine.sympify(-2.5), -2.5, float),
+        (symengine.Rational(3, 8), 0.375, float),
+    ],
+)
+def test_symengine_numbers_are_converted_to_corresponding_native_number(
+    symengine_number, expected_number, expected_class
+):
+    native_number = expression_from_symengine(symengine_number)
+    assert native_number == expected_number
+    assert isinstance(native_number, expected_class)
+
+
+def test_imaginary_unit_is_converted_to_1j():
+    assert expression_from_symengine(symengine.I) == 1j
+
+
+SYMENGINE_EXPRESSIONS = [
+    # Add
+    1 + symengine.Symbol("x"),
+    symengine.Symbol("x") + symengine.Symbol("y") + symengine.Symbol("z"),
+    # Mul
+    2 * symengine.Symbol("x"),
+    symengine.Symbol("x") * symengine.Symbol("y"),
+    # Division, also represented as symengine.Mul
+    symengine.Symbol("x") / symengine.Symbol("y"),
+    symengine.Symbol("x") / (symengine.Symbol("z") + 1),
+    # Function calls
+    symengine.cos(2),
+    symengine.sin(symengine.Symbol("theta")),
+    symengine.exp(symengine.Symbol("x")),
+]
+
+
+@pytest.mark.parametrize("symengine_expression", SYMENGINE_EXPRESSIONS)
+def test_roundtrip_between_symengine_and_zquantum_expressions(symengine_expression):
+    assert (
+        _to_symengine(expression_from_symengine(symengine_expression))
+        == symengine_expression
+    )
+
+
+@pytest.mark.parametrize(
+    "symengine_multiplication",
+    [
+        symengine.Symbol("x") / symengine.Symbol("y"),
+        symengine.Symbol("x") / (symengine.Symbol("z") + 1),
+    ],
+)
+def test_mul_from_division_is_classified_as_multiplication_by_reciprocal(
+    symengine_multiplication,
+):
+    assert is_multiplication_by_reciprocal(symengine_multiplication)
+
+
+@pytest.mark.parametrize(
+    "symengine_multiplication",
+    [
+        symengine.Symbol("x") * symengine.Symbol("y"),
+        2 * symengine.Symbol("theta"),
+        symengine.Symbol("x") * symengine.Symbol("y") * symengine.Symbol("z"),
+    ],
+)
+def test_mul_not_from_division_is_not_classified_as_multiplication_by_reciprocal(
+    symengine_multiplication,
+):
+    # Note: obviously you can manually construct multiplication that would
+    # be classified as multiplication by reciprocal. The bottom line of this
+    # test is: usual, simple multiplications are multiplications, not divisions.
+    assert not is_multiplication_by_reciprocal(symengine_multiplication)
+
+
+@pytest.mark.parametrize(
+    "symengine_multiplication",
+    [
+        symengine.Symbol("x") / symengine.Symbol("y"),
+        symengine.Symbol("x") / (symengine.Symbol("z") + 1),
+    ],
+)
+def test_division_is_converted_into_div_fn_call_instead_of_multiplication_by_reciprocal(
+    symengine_multiplication,
+):
+    assert expression_from_symengine(symengine_multiplication).name == "div"
+
+
+@pytest.mark.parametrize(
+    "symengine_addition",
+    [
+        symengine.Symbol("x") - symengine.Symbol("y"),
+        symengine.Symbol("x") - 1 / symengine.Symbol("y"),
+    ],
+)
+def test_add_resulting_from_subtraction_is_classified_as_addition_of_negation(
+    symengine_addition,
+):
+    assert is_left_addition_of_negation(
+        symengine_addition
+    ) or is_right_addition_of_negation(symengine_addition)
+
+
+@pytest.mark.parametrize(
+    "symengine_addition",
+    [symengine.Symbol("x") + symengine.Symbol("y"), symengine.Symbol("x") + 10],
+)
+def test_add_not_resulting_from_subtraction_is_not_classified_as_addition_of_negation(
+    symengine_addition,
+):
+    assert not (
+        is_left_addition_of_negation(symengine_addition)
+        or is_right_addition_of_negation(symengine_addition)
+    )
+
+
+@pytest.mark.parametrize(
+    "symengine_addition, expected_args",
+    [
+        (symengine.Symbol("x") - symengine.Symbol("y"), (Symbol("x"), Symbol("y"))),
+        (1 - symengine.Symbol("x"), (1, Symbol("x"))),
+        (
+            1 - symengine.Symbol("x") * symengine.Symbol("y"),
+            (1, FunctionCall("mul", (Symbol("x"), Symbol("y")))),
+        ),
+    ],
+)
+def test_add_resulting_from_subtraction_is_converted_to_sub_function_call(
+    symengine_addition, expected_args
+):
+    assert expression_from_symengine(symengine_addition) == FunctionCall(
+        "sub", expected_args
+    )
+
+
+@pytest.mark.parametrize(
+    "symengine_power, expected_args",
+    [
+        (symengine.Pow(symengine.Symbol("x"), 2), (Symbol("x"), 2)),
+        (symengine.Pow(2, symengine.Symbol("x")), (2, Symbol("x"))),
+        (
+            symengine.Pow(symengine.Symbol("x"), symengine.Symbol("y")),
+            (Symbol("x"), Symbol("y")),
+        ),
+    ],
+)
+def test_symengine_pow_is_converted_to_pow_function_call(
+    symengine_power, expected_args
+):
+    assert expression_from_symengine(symengine_power) == FunctionCall(
+        "pow", expected_args
+    )
+
+
+@pytest.mark.parametrize(
+    "symengine_power, expected_denominator",
+    [
+        (symengine.Pow(symengine.Symbol("x"), -1), Symbol("x")),
+        (
+            symengine.Pow(
+                symengine.Add(
+                    symengine.Symbol("x"), symengine.Symbol("y"), evaluate=False
+                ),
+                -1,
+            ),
+            FunctionCall("add", (Symbol("x"), Symbol("y"))),
+        ),
+    ],
+)
+def test_symengine_power_with_negative_one_exponent_gets_converted_to_division(
+    symengine_power, expected_denominator
+):
+    assert expression_from_symengine(symengine_power).name == "div"
+
+
+@pytest.mark.parametrize(
+    "symengine_function_call, expected_function_call",
+    [
+        (symengine.cos(2), FunctionCall("cos", (2,))),
+        (
+            symengine.sin(symengine.Symbol("theta")),
+            FunctionCall("sin", (Symbol("theta"),)),
+        ),
+        (symengine.exp(symengine.Symbol("x")), FunctionCall("exp", (Symbol("x"),))),
+    ],
+)
+def test_symengine_fn_calls_are_converted_to_fn_call_object_with_appropriate_fn_name(
+    symengine_function_call, expected_function_call
+):
+    assert expression_from_symengine(symengine_function_call) == expected_function_call


### PR DESCRIPTION
In a recent release, Qiskit switched to using symengine instead of sympy. This PR updates our code for Qiskit imports to follow this change. As a side effect, this PR also adds functions for converting symengine expressions to intermediate expression trees and a dialect for converting expression tree to symengine expression.