### PR TITLE
check validity of bitstring against np.integer type not native int type

### DIFF
--- a/src/python/zquantum/core/distribution/_measurement_outcome_distribution.py
+++ b/src/python/zquantum/core/distribution/_measurement_outcome_distribution.py
@@ -140,7 +140,7 @@ def _are_keys_non_negative_integer_tuples(
         bool: boolean variable indicating whether dict keys are binary strings or not.
     """
     return all(
-        all(isinstance(sub, np.integer) and sub >= 0 for sub in key)
+        all(isinstance(sub, (int, np.integer)) and sub >= 0 for sub in key)
         for key in input_dict.keys()
     )
 

--- a/src/python/zquantum/core/distribution/_measurement_outcome_distribution.py
+++ b/src/python/zquantum/core/distribution/_measurement_outcome_distribution.py
@@ -140,7 +140,7 @@ def _are_keys_non_negative_integer_tuples(
         bool: boolean variable indicating whether dict keys are binary strings or not.
     """
     return all(
-        all(isinstance(sub, int) and sub >= 0 for sub in key)
+        all(isinstance(sub, np.integer) and sub >= 0 for sub in key)
         for key in input_dict.keys()
     )
 


### PR DESCRIPTION
If a bitstring is of type Tuple[np.int32, ...], the `is_measurement_outcome_distribution` check at initialization of `BitstringDistribution` will fail because `_are_keys_non_negative_integer_tuples` returns `False`. The reason is that `numpy.integer` instances are not instances of `int`.
See https://stackoverflow.com/a/37727662  