### PR TITLE
Bugfix parameter unpacking in gate_factory

### DIFF
--- a/src/python/zquantum/core/circuits/_generators.py
+++ b/src/python/zquantum/core/circuits/_generators.py
@@ -61,7 +61,7 @@ def apply_gate_to_qubits(
         assert len(parameters) == len(unique_qubit_idx)
         gate_factory = cast(GatePrototype, gate_factory)
         for qubit, parameter in zip(unique_qubit_idx, parameters):
-            circuit += gate_factory(*parameter)(qubit)
+            circuit += gate_factory(*np.atleast_1d(parameter))(qubit)
     else:
         gate_factory = cast(Gate, gate_factory)
         for qubit in unique_qubit_idx:


### PR DESCRIPTION
The function would break if the passed `parameters` are a 1d array. `parameter` would then be a float.

@roberCO found this bug in `z-quantum-core`. I thought I once made a PR about this, but apparently it was never merged.