### PR TITLE
Bugfix/dexter2206/zqs 770 add symbol ordering with fixed names order

### DIFF
--- a/src/python/zquantum/core/circuits/symbolic/__init__.py
+++ b/src/python/zquantum/core/circuits/symbolic/__init__.py
@@ -1,1 +1,1 @@
-from ._sorting import natural_key, natural_key_revlex
+from ._sorting import natural_key, natural_key_fixed_names_order, natural_key_revlex

--- a/src/python/zquantum/core/circuits/symbolic/_sorting.py
+++ b/src/python/zquantum/core/circuits/symbolic/_sorting.py
@@ -45,6 +45,17 @@ def natural_key_revlex(symbol):
 
 
 def natural_key_fixed_names_order(names_order):
+    """Convert symbol to natural key but with custom ordering of names.
+
+    Consider a QAOA ansatz in which parameters are naturally ordered as:
+    gamma_0 < beta_0 < gamma_1 < beta_1 < ...
+
+    The above is an example of natural_key_fixed_names_order in which name 'gamma'
+    precedes name 'beta'.
+
+    Note that unlike natural_key and natural_key_revlex, this function returns
+    a key, i.e. it is a key factory.
+    """
     symbol_weights = {name: i for i, name in enumerate(names_order)}
 
     def _key(symbol):

--- a/src/python/zquantum/core/circuits/symbolic/_sorting.py
+++ b/src/python/zquantum/core/circuits/symbolic/_sorting.py
@@ -42,3 +42,13 @@ def natural_key_revlex(symbol):
     using natural_key_revlex will give beta_1 < theta_1 < beta_2 < theta_2.
     """
     return list(reversed(natural_key(symbol)))
+
+
+def natural_key_fixed_names_order(names_order):
+    symbol_weights = {name: i for i, name in enumerate(names_order)}
+
+    def _key(symbol):
+        name, index = symbol.name.split("_")
+        return int(index), symbol_weights[name]
+
+    return _key

--- a/tests/zquantum/core/circuits/symbolic/sorting_test.py
+++ b/tests/zquantum/core/circuits/symbolic/sorting_test.py
@@ -1,6 +1,7 @@
 import pytest
 import sympy
 from zquantum.core.circuits import natural_key, natural_key_revlex
+from zquantum.core.circuits.symbolic import natural_key_fixed_names_order
 
 
 @pytest.mark.parametrize(
@@ -43,3 +44,25 @@ def test_natural_key_revlex_orders_symbols_as_expected(
     assert sorted(unordered_symbols, key=natural_key_revlex) == list(
         expected_ordered_symbols
     )
+
+
+@pytest.mark.parametrize(
+    "names_order, unordered_symbols, expected_ordered_symbols",
+    [
+        (
+            ("gamma", "beta"),
+            sympy.symbols("beta_0, gamma_0, beta_3, gamma_3, beta_4"),
+            sympy.symbols("gamma_0, beta_0, gamma_3, beta_3, beta_4"),
+        ),
+        (
+            ("theta", "beta", "gamma"),
+            sympy.symbols("gamma_0, beta_0, theta_0, beta_1, theta_1, gamma_1"),
+            sympy.symbols("theta_0, beta_0, gamma_0, theta_1, beta_1, gamma_1"),
+        ),
+    ],
+)
+def test_natural_key_fixed_names_order_orders_symbols_ax_expected(
+    names_order, unordered_symbols, expected_ordered_symbols
+):
+    key = natural_key_fixed_names_order(names_order)
+    assert sorted(unordered_symbols, key=key) == list(expected_ordered_symbols)


### PR DESCRIPTION
This implements a variant of natural symbol ordering in which symbol names (without indices) are ordered in some custom fashion.

For instance, consider QAOA ansatz with symbols ordered as `gamma_0 < beta_0 < gamma_1 < beta_1 <....`.

This is an example of `natural_keys_fixed_names_order(["gamma", "beta"])` key. In other words, we compare indices first, and names second, but names are compared according to some user-defined ordering.