### PR TITLE
ZQS-770 Make natural_key_revlex a default

### DIFF
--- a/src/python/zquantum/core/interfaces/ansatz.py
+++ b/src/python/zquantum/core/interfaces/ansatz.py
@@ -6,7 +6,7 @@ import numpy as np
 import sympy
 from overrides import EnforceOverrides
 
-from ..circuits import Circuit
+from ..circuits import Circuit, natural_key_revlex
 from ..typing import SupportsLessThan
 from ..utils import create_symbols_map
 from .ansatz_utils import ansatz_property
@@ -93,7 +93,7 @@ class Ansatz(ABC, EnforceOverrides):
 
     @property
     def symbols_sort_key(self) -> SymbolsSortKey:
-        return str
+        return natural_key_revlex
 
     def _generate_circuit(self, params: Optional[np.ndarray] = None) -> Circuit:
         """Returns a circuit represention of the ansatz.


### PR DESCRIPTION
This makes `natural_key_revlex` a default key for sorting symbols in ansatz.

As a reminder, using the aforementioned key results in the following order (assuming ansatz has symbols `alpha_i, beta_j`:
`alpha_0 < beta_0 < alpha_1 < beta_1 < alpha_2 < beta_2 < alpha_3 < beta_3 < ...`.