### PR TITLE
ZQS-677 Update preinstalled dependencies

### DIFF
--- a/docker/z-quantum-default/Dockerfile
+++ b/docker/z-quantum-default/Dockerfile
@@ -3,12 +3,14 @@ FROM ubuntu
 WORKDIR /app
 USER root
 RUN apt-get clean && apt-get update
-# Install python, pip, and other utilities
+
+# Install Python 3.7
 RUN apt-get install -y software-properties-common && \
     add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get install -y python3.7 && \
     apt-get install -y python3-pip && \
     apt-get install -y python3.7-dev
+
 RUN apt-get -y install \
                 wget \
                 git \
@@ -23,18 +25,20 @@ RUN apt-get -y install \
                 libblas-dev \
                 liblapack-dev
 
-# Set the default version of Python3 to Python 3.7 since z-quantum-core uses Python 3.7 features
+
+# ZQuantum requires Python 3.7. By installing `python3-pip` we have also installed 
+# Python 3.8. We need to set back the Python version to 3.7.
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1 && \
     update-alternatives --set python3 /usr/bin/python3.7
 
 ENV PYTHONPATH="/usr/local/lib/python3.7/dist-packages:${PYTHONPATH}"
 
-# We fix pip version to 20.2.4 until the issues with dependency resolving in pip is solved.
-RUN pip3 install pip==20.2.4
+# Downgrade pip to 20.2.4 until the issues with dependency resolving in pip is solved.
+RUN python3 -m pip install pip==20.2.4
 # Make sure to upgrade setuptools else z-quantum-core won't be installed because it uses find_namespace_packages
-RUN pip3 install --upgrade setuptools
-# Install Rigetti QVM
-#RUN tar xjf sbcl-1.5.4-x86-64-linux-binary.tar.bz2
+RUN python3 -m pip install --upgrade setuptools
+
+# Build & install Rigetti QVM simulator
 WORKDIR /root
 RUN curl -O https://beta.quicklisp.org/quicklisp.lisp && \
     echo '(quicklisp-quickstart:install)'  | sbcl --load quicklisp.lisp

--- a/docker/z-quantum-default/Dockerfile
+++ b/docker/z-quantum-default/Dockerfile
@@ -45,7 +45,7 @@ RUN curl -O https://beta.quicklisp.org/quicklisp.lisp && \
 RUN git clone https://github.com/rigetti/quilc.git && \
                 cd quilc && \
                 git fetch && \
-                git checkout v1.23.0 && \
+                git checkout v1.25.1 && \
                 git submodule init && \
                 git submodule update --init && \
                 make && \

--- a/docker/z-quantum-default/Dockerfile
+++ b/docker/z-quantum-default/Dockerfile
@@ -57,23 +57,15 @@ RUN git clone https://github.com/rigetti/qvm.git && \
                 make QVM_WORKSPACE=10240 qvm && \
                 mv qvm /usr/local/bin
 
-RUN python3 -m pip install rpcq==3.6.0 \
-                    pytest==5.3.5 \
-                    networkx==2.4 \
-                    pyquil==2.25.0 \
-                    cirq==0.9.1 \
-                    openfermion==1.0.0 \
-                    openfermioncirq==0.4.0 \
-                    qiskit==0.24 \
-                    scipy==1.4.1 \
-                    lea==3.2.0 \
-                    numpy==1.18.1 \
-                    pyyaml==5.1 \
-                    overrides>=3.1.0 \
-                    sympy==1.7 \
-                    codecarbon==1.1.0 \
-                    cvxpy==1.1.11
-                    
+# Install z-quantum-core's dependencies, but not the library itself.
+RUN python3 -m pip install --no-cache git+git://github.com/zapatacomputing/z-quantum-core && \
+    python3 -m pip uninstall -y z-quantum-core
+
+# Misc libraries that we'd like to have already preinstalled.
+RUN python3 -m pip install \
+        codecarbon \
+        cvxpy
+
                     
 WORKDIR /app
 ENTRYPOINT bash


### PR DESCRIPTION
Should be reviewed after #398 is merged.

- infers preinstall packages from dependencies required for installing z-quantum-core
- bumps quilc version to fix [build error](https://github.com/quil-lang/quilc/issues/706). The updated image has been [verified](https://github.com/zapatacomputing/qe-forest/pull/37/checks?check_run_id=3241769123) to work with qe-forest.