### PR TITLE
bump z-quantum-julia to 1.7.2

### DIFF
--- a/docker/z-quantum-julia/Dockerfile
+++ b/docker/z-quantum-julia/Dockerfile
@@ -1,8 +1,8 @@
 # Dockerfile for the default OpenPack docker image
 FROM zapatacomputing/z-quantum-default:latest
 
-ARG JULIA_MINOR_VERSION=1.6
-ARG JULIA_PATCH_VERSION=1.6.0
+ARG JULIA_MINOR_VERSION=1.7
+ARG JULIA_PATCH_VERSION=1.7.2
 WORKDIR /root
 
 # get julia


### PR DESCRIPTION
We need to bump to julia 1.7 for some of @ghazivakili 's work. It hasn't been built in over a year so it's due for a refresh. I'm pretty sure a merge into main will trigger a rebuild in concourse