### PR TITLE
Fix/zqs 936/athena caesura/python3.9.7 compatibility 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import os
 import site
 import sys
 import warnings
+from platform import python_version
 
 import setuptools
 
@@ -43,6 +44,8 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Operating System :: OS Independent",
     ],
+    # Avoid bug in Protocol in python 3.9.7
+    python_version="!=3.9.7",
     install_requires=[
         "networkx==2.4",
         "numpy>=1.20",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Operating System :: OS Independent",
     ],
-    # Avoid bug in Protocol in python 3.9.7
+    # Avoid bug in Protocol in python 3.9.7. Note that higher and lower versions of Python are fine.
     python_version="!=3.9.7",
     install_requires=[
         "networkx==2.4",


### PR DESCRIPTION
Reject installs with python 3.9.7 to avoid bug with Protocol class.