### PR TITLE
ZQS-848 Use latest openfermion from master branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setuptools.setup(
         "numpy>=1.20",
         "scipy>=1.4.1",
         "sympy>=1.5",
-        "openfermion @ git+https://github.com/quantumlib/OpenFermion",
+        "openfermion @ git+https://github.com/quantumlib/OpenFermion@7532ad9e6d34f6922537f00a5cc001047f2bfdd1",  # noqa: 501
         "lea>=3.2.0",
         "overrides~=3.1",
         "python-rapidjson",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setuptools.setup(
         "numpy>=1.20",
         "scipy>=1.4.1",
         "sympy>=1.5",
-        "openfermion>=1.0.0",
+        "openfermion @ git+https://github.com/quantumlib/OpenFermion",
         "lea>=3.2.0",
         "overrides~=3.1",
         "python-rapidjson",

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setuptools.setup(
         "numpy>=1.20",
         "scipy>=1.4.1",
         "sympy>=1.5",
+        # TODO: use openfermion from PyPI when 1.3 is released
         "openfermion @ git+https://github.com/quantumlib/OpenFermion@7532ad9e6d34f6922537f00a5cc001047f2bfdd1",  # noqa: 501
         "lea>=3.2.0",
         "overrides~=3.1",


### PR DESCRIPTION
This PR allows z-quantum-core to work with newest cirq (0.13+). At the time of submitting this, openfermion has a [fix](https://github.com/quantumlib/OpenFermion/pull/755) on `master`, but it wasn't released yet.

Let's revert this PR when a new openfermion is released.