### PR TITLE
ZQS-359 Make contract 3 compatible with post selection estimator

### DIFF
--- a/src/python/zquantum/core/interfaces/estimator_contract.py
+++ b/src/python/zquantum/core/interfaces/estimator_contract.py
@@ -85,9 +85,9 @@ def _validate_expectation_value_includes_coefficients(
     estimator: EstimateExpectationValues,
 ):
     estimation_tasks = [
-        EstimationTask(IsingOperator("Z0"), Circuit([RX(np.pi / 3)(0)]), 10000),
+        EstimationTask(IsingOperator("Z0"), Circuit([RX(np.pi / 3)(0), H(1)]), 10000),
         EstimationTask(
-            IsingOperator("Z0", 19.971997), Circuit([RX(np.pi / 3)(0)]), 10000
+            IsingOperator("Z0", 19.971997), Circuit([RX(np.pi / 3)(0), H(1)]), 10000
         ),
     ]
 


### PR DESCRIPTION
~~On the post selection estimator in z-quantum-internal, contract 3 fails because the estimation task returns a expval of 0, and so multiplying it with a coefficient is still 0. This change makes it so the expval is not 0.~~ nvm no longer needed, fixed by change the estimator from `PostSelectedEstimator(2)` to `PostSelectedEstimator(1)`
