### PR TITLE
Enable black style checks

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -40,7 +40,7 @@ jobs:
           use-pylint: false
           use-pycodestyle: false
           use-flake8: true
-          # We're not ready yet to validate mypy, black & isort on every PR. In the
+          # We're not ready yet to validate mypy on every PR. In the
           # mean time, please rely on local pre-commit hook checks.
           use-mypy: false
           use-black: true

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,11 +1,11 @@
 name: style
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   push:
-    branches: [ main, master, dev ]
+    branches: [main, master, dev]
   pull_request:
-    branches: [ main, master, dev ]
+    branches: [main, master, dev]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -23,7 +23,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-      
+
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
@@ -32,7 +32,7 @@ jobs:
       - name: Python Code Quality and Lint
         # You may pin to the exact commit or the version.
         # uses: ricardochaves/python-lint@32032eca67291cd71f88d79e61bc4b904ee03265
-        uses: ricardochaves/python-lint@v1.3.0
+        uses: ricardochaves/python-lint@v1.4.0
         with:
           # A list of all paths to test
           python-root-list: "src/python/zquantum/core steps tests/zquantum/core tests/acceptance_tests"
@@ -40,17 +40,17 @@ jobs:
           use-pylint: false
           use-pycodestyle: false
           use-flake8: true
-          # We're not ready yet to validate mypy, black & isort on every PR. In the 
+          # We're not ready yet to validate mypy, black & isort on every PR. In the
           # mean time, please rely on local pre-commit hook checks.
           use-mypy: false
-          use-black: false
+          use-black: true
           use-isort: true
 
           # Extra options: pylint $(extra-pylint-options) $(python-root-list)
-          # extra-pylint-options: # optional, default is 
+          # extra-pylint-options: # optional, default is
 
           # Extra options: pycodestyle $(extra-pycodestyle-options) $(python-root-list)
-          # extra-pycodestyle-options: # optional, default is 
+          # extra-pycodestyle-options: # optional, default is
 
           # Extra options: flake8 $(extra-flake8-options) $(python-root-list)
           # Black's output doesn't pass all flake8 checks. We need to disable some of them.
@@ -62,5 +62,5 @@ jobs:
           # Extra options: mypy $(extra-mypy-options) $(python-root-list)
           extra-mypy-options: --ignore-missing-imports --namespace-packages
 
-          # Extra options: isort -rc $(extra-isort-options) $(python-root-list) -c --diff 
+          # Extra options: isort -rc $(extra-isort-options) $(python-root-list) -c --diff
           extra-isort-options: --check-only --profile black

--- a/tests/zquantum/core/history/attribute_forwarding_test.py
+++ b/tests/zquantum/core/history/attribute_forwarding_test.py
@@ -10,10 +10,7 @@ from zquantum.core.history.example_functions import (
 from zquantum.core.history.recorder import recorder
 
 
-@pytest.mark.parametrize(
-    "func",
-    [Function2(5), function_3, function_4, Function5(0.5)]
-)
+@pytest.mark.parametrize("func", [Function2(5), function_3, function_4, Function5(0.5)])
 def test_recorder_correctly_gets_attributes_of_recorder_function(func):
     func.custom_attribute = "custom-attr"
 
@@ -26,10 +23,7 @@ def test_recorder_correctly_gets_attributes_of_recorder_function(func):
     assert recorded.custom_attribute == func.custom_attribute
 
 
-@pytest.mark.parametrize(
-    "func",
-    [Function2(5), function_3, function_4, Function5(0.5)]
-)
+@pytest.mark.parametrize("func", [Function2(5), function_3, function_4, Function5(0.5)])
 def test_recorder_correctly_sets_attributes_of_recorder_function(func):
     func.custom_attribute = "custom-attr"
 


### PR DESCRIPTION
Style check actions v1.4.0 uses the same black version as our pre commit hooks, while the older one doesn't. So, upgrading to this new version allows us to enable black style checks whereas it was previously disabled.