### PR TITLE
ZQS-811 Fix deserialization for circuits with custom gates

### DIFF
--- a/src/python/zquantum/core/circuits/_serde.py
+++ b/src/python/zquantum/core/circuits/_serde.py
@@ -208,7 +208,7 @@ def _builtin_gate_from_dict(dict_) -> _builtin_gates.GateRef:
         return gate_ref(
             *[
                 deserialize_expr(param, dict_.get("free_symbols", []))
-                for param in dict_["params"]
+                for param in dict_.get("params", [])
             ]
         )
     else:
@@ -253,7 +253,7 @@ def _custom_gate_instance_from_dict(dict_, custom_gate_defs) -> _gates.Gate:
 
     symbol_names = map(serialize_expr, gate_def.params_ordering)
     return gate_def(
-        *[deserialize_expr(param, symbol_names) for param in dict_["params"]]
+        *[deserialize_expr(param, symbol_names) for param in dict_.get("params", [])]
     )
 
 

--- a/tests/zquantum/core/circuits/_serde_test.py
+++ b/tests/zquantum/core/circuits/_serde_test.py
@@ -34,6 +34,19 @@ CUSTOM_U_GATE = _gates.CustomGateDefinition(
 )
 
 
+# Based on ZQS-811 bug report
+CUSTOM_SGD_GATE = _gates.CustomGateDefinition(
+    gate_name="SGD",
+    matrix=sympy.Matrix(
+        [
+            [1.0, 0],
+            [0, -1.0j],
+        ]
+    ),
+    params_ordering=tuple(),
+)
+
+
 EXAMPLE_CIRCUITS = [
     _circuit.Circuit(),
     _circuit.Circuit([_builtin_gates.X(0)]),
@@ -56,6 +69,11 @@ EXAMPLE_CIRCUITS = [
             _builtin_gates.T(0),
             CUSTOM_U_GATE(1, -1)(3),
             CUSTOM_U_GATE(ALPHA, -1)(2),
+        ],
+    ),
+    _circuit.Circuit(
+        operations=[
+            CUSTOM_SGD_GATE()(3),
         ],
     ),
     _circuit.Circuit(


### PR DESCRIPTION
We had a bug in deserialization code for circuits with non-parametric custom gates. Up to this point our tests only covered circuits with parametric custom gates, but not non-parametric ones.