### PR TITLE
Feature/zqs 814/change bitstring convention to canonical

### DIFF
--- a/src/python/zquantum/core/interfaces/backend.py
+++ b/src/python/zquantum/core/interfaces/backend.py
@@ -184,4 +184,4 @@ def flip_amplitudes(amplitudes: np.ndarray) -> np.ndarray:
 
 
 def flip_wavefunction(wavefunction: Wavefunction):
-    return Wavefunction(flip_amplitudes(wavefunction))
+    return Wavefunction(flip_amplitudes(wavefunction.amplitudes))

--- a/src/python/zquantum/core/interfaces/backend.py
+++ b/src/python/zquantum/core/interfaces/backend.py
@@ -168,20 +168,3 @@ class QuantumSimulator(QuantumBackend):
             # Get the expectation values
             measurements = self.run_circuit_and_measure(circuit, n_samples)
             return measurements.get_distribution()
-
-
-def _flip_bits(n, num_bits):
-    return int(bin(n)[2:].zfill(num_bits)[::-1], 2)
-
-
-def flip_amplitudes(amplitudes: np.ndarray) -> np.ndarray:
-    number_of_states = len(amplitudes)
-    ordering = [
-        _flip_bits(n, number_of_states.bit_length() - 1)
-        for n in range(number_of_states)
-    ]
-    return np.array([amplitudes[i] for i in ordering])
-
-
-def flip_wavefunction(wavefunction: Wavefunction):
-    return Wavefunction(flip_amplitudes(wavefunction.amplitudes))

--- a/src/python/zquantum/core/interfaces/backend.py
+++ b/src/python/zquantum/core/interfaces/backend.py
@@ -174,11 +174,14 @@ def _flip_bits(n, num_bits):
     return int(bin(n)[2:].zfill(num_bits)[::-1], 2)
 
 
-def flip_wavefunction(wavefunction: Wavefunction):
-    number_of_states = len(wavefunction.amplitudes)
+def flip_amplitudes(amplitudes: np.ndarray) -> np.ndarray:
+    number_of_states = len(amplitudes)
     ordering = [
         _flip_bits(n, number_of_states.bit_length() - 1)
         for n in range(number_of_states)
     ]
-    flipped_amplitudes = [wavefunction.amplitudes[i] for i in ordering]
-    return Wavefunction(np.array(flipped_amplitudes))
+    return np.array([amplitudes[i] for i in ordering])
+
+
+def flip_wavefunction(wavefunction: Wavefunction):
+    return Wavefunction(flip_amplitudes(wavefunction))

--- a/src/python/zquantum/core/openfermion/_utils.py
+++ b/src/python/zquantum/core/openfermion/_utils.py
@@ -24,6 +24,7 @@ from openfermion.transforms import freeze_orbitals, get_fermion_operator
 from ..circuits import Circuit, X, Y, Z
 from ..measurement import ExpectationValues
 from ..utils import ValueEstimate, bin2dec, dec2bin
+from ..wavefunction import Wavefunction
 
 
 def get_qubitop_from_matrix(operator: List[List]) -> QubitOperator:
@@ -295,16 +296,18 @@ def reverse_qubit_order(qubit_operator: QubitOperator, n_qubits: Optional[int] =
     return reversed_op
 
 
-def get_expectation_value(qubit_op, wavefunction, reverse_operator=True):
+def get_expectation_value(
+    qubit_op: QubitOperator, wavefunction: Wavefunction, reverse_operator: bool = False
+) -> complex:
     """Get the expectation value of a qubit operator with respect to a wavefunction.
     Args:
-        qubit_op (openfermion.ops.QubitOperator): the operator
+        qubit_op (): the operator
         wavefunction (zquantum.core.Wavefunction): the wavefunction
         reverse_operator (boolean): whether to reverse order of qubit operator
             before computing expectation value. This should be True if the convention
             of the basis states used for the wavefunction is the opposite of the one in
-            the qubit operator. This is the case, e.g. when the wavefunction comes from
-            our Wavefunction class.
+            the qubit operator. This is the case when the wavefunction uses
+            Rigetti convention (https://arxiv.org/abs/1711.02086) of ordering qubits.
     Returns:
         complex: the expectation value
     """

--- a/src/python/zquantum/core/openfermion/_utils.py
+++ b/src/python/zquantum/core/openfermion/_utils.py
@@ -301,15 +301,15 @@ def get_expectation_value(
 ) -> complex:
     """Get the expectation value of a qubit operator with respect to a wavefunction.
     Args:
-        qubit_op (): the operator
-        wavefunction (zquantum.core.Wavefunction): the wavefunction
-        reverse_operator (boolean): whether to reverse order of qubit operator
+        qubit_op: the operator
+        wavefunction: the wavefunction
+        reverse_operator: whether to reverse order of qubit operator
             before computing expectation value. This should be True if the convention
             of the basis states used for the wavefunction is the opposite of the one in
             the qubit operator. This is the case when the wavefunction uses
             Rigetti convention (https://arxiv.org/abs/1711.02086) of ordering qubits.
     Returns:
-        complex: the expectation value
+        the expectation value
     """
     n_qubits = wavefunction.amplitudes.shape[0].bit_length() - 1
 

--- a/src/python/zquantum/core/symbolic_simulator.py
+++ b/src/python/zquantum/core/symbolic_simulator.py
@@ -53,4 +53,4 @@ class SymbolicSimulator(QuantumSimulator):
         for operation in circuit.operations:
             state = operation.apply(state)
 
-        return flip_wavefunction(Wavefunction(state))
+        return Wavefunction(state)

--- a/src/python/zquantum/core/symbolic_simulator.py
+++ b/src/python/zquantum/core/symbolic_simulator.py
@@ -4,9 +4,9 @@ import numpy as np
 from sympy import Symbol
 from zquantum.core.circuits import Circuit
 from zquantum.core.circuits.layouts import CircuitConnectivity
-from zquantum.core.interfaces.backend import QuantumSimulator, flip_wavefunction
+from zquantum.core.interfaces.backend import QuantumSimulator
 from zquantum.core.measurement import Measurements, sample_from_wavefunction
-from zquantum.core.wavefunction import Wavefunction
+from zquantum.core.wavefunction import Wavefunction, flip_wavefunction
 
 
 class SymbolicSimulator(QuantumSimulator):

--- a/src/python/zquantum/core/testing/generate_cases_for_backend_tests.py
+++ b/src/python/zquantum/core/testing/generate_cases_for_backend_tests.py
@@ -28,15 +28,15 @@ SWAP = sympy.Matrix([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
 ISWAP = sympy.Matrix([[1, 0, 0, 0], [0, 0, 1j, 0], [0, 1j, 0, 0], [0, 0, 0, 1]])
 
 II = TensorProduct(I, I)
-IH = TensorProduct(H, I)
-HI = TensorProduct(I, H)
+IH = TensorProduct(I, H)
+HI = TensorProduct(H, I)
 
 HH = TensorProduct(H, H)
 XX = TensorProduct(X, X)
 YY = TensorProduct(Y, Y)
 ZZ = TensorProduct(Z, Z)
-IX = TensorProduct(X, I)
-ZI = TensorProduct(I, Z)
+IX = TensorProduct(I, X)
+ZI = TensorProduct(Z, I)
 
 single_qubit_initial_states = [(I, "I"), (H, "H")]
 single_qubit_operators = [I, X, Y, Z]

--- a/src/python/zquantum/core/testing/test_cases_for_backend_tests.py
+++ b/src/python/zquantum/core/testing/test_cases_for_backend_tests.py
@@ -163,7 +163,6 @@ one_qubit_parametric_gates_exp_vals_test_set = [
     ["H", "RH", [np.pi], [1.00000000000000, 0, 0, 1.00000000000000]],
 ]
 
-
 two_qubit_non_parametric_gates_exp_vals_test_set = [
     [
         ["I", "I"],
@@ -2017,20 +2016,20 @@ one_qubit_parametric_gates_amplitudes_test_set = [
 
 two_qubit_non_parametric_gates_amplitudes_test_set = [
     [["I", "I"], "CNOT", [1.0, 0.0, 0.0, 0.0]],
-    [["I", "X"], "CNOT", [0.0, 0.0, 1.0, 0.0]],
+    [["I", "X"], "CNOT", [0.0, 1.0, 0.0, 0.0]],
     [["X", "I"], "CNOT", [0.0, 0.0, 0.0, 1.0]],
-    [["X", "X"], "CNOT", [0.0, 1.0, 0.0, 0.0]],
+    [["X", "X"], "CNOT", [0.0, 0.0, 1.0, 0.0]],
     [["I", "I"], "SWAP", [1.0, 0.0, 0.0, 0.0]],
-    [["I", "X"], "SWAP", [0.0, 1.0, 0.0, 0.0]],
-    [["X", "I"], "SWAP", [0.0, 0.0, 1.0, 0.0]],
+    [["I", "X"], "SWAP", [0.0, 0.0, 1.0, 0.0]],
+    [["X", "I"], "SWAP", [0.0, 1.0, 0.0, 0.0]],
     [["X", "X"], "SWAP", [0.0, 0.0, 0.0, 1.0]],
     [["I", "I"], "ISWAP", [1.0, 0.0, 0.0, 0.0]],
-    [["I", "X"], "ISWAP", [0.0, 1.0j, 0.0, 0.0]],
-    [["X", "I"], "ISWAP", [0.0, 0.0, 1.0j, 0.0]],
+    [["I", "X"], "ISWAP", [0.0, 0.0, 1.0j, 0.0]],
+    [["X", "I"], "ISWAP", [0.0, 1.0j, 0.0, 0.0]],
     [["X", "X"], "ISWAP", [0.0, 0.0, 0.0, 1.0]],
     [["I", "I"], "CZ", [1.0, 0.0, 0.0, 0.0]],
-    [["I", "X"], "CZ", [0.0, 0.0, 1.0, 0.0]],
-    [["X", "I"], "CZ", [0.0, 1.0, 0.0, 0.0]],
+    [["I", "X"], "CZ", [0.0, 1.0, 0.0, 0.0]],
+    [["X", "I"], "CZ", [0.0, 0.0, 1.0, 0.0]],
     [["X", "X"], "CZ", [0.0, 0.0, 0.0, -1.0]],
 ]
 
@@ -2040,16 +2039,16 @@ two_qubit_parametric_gates_amplitudes_test_set = [
     [["I", "I"], "CPHASE", [np.pi / 5], [1, 0, 0, 0]],
     [["I", "I"], "CPHASE", [np.pi / 2], [1, 0, 0, 0]],
     [["I", "I"], "CPHASE", [np.pi], [1, 0, 0, 0]],
-    [["I", "H"], "CPHASE", [-np.pi / 2], [np.sqrt(2) / 2, 0, np.sqrt(2) / 2, 0]],
-    [["I", "H"], "CPHASE", [0], [np.sqrt(2) / 2, 0, np.sqrt(2) / 2, 0]],
-    [["I", "H"], "CPHASE", [np.pi / 5], [np.sqrt(2) / 2, 0, np.sqrt(2) / 2, 0]],
-    [["I", "H"], "CPHASE", [np.pi / 2], [np.sqrt(2) / 2, 0, np.sqrt(2) / 2, 0]],
-    [["I", "H"], "CPHASE", [np.pi], [np.sqrt(2) / 2, 0, np.sqrt(2) / 2, 0]],
-    [["H", "I"], "CPHASE", [-np.pi / 2], [np.sqrt(2) / 2, np.sqrt(2) / 2, 0, 0]],
-    [["H", "I"], "CPHASE", [0], [np.sqrt(2) / 2, np.sqrt(2) / 2, 0, 0]],
-    [["H", "I"], "CPHASE", [np.pi / 5], [np.sqrt(2) / 2, np.sqrt(2) / 2, 0, 0]],
-    [["H", "I"], "CPHASE", [np.pi / 2], [np.sqrt(2) / 2, np.sqrt(2) / 2, 0, 0]],
-    [["H", "I"], "CPHASE", [np.pi], [np.sqrt(2) / 2, np.sqrt(2) / 2, 0, 0]],
+    [["I", "H"], "CPHASE", [-np.pi / 2], [np.sqrt(2) / 2, np.sqrt(2) / 2, 0, 0]],
+    [["I", "H"], "CPHASE", [0], [np.sqrt(2) / 2, np.sqrt(2) / 2, 0, 0]],
+    [["I", "H"], "CPHASE", [np.pi / 5], [np.sqrt(2) / 2, np.sqrt(2) / 2, 0, 0]],
+    [["I", "H"], "CPHASE", [np.pi / 2], [np.sqrt(2) / 2, np.sqrt(2) / 2, 0, 0]],
+    [["I", "H"], "CPHASE", [np.pi], [np.sqrt(2) / 2, np.sqrt(2) / 2, 0, 0]],
+    [["H", "I"], "CPHASE", [-np.pi / 2], [np.sqrt(2) / 2, 0, np.sqrt(2) / 2, 0]],
+    [["H", "I"], "CPHASE", [0], [np.sqrt(2) / 2, 0, np.sqrt(2) / 2, 0]],
+    [["H", "I"], "CPHASE", [np.pi / 5], [np.sqrt(2) / 2, 0, np.sqrt(2) / 2, 0]],
+    [["H", "I"], "CPHASE", [np.pi / 2], [np.sqrt(2) / 2, 0, np.sqrt(2) / 2, 0]],
+    [["H", "I"], "CPHASE", [np.pi], [np.sqrt(2) / 2, 0, np.sqrt(2) / 2, 0]],
     [["H", "H"], "CPHASE", [-np.pi / 2], [1 / 2, 1 / 2, 1 / 2, -0.5 * 1.0j]],
     [["H", "H"], "CPHASE", [0], [1 / 2, 1 / 2, 1 / 2, 1 / 2]],
     [
@@ -2075,30 +2074,10 @@ two_qubit_parametric_gates_amplitudes_test_set = [
     ],
     [["I", "I"], "XX", [np.pi / 2], [np.sqrt(2) / 2, 0, 0, -0.5 * np.sqrt(2) * 1.0j]],
     [["I", "I"], "XX", [np.pi], [0, 0, 0, -1.0j]],
-    [["I", "H"], "XX", [-np.pi / 2], [1 / 2, 0.5 * 1.0j, 1 / 2, 0.5 * 1.0j]],
-    [["I", "H"], "XX", [0], [np.sqrt(2) / 2, 0, np.sqrt(2) / 2, 0]],
+    [["I", "H"], "XX", [-np.pi / 2], [1 / 2, 1 / 2, 0.5 * 1.0j, 0.5 * 1.0j]],
+    [["I", "H"], "XX", [0], [np.sqrt(2) / 2, np.sqrt(2) / 2, 0, 0]],
     [
         ["I", "H"],
-        "XX",
-        [np.pi / 5],
-        [
-            np.sqrt(2) * np.sqrt(np.sqrt(5) / 8 + 5 / 8) / 2,
-            -0.5 * np.sqrt(2) * 1.0j * (-1 / 4 + np.sqrt(5) / 4),
-            np.sqrt(2) * np.sqrt(np.sqrt(5) / 8 + 5 / 8) / 2,
-            -0.5 * np.sqrt(2) * 1.0j * (-1 / 4 + np.sqrt(5) / 4),
-        ],
-    ],
-    [["I", "H"], "XX", [np.pi / 2], [1 / 2, -0.5 * 1.0j, 1 / 2, -0.5 * 1.0j]],
-    [
-        ["I", "H"],
-        "XX",
-        [np.pi],
-        [0, -0.5 * np.sqrt(2) * 1.0j, 0, -0.5 * np.sqrt(2) * 1.0j],
-    ],
-    [["H", "I"], "XX", [-np.pi / 2], [1 / 2, 1 / 2, 0.5 * 1.0j, 0.5 * 1.0j]],
-    [["H", "I"], "XX", [0], [np.sqrt(2) / 2, np.sqrt(2) / 2, 0, 0]],
-    [
-        ["H", "I"],
         "XX",
         [np.pi / 5],
         [
@@ -2108,12 +2087,32 @@ two_qubit_parametric_gates_amplitudes_test_set = [
             -0.5 * np.sqrt(2) * 1.0j * (-1 / 4 + np.sqrt(5) / 4),
         ],
     ],
-    [["H", "I"], "XX", [np.pi / 2], [1 / 2, 1 / 2, -0.5 * 1.0j, -0.5 * 1.0j]],
+    [["I", "H"], "XX", [np.pi / 2], [1 / 2, 1 / 2, -0.5 * 1.0j, -0.5 * 1.0j]],
     [
-        ["H", "I"],
+        ["I", "H"],
         "XX",
         [np.pi],
         [0, 0, -0.5 * np.sqrt(2) * 1.0j, -0.5 * np.sqrt(2) * 1.0j],
+    ],
+    [["H", "I"], "XX", [-np.pi / 2], [1 / 2, 0.5 * 1.0j, 1 / 2, 0.5 * 1.0j]],
+    [["H", "I"], "XX", [0], [np.sqrt(2) / 2, 0, np.sqrt(2) / 2, 0]],
+    [
+        ["H", "I"],
+        "XX",
+        [np.pi / 5],
+        [
+            np.sqrt(2) * np.sqrt(np.sqrt(5) / 8 + 5 / 8) / 2,
+            -0.5 * np.sqrt(2) * 1.0j * (-1 / 4 + np.sqrt(5) / 4),
+            np.sqrt(2) * np.sqrt(np.sqrt(5) / 8 + 5 / 8) / 2,
+            -0.5 * np.sqrt(2) * 1.0j * (-1 / 4 + np.sqrt(5) / 4),
+        ],
+    ],
+    [["H", "I"], "XX", [np.pi / 2], [1 / 2, -0.5 * 1.0j, 1 / 2, -0.5 * 1.0j]],
+    [
+        ["H", "I"],
+        "XX",
+        [np.pi],
+        [0, -0.5 * np.sqrt(2) * 1.0j, 0, -0.5 * np.sqrt(2) * 1.0j],
     ],
     [
         ["H", "H"],
@@ -2164,30 +2163,10 @@ two_qubit_parametric_gates_amplitudes_test_set = [
     ],
     [["I", "I"], "YY", [np.pi / 2], [np.sqrt(2) / 2, 0, 0, 0.5 * np.sqrt(2) * 1.0j]],
     [["I", "I"], "YY", [np.pi], [0, 0, 0, 1.0j]],
-    [["I", "H"], "YY", [-np.pi / 2], [1 / 2, 0.5 * 1.0j, 1 / 2, -0.5 * 1.0j]],
-    [["I", "H"], "YY", [0], [np.sqrt(2) / 2, 0, np.sqrt(2) / 2, 0]],
+    [["I", "H"], "YY", [-np.pi / 2], [1 / 2, 1 / 2, 0.5 * 1.0j, -0.5 * 1.0j]],
+    [["I", "H"], "YY", [0], [np.sqrt(2) / 2, np.sqrt(2) / 2, 0, 0]],
     [
         ["I", "H"],
-        "YY",
-        [np.pi / 5],
-        [
-            np.sqrt(2) * np.sqrt(np.sqrt(5) / 8 + 5 / 8) / 2,
-            -0.5 * np.sqrt(2) * 1.0j * (-1 / 4 + np.sqrt(5) / 4),
-            np.sqrt(2) * np.sqrt(np.sqrt(5) / 8 + 5 / 8) / 2,
-            0.5 * np.sqrt(2) * 1.0j * (-1 / 4 + np.sqrt(5) / 4),
-        ],
-    ],
-    [["I", "H"], "YY", [np.pi / 2], [1 / 2, -0.5 * 1.0j, 1 / 2, 0.5 * 1.0j]],
-    [
-        ["I", "H"],
-        "YY",
-        [np.pi],
-        [0, -0.5 * np.sqrt(2) * 1.0j, 0, 0.5 * np.sqrt(2) * 1.0j],
-    ],
-    [["H", "I"], "YY", [-np.pi / 2], [1 / 2, 1 / 2, 0.5 * 1.0j, -0.5 * 1.0j]],
-    [["H", "I"], "YY", [0], [np.sqrt(2) / 2, np.sqrt(2) / 2, 0, 0]],
-    [
-        ["H", "I"],
         "YY",
         [np.pi / 5],
         [
@@ -2197,12 +2176,32 @@ two_qubit_parametric_gates_amplitudes_test_set = [
             0.5 * np.sqrt(2) * 1.0j * (-1 / 4 + np.sqrt(5) / 4),
         ],
     ],
-    [["H", "I"], "YY", [np.pi / 2], [1 / 2, 1 / 2, -0.5 * 1.0j, 0.5 * 1.0j]],
+    [["I", "H"], "YY", [np.pi / 2], [1 / 2, 1 / 2, -0.5 * 1.0j, 0.5 * 1.0j]],
     [
-        ["H", "I"],
+        ["I", "H"],
         "YY",
         [np.pi],
         [0, 0, -0.5 * np.sqrt(2) * 1.0j, 0.5 * np.sqrt(2) * 1.0j],
+    ],
+    [["H", "I"], "YY", [-np.pi / 2], [1 / 2, 0.5 * 1.0j, 1 / 2, -0.5 * 1.0j]],
+    [["H", "I"], "YY", [0], [np.sqrt(2) / 2, 0, np.sqrt(2) / 2, 0]],
+    [
+        ["H", "I"],
+        "YY",
+        [np.pi / 5],
+        [
+            np.sqrt(2) * np.sqrt(np.sqrt(5) / 8 + 5 / 8) / 2,
+            -0.5 * np.sqrt(2) * 1.0j * (-1 / 4 + np.sqrt(5) / 4),
+            np.sqrt(2) * np.sqrt(np.sqrt(5) / 8 + 5 / 8) / 2,
+            0.5 * np.sqrt(2) * 1.0j * (-1 / 4 + np.sqrt(5) / 4),
+        ],
+    ],
+    [["H", "I"], "YY", [np.pi / 2], [1 / 2, -0.5 * 1.0j, 1 / 2, 0.5 * 1.0j]],
+    [
+        ["H", "I"],
+        "YY",
+        [np.pi],
+        [0, -0.5 * np.sqrt(2) * 1.0j, 0, 0.5 * np.sqrt(2) * 1.0j],
     ],
     [
         ["H", "H"],
@@ -2269,12 +2268,12 @@ two_qubit_parametric_gates_amplitudes_test_set = [
         [-np.pi / 2],
         [
             np.sqrt(2) * (np.sqrt(2) / 2 + 0.5 * np.sqrt(2) * 1.0j) / 2,
-            0,
             np.sqrt(2) * (np.sqrt(2) / 2 - 0.5 * np.sqrt(2) * 1.0j) / 2,
+            0,
             0,
         ],
     ],
-    [["I", "H"], "ZZ", [0], [np.sqrt(2) / 2, 0, np.sqrt(2) / 2, 0]],
+    [["I", "H"], "ZZ", [0], [np.sqrt(2) / 2, np.sqrt(2) / 2, 0, 0]],
     [
         ["I", "H"],
         "ZZ",
@@ -2283,10 +2282,10 @@ two_qubit_parametric_gates_amplitudes_test_set = [
             np.sqrt(2)
             * (np.sqrt(np.sqrt(5) / 8 + 5 / 8) - 1.0j * (-1 / 4 + np.sqrt(5) / 4))
             / 2,
-            0,
             np.sqrt(2)
             * (np.sqrt(np.sqrt(5) / 8 + 5 / 8) + 1.0j * (-1 / 4 + np.sqrt(5) / 4))
             / 2,
+            0,
             0,
         ],
     ],
@@ -2296,8 +2295,8 @@ two_qubit_parametric_gates_amplitudes_test_set = [
         [np.pi / 2],
         [
             np.sqrt(2) * (np.sqrt(2) / 2 - 0.5 * np.sqrt(2) * 1.0j) / 2,
-            0,
             np.sqrt(2) * (np.sqrt(2) / 2 + 0.5 * np.sqrt(2) * 1.0j) / 2,
+            0,
             0,
         ],
     ],
@@ -2305,7 +2304,7 @@ two_qubit_parametric_gates_amplitudes_test_set = [
         ["I", "H"],
         "ZZ",
         [np.pi],
-        [-0.5 * np.sqrt(2) * 1.0j, 0, 0.5 * np.sqrt(2) * 1.0j, 0],
+        [-0.5 * np.sqrt(2) * 1.0j, 0.5 * np.sqrt(2) * 1.0j, 0, 0],
     ],
     [
         ["H", "I"],
@@ -2313,12 +2312,12 @@ two_qubit_parametric_gates_amplitudes_test_set = [
         [-np.pi / 2],
         [
             np.sqrt(2) * (np.sqrt(2) / 2 + 0.5 * np.sqrt(2) * 1.0j) / 2,
-            np.sqrt(2) * (np.sqrt(2) / 2 - 0.5 * np.sqrt(2) * 1.0j) / 2,
             0,
+            np.sqrt(2) * (np.sqrt(2) / 2 - 0.5 * np.sqrt(2) * 1.0j) / 2,
             0,
         ],
     ],
-    [["H", "I"], "ZZ", [0], [np.sqrt(2) / 2, np.sqrt(2) / 2, 0, 0]],
+    [["H", "I"], "ZZ", [0], [np.sqrt(2) / 2, 0, np.sqrt(2) / 2, 0]],
     [
         ["H", "I"],
         "ZZ",
@@ -2327,10 +2326,10 @@ two_qubit_parametric_gates_amplitudes_test_set = [
             np.sqrt(2)
             * (np.sqrt(np.sqrt(5) / 8 + 5 / 8) - 1.0j * (-1 / 4 + np.sqrt(5) / 4))
             / 2,
+            0,
             np.sqrt(2)
             * (np.sqrt(np.sqrt(5) / 8 + 5 / 8) + 1.0j * (-1 / 4 + np.sqrt(5) / 4))
             / 2,
-            0,
             0,
         ],
     ],
@@ -2340,8 +2339,8 @@ two_qubit_parametric_gates_amplitudes_test_set = [
         [np.pi / 2],
         [
             np.sqrt(2) * (np.sqrt(2) / 2 - 0.5 * np.sqrt(2) * 1.0j) / 2,
-            np.sqrt(2) * (np.sqrt(2) / 2 + 0.5 * np.sqrt(2) * 1.0j) / 2,
             0,
+            np.sqrt(2) * (np.sqrt(2) / 2 + 0.5 * np.sqrt(2) * 1.0j) / 2,
             0,
         ],
     ],
@@ -2349,7 +2348,7 @@ two_qubit_parametric_gates_amplitudes_test_set = [
         ["H", "I"],
         "ZZ",
         [np.pi],
-        [-0.5 * np.sqrt(2) * 1.0j, 0.5 * np.sqrt(2) * 1.0j, 0, 0],
+        [-0.5 * np.sqrt(2) * 1.0j, 0, 0.5 * np.sqrt(2) * 1.0j, 0],
     ],
     [
         ["H", "H"],
@@ -2395,36 +2394,36 @@ two_qubit_parametric_gates_amplitudes_test_set = [
     [["I", "I"], "XY", [np.pi / 5], [1, 0, 0, 0]],
     [["I", "I"], "XY", [np.pi / 2], [1, 0, 0, 0]],
     [["I", "I"], "XY", [np.pi], [1, 0, 0, 0]],
-    [["I", "H"], "XY", [-np.pi / 2], [np.sqrt(2) / 2, -0.5 * 1.0j, 1 / 2, 0]],
-    [["I", "H"], "XY", [0], [np.sqrt(2) / 2, 0, np.sqrt(2) / 2, 0]],
+    [["I", "H"], "XY", [-np.pi / 2], [np.sqrt(2) / 2, 1 / 2, -0.5 * 1.0j, 0]],
+    [["I", "H"], "XY", [0], [np.sqrt(2) / 2, np.sqrt(2) / 2, 0, 0]],
     [
         ["I", "H"],
         "XY",
         [np.pi / 5],
         [
             np.sqrt(2) / 2,
-            0.5 * np.sqrt(2) * 1.0j * (-1 / 4 + np.sqrt(5) / 4),
             np.sqrt(2) * np.sqrt(np.sqrt(5) / 8 + 5 / 8) / 2,
+            0.5 * np.sqrt(2) * 1.0j * (-1 / 4 + np.sqrt(5) / 4),
             0,
         ],
     ],
-    [["I", "H"], "XY", [np.pi / 2], [np.sqrt(2) / 2, 0.5 * 1.0j, 1 / 2, 0]],
-    [["I", "H"], "XY", [np.pi], [np.sqrt(2) / 2, 0.5 * np.sqrt(2) * 1.0j, 0, 0]],
-    [["H", "I"], "XY", [-np.pi / 2], [np.sqrt(2) / 2, 1 / 2, -0.5 * 1.0j, 0]],
-    [["H", "I"], "XY", [0], [np.sqrt(2) / 2, np.sqrt(2) / 2, 0, 0]],
+    [["I", "H"], "XY", [np.pi / 2], [np.sqrt(2) / 2, 1 / 2, 0.5 * 1.0j, 0]],
+    [["I", "H"], "XY", [np.pi], [np.sqrt(2) / 2, 0, 0.5 * np.sqrt(2) * 1.0j, 0]],
+    [["H", "I"], "XY", [-np.pi / 2], [np.sqrt(2) / 2, -0.5 * 1.0j, 1 / 2, 0]],
+    [["H", "I"], "XY", [0], [np.sqrt(2) / 2, 0, np.sqrt(2) / 2, 0]],
     [
         ["H", "I"],
         "XY",
         [np.pi / 5],
         [
             np.sqrt(2) / 2,
-            np.sqrt(2) * np.sqrt(np.sqrt(5) / 8 + 5 / 8) / 2,
             0.5 * np.sqrt(2) * 1.0j * (-1 / 4 + np.sqrt(5) / 4),
+            np.sqrt(2) * np.sqrt(np.sqrt(5) / 8 + 5 / 8) / 2,
             0,
         ],
     ],
-    [["H", "I"], "XY", [np.pi / 2], [np.sqrt(2) / 2, 1 / 2, 0.5 * 1.0j, 0]],
-    [["H", "I"], "XY", [np.pi], [np.sqrt(2) / 2, 0, 0.5 * np.sqrt(2) * 1.0j, 0]],
+    [["H", "I"], "XY", [np.pi / 2], [np.sqrt(2) / 2, 0.5 * 1.0j, 1 / 2, 0]],
+    [["H", "I"], "XY", [np.pi], [np.sqrt(2) / 2, 0.5 * np.sqrt(2) * 1.0j, 0, 0]],
     [
         ["H", "H"],
         "XY",

--- a/src/python/zquantum/core/wavefunction.py
+++ b/src/python/zquantum/core/wavefunction.py
@@ -154,3 +154,20 @@ class Wavefunction:
         probs = self.probabilities()
 
         return dict(zip(values, probs))
+
+
+def flip_wavefunction(wavefunction: Wavefunction):
+    return Wavefunction(flip_amplitudes(wavefunction.amplitudes))
+
+
+def flip_amplitudes(amplitudes: np.ndarray) -> np.ndarray:
+    number_of_states = len(amplitudes)
+    ordering = [
+        _flip_bits(n, number_of_states.bit_length() - 1)
+        for n in range(number_of_states)
+    ]
+    return np.array([amplitudes[i] for i in ordering])
+
+
+def _flip_bits(n, num_bits):
+    return int(bin(n)[2:].zfill(num_bits)[::-1], 2)

--- a/src/python/zquantum/core/wavefunction.py
+++ b/src/python/zquantum/core/wavefunction.py
@@ -147,7 +147,9 @@ class Wavefunction:
         return np.array([abs(elem) ** 2 for elem in self._amplitude_vector])
 
     def get_outcome_probs(self) -> Dict[str, float]:
-        values = [format(i, "0" + str(self.n_qubits) + "b") for i in range(len(self))]
+        values = [
+            format(i, "0" + str(self.n_qubits) + "b")[::-1] for i in range(len(self))
+        ]
 
         probs = self.probabilities()
 

--- a/tests/zquantum/core/interfaces/backend_utils_test.py
+++ b/tests/zquantum/core/interfaces/backend_utils_test.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
-from zquantum.core.interfaces.backend import flip_wavefunction
-from zquantum.core.wavefunction import Wavefunction
+from zquantum.core.wavefunction import Wavefunction, flip_wavefunction
 
 
 @pytest.mark.parametrize(

--- a/tests/zquantum/core/measurement_test.py
+++ b/tests/zquantum/core/measurement_test.py
@@ -109,9 +109,6 @@ def test_sample_from_wavefunction():
         bitstring = format(num, "b")
         while len(bitstring) < wavefunction.n_qubits:
             bitstring = "0" + bitstring
-        # NOTE: our indexing places the state of qubit i at the ith index of the tuple.
-        # Hence |01> will result in the tuple (1, 0)
-        bitstring = bitstring[::-1]
         measurement = convert_bitstrings_to_tuples([bitstring])[0]
         sampled_probabilities.append(sampled_dict[measurement] / 10000)
 
@@ -122,9 +119,7 @@ def test_sample_from_wavefunction():
 
 def test_sample_from_wavefunction_column_vector():
     n_qubits = 4
-    # NOTE: our indexing places the state of qubit i at the ith index of the tuple.
-    # Hence |01> will result in the tuple (1, 0)
-    expected_bitstring = (1, 0, 0, 0)
+    expected_bitstring = (0, 0, 0, 1)
     amplitudes = np.array([0] * (2 ** n_qubits)).reshape(2 ** n_qubits, 1)
     amplitudes[1] = 1  # |0001> will be measured in all cases.
     wavefunction = Wavefunction(amplitudes)
@@ -135,9 +130,7 @@ def test_sample_from_wavefunction_column_vector():
 
 def test_sample_from_wavefunction_row_vector():
     n_qubits = 4
-    # NOTE: our indexing places the state of qubit i at the ith index of the tuple.
-    # Hence |01> will result in the tuple (1, 0)
-    expected_bitstring = (1, 0, 0, 0)
+    expected_bitstring = (0, 0, 0, 1)
     amplitudes = np.array([0] * (2 ** n_qubits))
     amplitudes[1] = 1  # |0001> will be measured in all cases.
     wavefunction = Wavefunction(amplitudes)
@@ -148,9 +141,7 @@ def test_sample_from_wavefunction_row_vector():
 
 def test_sample_from_wavefunction_list():
     n_qubits = 4
-    # NOTE: our indexing places the state of qubit i at the ith index of the tuple.
-    # Hence |01> will result in the tuple (1, 0)
-    expected_bitstring = (1, 0, 0, 0)
+    expected_bitstring = (0, 0, 0, 1)
     amplitudes = [0] * (2 ** n_qubits)
     amplitudes[1] = 1  # |0001> will be measured in all cases.
     wavefunction = Wavefunction(amplitudes)
@@ -163,7 +154,7 @@ def test_sample_from_wavefunction_list():
 def test_sample_from_wavefunction_fails_for_invalid_n_samples(n_samples):
     n_qubits = 4
     amplitudes = [0] * (2 ** n_qubits)
-    amplitudes[1] = 1  # |0001> will be measured in all cases.
+    amplitudes[1] = 1
     wavefunction = Wavefunction(amplitudes)
     with pytest.raises(AssertionError):
         sample_from_wavefunction(wavefunction, n_samples)

--- a/tests/zquantum/core/openfermion_tests/_utils_test.py
+++ b/tests/zquantum/core/openfermion_tests/_utils_test.py
@@ -144,8 +144,8 @@ class TestQubitOperator(unittest.TestCase):
         op1 = QubitOperator("Z0")
         op2 = QubitOperator("Z1")
         # When
-        exp_op1 = get_expectation_value(op1, wf)
-        exp_op2 = get_expectation_value(op2, wf)
+        exp_op1 = get_expectation_value(op1, wf, True)
+        exp_op2 = get_expectation_value(op2, wf, True)
 
         # Then
         self.assertAlmostEqual(-1, exp_op1)


### PR DESCRIPTION
This changes ordering of basis and bitstrings (a.k.a. bitstring convention) used by base simulators and backends to the "canonical" one. In this convention:

- i-th digit in bitstring corresponds to i-th qubit
- ordering of basis vectors follows ordering of bitstrings, that is e.g. for two qubits map from kets to vectors in `C^4` looks as follows:
  `|00> -> [1, 0, 0, 0]`, `|01> -> [0, 1, 0, 0]` , `|10> -> [0, 0, 1, 0]`, `|11> -> [0, 0, 0, 1]` 

Changelist:
- updated backend tests, simulator tests and script that generates them (only multiqubit cases needed change)
- added additional function for flipping wavefunction's amplitudes
- changed `get_expectation_value` from `QubitOperator` to not flip the wavefunction by default
- changed the ordering of bitstrings in `Wavefunction.get_outcome_probs`


This PR does not change the way the bitstrings are stored. Switch from strings to tuples will be implemented as a part of the next PR.