### PR TITLE
Unpacking breaks for usual parameter vectors

### DIFF
--- a/src/python/zquantum/core/circuits/_generators.py
+++ b/src/python/zquantum/core/circuits/_generators.py
@@ -61,7 +61,7 @@ def apply_gate_to_qubits(
         assert len(parameters) == len(unique_qubit_idx)
         gate_factory = cast(GatePrototype, gate_factory)
         for qubit, parameter in zip(unique_qubit_idx, parameters):
-            circuit += gate_factory(*parameter)(qubit)
+            circuit += gate_factory(*np.atleast1d(parameter))(qubit)
     else:
         gate_factory = cast(Gate, gate_factory)
         for qubit in unique_qubit_idx:


### PR DESCRIPTION
By looping `for parameter in parameters`, `parameter` can be a float. The current implementation breaks the function.