### PR TITLE
Bugfix/laurgao/add nit to mock optimizer output

### DIFF
--- a/src/python/zquantum/core/interfaces/mock_objects.py
+++ b/src/python/zquantum/core/interfaces/mock_objects.py
@@ -52,6 +52,7 @@ class MockOptimizer(Optimizer):
         return optimization_result(
             opt_value=cost_function(new_parameters),
             opt_params=new_parameters,
+            nit=1,
             nfev=1,
             **construct_history_info(cost_function, keep_history),
         )


### PR DESCRIPTION
`nit` is in the "mandatory optimizer result fields" specified in [optimizer tests](https://github.com/zapatacomputing/z-quantum-core/blob/main/src/python/zquantum/core/interfaces/optimizer_test.py#L19) but was not in the output of our mock optimizer object

Not a huge deal but it was breaking a couple of tests I was writing for a nested optimizer so I thought I'd fix it.