### PR TITLE
Fix bug in `run_circuit_and_measure` and speed up function execution

### DIFF
--- a/src/python/zquantum/core/symbolic_simulator.py
+++ b/src/python/zquantum/core/symbolic_simulator.py
@@ -36,10 +36,12 @@ class SymbolicSimulator(QuantumSimulator):
             circuit: the circuit to prepare the state
             n_samples: the number of bitstrings to sample
         """
-        wavefunction = self.get_wavefunction(circuit).bind(symbol_map=symbol_map)
+        wavefunction = self.get_wavefunction(circuit.bind(symbol_map))
 
-        if circuit.free_symbols:
-            raise ValueError("Cannot sample from circuit with symbolic parameters.")
+        if wavefunction.free_symbols:
+            raise ValueError(
+                "Cannot sample from wavefunction with symbolic parameters."
+            )
 
         bitstrings = sample_from_wavefunction(wavefunction, n_samples, self._seed)
         return Measurements(bitstrings)

--- a/tests/zquantum/core/symbolic_simulator_test.py
+++ b/tests/zquantum/core/symbolic_simulator_test.py
@@ -19,33 +19,49 @@ def wf_simulator() -> SymbolicSimulator:
 
 
 class TestSymbolicSimulator(QuantumSimulatorTests):
+    gates_list = [
+        circuits.XX(sympy.Symbol("theta"))(2, 1),
+        circuits.U3(
+            sympy.Symbol("alpha"),
+            sympy.Symbol("beta"),
+            sympy.Symbol("gamma"),
+        )(1),
+    ]
+    incorrect_bindings = [
+        {},
+        {
+            "alpha": sympy.pi,
+            "beta": sympy.pi,
+        },
+    ]
+    correct_bindings = [
+        dict(zip(gate.free_symbols, [sympy.pi] * len(gate.free_symbols)))
+        for gate in gates_list
+    ]
+
     @pytest.mark.parametrize(
-        "circuit_list, binding",
-        [
-            ([circuits.XX(sympy.Symbol("theta"))(2, 1)], {}),
-            (
-                [
-                    circuits.U3(
-                        sympy.Symbol("alpha"),
-                        sympy.Symbol("beta"),
-                        sympy.Symbol("gamma"),
-                    )(1)
-                ],
-                {
-                    "alpha": sympy.pi,
-                    "beta": sympy.pi,
-                },
-            ),
-        ],
+        "gate, binding",
+        list(zip(gates_list, incorrect_bindings)),
     )
     def test_cannot_sample_from_circuit_containing_free_symbols(
-        self, wf_simulator, circuit_list, binding
+        self, wf_simulator, gate, binding
     ):
-        circuit = circuits.Circuit(circuit_list)
+
+        circuit = circuits.Circuit([gate])
         with pytest.raises(ValueError):
             wf_simulator.run_circuit_and_measure(
                 circuit, n_samples=1000, symbol_map=binding
             )
+
+    @pytest.mark.parametrize(
+        "gate, binding",
+        list(zip(gates_list, correct_bindings)),
+    )
+    def test_passes_for_complete_bindings(self, wf_simulator, gate, binding):
+        circuit = circuits.Circuit([gate])
+        wf_simulator.run_circuit_and_measure(
+            circuit, n_samples=1000, symbol_map=binding
+        )
 
 
 class TestSymbolicSimulatorGates(QuantumSimulatorGatesTest):


### PR DESCRIPTION
There was a bug in the `run_circuit_and_measure` function of the SymbolicSimulator, which wasn't appearing in the tests, because positive tests weren't implemented for that function after it was integrated with our `Wavefunction` class. I fixed the bug and added the tests.

In addition, I improved the performance of the function significantly, by binding symbols' values to the circuit first, before retrieving the wavefunction. I did a simple quantitative test and this was the result:
- Run symbolic circuit then bind to wavefunction:
```python
170 ms ± 548 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
- Bind to symbolic circuit and then get wavefunction:
```python
12.9 ms ± 40.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
The test circuit was:
```python
circ = circuits.Circuit(
        [
            circuits.XX(sympy.Symbol("theta"))(0, 1),
            circuits.U3(
                sympy.Symbol("alpha"), sympy.Symbol("beta"), sympy.Symbol("gamma")
            )(2),
            circuits.XX(sympy.Symbol("mana"))(1, 2),
        ]
    )
```

This result matches our intuition since sympy calculations are relatively slower than those of numpy.