### PR TITLE
ZQS-770 Sort symbols depending on ansatz or cost function

### DIFF
--- a/src/python/zquantum/core/cost_function.py
+++ b/src/python/zquantum/core/cost_function.py
@@ -35,10 +35,11 @@ from .measurement import (
     concatenate_expectation_values,
     expectation_values_to_real,
 )
+from .typing import SupportsLessThan
 from .utils import ValueEstimate, create_symbols_map
 
 GradientFactory = Callable[[Callable], Callable[[np.ndarray], np.ndarray]]
-SymbolsSortKey = Callable[[sympy.Symbol], Any]
+SymbolsSortKey = Callable[[sympy.Symbol], SupportsLessThan]
 
 
 def _get_sorted_set_of_circuit_symbols(

--- a/src/python/zquantum/core/cost_function.py
+++ b/src/python/zquantum/core/cost_function.py
@@ -89,7 +89,10 @@ def get_ground_state_cost_function(
         gradient_function: a function which returns a function used to compute the
             gradient of the cost function (see
             zquantum.core.gradients.finite_differences_gradient for reference)
-
+        symbols_sort_key: key defining ordering on parametrized_circuits free symbols.
+            If s1,...,sN are all free symbols in parametrized_circuit, and cost function
+            is called with `parameters` then the following binding occurs:
+            parameters[i] -> sorted([s1,...,sN], key=symbols_sort_key)[i]
     Returns:
         Callable
     """
@@ -222,8 +225,6 @@ class AnsatzBasedCostFunction:
         circuit_symbols: A list of all symbolic parameters used in any estimation task
     """
 
-    symbols_sort_key = str
-
     def __init__(
         self,
         target_operator: SymbolicOperator,
@@ -266,7 +267,7 @@ class AnsatzBasedCostFunction:
             self.estimation_tasks = estimation_preprocessor(self.estimation_tasks)
 
         self.circuit_symbols = _get_sorted_set_of_circuit_symbols(
-            self.estimation_tasks, self.symbols_sort_key
+            self.estimation_tasks, ansatz.symbols_sort_key
         )
 
     def __call__(self, parameters: np.ndarray) -> ValueEstimate:
@@ -408,7 +409,7 @@ def expectation_value_estimation_tasks_factory(
     target_operator: SymbolicOperator,
     parametrized_circuit: Circuit,
     estimation_preprocessors: List[EstimationPreprocessor] = None,
-    symbols_sort_key: Callable[[sympy.Symbol], Any] = str,
+    symbols_sort_key: SymbolsSortKey = str,
 ) -> EstimationTasksFactory:
     """Creates a EstimationTasksFactory object that can be used to create
     estimation tasks that returns the estimated expectation value of the input
@@ -424,7 +425,10 @@ def expectation_value_estimation_tasks_factory(
         estimation_preprocessors: A list of callable functions used to create the
             estimation tasks. Each function must adhere to the EstimationPreprocessor
             protocol.
-
+        symbols_sort_key: key defining ordering on parametrized_circuits free symbols.
+            If s1,...,sN are all free symbols in parametrized_circuit, and cost function
+            is called with `parameters` then the following binding occurs:
+            parameters[i] -> sorted([s1,...,sN], key=symbols_sort_key)[i]
     Returns:
         An EstimationTasksFactory object.
 
@@ -481,7 +485,10 @@ def substitution_based_estimation_tasks_factory(
 
     """
     return expectation_value_estimation_tasks_factory(
-        target_operator, ansatz.parametrized_circuit, estimation_preprocessors
+        target_operator,
+        ansatz.parametrized_circuit,
+        estimation_preprocessors,
+        ansatz.symbols_sort_key,
     )
 
 

--- a/src/python/zquantum/core/interfaces/ansatz.py
+++ b/src/python/zquantum/core/interfaces/ansatz.py
@@ -1,14 +1,17 @@
 import warnings
 from abc import ABC
-from typing import List, Optional, Sequence, Tuple
+from typing import Any, Callable, List, Optional, Sequence, Tuple
 
 import numpy as np
 import sympy
 from overrides import EnforceOverrides
 
 from ..circuits import Circuit
+from ..typing import SupportsLessThan
 from ..utils import create_symbols_map
 from .ansatz_utils import ansatz_property
+
+SymbolsSortKey = Callable[[sympy.Symbol], SupportsLessThan]
 
 
 class Ansatz(ABC, EnforceOverrides):
@@ -29,7 +32,12 @@ class Ansatz(ABC, EnforceOverrides):
                 representation of the ansatz. Might not be supported for given ansatz,
                 see supports_parametrized_circuits.
             supports_parametrized_circuits: a flag.
-
+            symbols_sort_key: a key used for defining natural ordering of free symbols
+                for this ansatz. This is used by `get_executable` circuit to map
+                position in parameter vector onto ansatz free symbols.
+                If s1, s2, ..., sN are free symbols in this ansatz and `parameters`
+                is N-dimensional vector passed to get_executable, then
+                parameters[i] -> sorted([s1,...,sN], key=symbols_sort_key)[i]
         """
         if number_of_layers < 0:
             raise ValueError("number_of_layers must be non-negative.")
@@ -74,12 +82,18 @@ class Ansatz(ABC, EnforceOverrides):
         if params is None:
             raise Exception("Parameters can't be None for executable circuit.")
         if self.supports_parametrized_circuits:
-            symbols = self.parametrized_circuit.free_symbols
+            symbols = sorted(
+                self.parametrized_circuit.free_symbols, key=self.symbols_sort_key
+            )
             symbols_map = create_symbols_map(symbols, params)
             executable_circuit = self.parametrized_circuit.bind(symbols_map)
             return executable_circuit
         else:
             return self._generate_circuit(params)
+
+    @property
+    def symbols_sort_key(self) -> SymbolsSortKey:
+        return str
 
     def _generate_circuit(self, params: Optional[np.ndarray] = None) -> Circuit:
         """Returns a circuit represention of the ansatz.

--- a/src/python/zquantum/core/typing.py
+++ b/src/python/zquantum/core/typing.py
@@ -1,6 +1,7 @@
 """Types commonly encountered in zquantum repositories."""
+from abc import abstractmethod
 from os import PathLike
-from typing import Callable, Dict, Union
+from typing import Any, Callable, Dict, Union
 
 from typing_extensions import Protocol
 
@@ -33,3 +34,8 @@ Specs = Union[str, Dict]
 
 AnyRecorder = Union[SimpleRecorder, ArtifactRecorder]
 RecorderFactory = Callable[[Callable], AnyRecorder]
+
+
+class SupportsLassThan(Protocol):
+    def __lt__(self, other: Any) -> bool:
+        pass

--- a/src/python/zquantum/core/typing.py
+++ b/src/python/zquantum/core/typing.py
@@ -38,4 +38,4 @@ RecorderFactory = Callable[[Callable], AnyRecorder]
 
 class SupportsLessThan(Protocol):
     def __lt__(self, other: Any) -> bool:
-        ...
+        """Return result of comparison self < other."""

--- a/src/python/zquantum/core/typing.py
+++ b/src/python/zquantum/core/typing.py
@@ -38,4 +38,4 @@ RecorderFactory = Callable[[Callable], AnyRecorder]
 
 class SupportsLessThan(Protocol):
     def __lt__(self, other: Any) -> bool:
-        pass
+        ...

--- a/src/python/zquantum/core/typing.py
+++ b/src/python/zquantum/core/typing.py
@@ -36,6 +36,6 @@ AnyRecorder = Union[SimpleRecorder, ArtifactRecorder]
 RecorderFactory = Callable[[Callable], AnyRecorder]
 
 
-class SupportsLassThan(Protocol):
+class SupportsLessThan(Protocol):
     def __lt__(self, other: Any) -> bool:
         pass


### PR DESCRIPTION
This redefines mechanisms governing how free symbols are ordered in cost functions. The summary of changes is as follows:

- Ansatzes should declare their `symbols_sort_key` defining natural ordering of their free symbols. This ordering is taken into account when using `Ansatz.get_executable_circuit` method. if `s1,...,sN` are all of the ansatz free symbols and `get_execeutable_circuit` is called with N-dimensional `parameters` vector, then binding `parameters[i] -> sorted([s1, ..., sN, key=symbols_sort_key)[i]` occurs.
- The default `symbols_sort_key` is `str(symbol)`, which is identical with the current behavior.
- Cost function factories relying on estimation tasks that don't use ansatz also get separate `symbols_sort_key`  parameter with precisely the same semantics.