### PR TITLE
Feature/zqs 770/dexter2206/define symbol orderings

### DIFF
--- a/src/python/zquantum/core/circuits/__init__.py
+++ b/src/python/zquantum/core/circuits/__init__.py
@@ -156,3 +156,4 @@ from ._serde import (
 from ._testing import create_random_circuit
 from ._wavefunction_operations import MultiPhaseOperation
 from .conversions.cirq_conversions import export_to_cirq, import_from_cirq
+from .symbolic._sorting import natural_key, natural_key_number_first

--- a/src/python/zquantum/core/circuits/__init__.py
+++ b/src/python/zquantum/core/circuits/__init__.py
@@ -156,4 +156,4 @@ from ._serde import (
 from ._testing import create_random_circuit
 from ._wavefunction_operations import MultiPhaseOperation
 from .conversions.cirq_conversions import export_to_cirq, import_from_cirq
-from .symbolic._sorting import natural_key, natural_key_revlex
+from .symbolic import natural_key, natural_key_revlex

--- a/src/python/zquantum/core/circuits/__init__.py
+++ b/src/python/zquantum/core/circuits/__init__.py
@@ -156,4 +156,4 @@ from ._serde import (
 from ._testing import create_random_circuit
 from ._wavefunction_operations import MultiPhaseOperation
 from .conversions.cirq_conversions import export_to_cirq, import_from_cirq
-from .symbolic._sorting import natural_key, natural_key_number_first
+from .symbolic._sorting import natural_key, natural_key_revlex

--- a/src/python/zquantum/core/circuits/symbolic/__init__.py
+++ b/src/python/zquantum/core/circuits/symbolic/__init__.py
@@ -1,0 +1,1 @@
+from ._sorting import natural_key, natural_key_revlex

--- a/src/python/zquantum/core/circuits/symbolic/_sorting.py
+++ b/src/python/zquantum/core/circuits/symbolic/_sorting.py
@@ -33,7 +33,7 @@ def natural_key(symbol):
 def natural_key_revlex(symbol):
     """Convert symbol to lexically reversed natural-ordering key.
 
-    This returns key produced by `natural_key`. They main usage is for list
+    This returns reversed key produced by `natural_key`. The main usage is for list
     of symbols with names of the form <symbol_name>_<number> where <symbol_name>
     can take one of several predefined values, and orders should consider <number>
     before <symbol_name>.

--- a/src/python/zquantum/core/circuits/symbolic/_sorting.py
+++ b/src/python/zquantum/core/circuits/symbolic/_sorting.py
@@ -1,3 +1,4 @@
+"""Definitions of keys for various symbol orderings."""
 import re
 
 
@@ -19,6 +20,9 @@ def natural_key(symbol):
     ordering treats variable indices as integers. Thus, in this ordering,
     symbols beta_10, theta_2, beta_2, theta_1 would be ordered as follows:
     beta_2 < beta_10 < theta_1 < theta_2.
+
+    The original idea behind this implementation was found byMSRudolph here:
+    http://nedbatchelder.com/blog/200712/human_sorting.html
     """
     return [
         _convert_string_to_int_if_possible(group)

--- a/src/python/zquantum/core/circuits/symbolic/_sorting.py
+++ b/src/python/zquantum/core/circuits/symbolic/_sorting.py
@@ -26,5 +26,15 @@ def natural_key(symbol):
     ]
 
 
-def natural_key_number_first(symbol):
-    pass
+def natural_key_revlex(symbol):
+    """Convert symbol to lexically reversed natural-ordering key.
+
+    This returns key produced by `natural_key`. They main usage is for list
+    of symbols with names of the form <symbol_name>_<number> where <symbol_name>
+    can take one of several predefined values, and orders should consider <number>
+    before <symbol_name>.
+
+    For instance, given symbols beta_1, beta_2, theta_1, theta_2, sorting them
+    using natural_key_revlex will give beta_1 < theta_1 < beta_2 < theta_2.
+    """
+    return list(reversed(natural_key(symbol)))

--- a/src/python/zquantum/core/circuits/symbolic/_sorting.py
+++ b/src/python/zquantum/core/circuits/symbolic/_sorting.py
@@ -1,0 +1,30 @@
+import re
+
+
+def _convert_string_to_int_if_possible(text):
+    return int(text) if text.isdigit() else text
+
+
+def natural_key(symbol):
+    """Convert symbol to a natural-ordering key.
+
+    The natural ordering of symbols works as follows:
+    1. Split a symbol on each group of digits.
+    2. For each group in this split, convert all-digit groups to integers.
+
+    Comparing such groups using lexicographical ordering gives natural ordering
+    of symbols.
+
+    In contrast to usual ordering obtained by casting symbol to string, natural
+    ordering treats variable indices as integers. Thus, in this ordering,
+    symbols beta_10, theta_2, beta_2, theta_1 would be ordered as follows:
+    beta_2 < beta_10 < theta_1 < theta_2.
+    """
+    return [
+        _convert_string_to_int_if_possible(group)
+        for group in re.split(r"(\d+)", symbol.name)
+    ]
+
+
+def natural_key_number_first(symbol):
+    pass

--- a/tests/zquantum/core/circuits/symbolic/sorting_test.py
+++ b/tests/zquantum/core/circuits/symbolic/sorting_test.py
@@ -1,6 +1,6 @@
 import pytest
 import sympy
-from zquantum.core.circuits import natural_key
+from zquantum.core.circuits import natural_key, natural_key_revlex
 
 
 @pytest.mark.parametrize(
@@ -21,3 +21,25 @@ def test_natural_key_orders_symbols_as_expected(
     unordered_symbols, expected_ordered_symbols
 ):
     assert sorted(unordered_symbols, key=natural_key) == list(expected_ordered_symbols)
+
+
+@pytest.mark.parametrize(
+    "unordered_symbols, expected_ordered_symbols",
+    [
+        (
+            sympy.symbols("theta_10, theta_2, theta_1"),
+            sympy.symbols("theta_1, theta_2, theta_10"),
+        ),
+        (
+            sympy.symbols("beta_10, theta_1, beta_2, theta_2"),
+            sympy.symbols("theta_1, beta_2, theta_2, beta_10"),
+        ),
+        (sympy.symbols("gamma, beta, alpha"), sympy.symbols("alpha, beta, gamma")),
+    ],
+)
+def test_natural_key_revlex_orders_symbols_as_expected(
+    unordered_symbols, expected_ordered_symbols
+):
+    assert sorted(unordered_symbols, key=natural_key_revlex) == list(
+        expected_ordered_symbols
+    )

--- a/tests/zquantum/core/circuits/symbolic/sorting_test.py
+++ b/tests/zquantum/core/circuits/symbolic/sorting_test.py
@@ -1,0 +1,23 @@
+import pytest
+import sympy
+from zquantum.core.circuits import natural_key
+
+
+@pytest.mark.parametrize(
+    "unordered_symbols, expected_ordered_symbols",
+    [
+        (
+            sympy.symbols("theta_10, theta_2, theta_1"),
+            sympy.symbols("theta_1, theta_2, theta_10"),
+        ),
+        (
+            sympy.symbols("beta_10, theta_1, beta_2, theta_2"),
+            sympy.symbols("beta_2, beta_10, theta_1, theta_2"),
+        ),
+        (sympy.symbols("gamma, beta, alpha"), sympy.symbols("alpha, beta, gamma")),
+    ],
+)
+def test_natural_key_orders_symbols_as_expected(
+    unordered_symbols, expected_ordered_symbols
+):
+    assert sorted(unordered_symbols, key=natural_key) == list(expected_ordered_symbols)


### PR DESCRIPTION
This PR adds sorting keys for two symbol orderings:

- natural (a.k.a. human) ordering
- lexicographically reversed natural ordering

For exact definitions of those orderings refer to docstrings in `zquantum.core.circuits.symbolic._sorting`.

This is the first step towards fixing symbol ordering issues.  After this PR is merged, accompanying changes to ansatz based cost functions will be introduced.